### PR TITLE
[Feature] 사용자 프로필 및 알림 설정 API 구현

### DIFF
--- a/src/main/kotlin/digdaserver/domain/user/application/service/UserNotificationSettingService.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/UserNotificationSettingService.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.user.application.service
+
+import digdaserver.domain.user.presentation.dto.req.UpdateNotificationSettingRequest
+import digdaserver.domain.user.presentation.dto.res.NotificationSettingResponse
+import java.util.UUID
+
+interface UserNotificationSettingService {
+
+    fun getNotificationSetting(userId: UUID): NotificationSettingResponse
+
+    fun updateNotificationSetting(userId: UUID, request: UpdateNotificationSettingRequest): NotificationSettingResponse
+}

--- a/src/main/kotlin/digdaserver/domain/user/application/service/UserProfileService.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/UserProfileService.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.user.application.service
+
+import digdaserver.domain.user.presentation.dto.req.UpdateProfileRequest
+import digdaserver.domain.user.presentation.dto.res.MyProfileResponse
+import java.util.UUID
+
+interface UserProfileService {
+
+    fun getMyProfile(userId: UUID): MyProfileResponse
+
+    fun updateProfile(userId: UUID, request: UpdateProfileRequest): MyProfileResponse
+}

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserNotificationSettingServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserNotificationSettingServiceImpl.kt
@@ -1,0 +1,41 @@
+package digdaserver.domain.user.application.service.impl
+
+import digdaserver.domain.user.application.service.UserNotificationSettingService
+import digdaserver.domain.user.domain.repository.UserNotificationSettingRepository
+import digdaserver.domain.user.presentation.dto.req.UpdateNotificationSettingRequest
+import digdaserver.domain.user.presentation.dto.res.NotificationSettingResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class UserNotificationSettingServiceImpl(
+    private val userNotificationSettingRepository: UserNotificationSettingRepository
+) : UserNotificationSettingService {
+
+    override fun getNotificationSetting(userId: UUID): NotificationSettingResponse {
+        val setting = userNotificationSettingRepository.findByUserId(userId)
+            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND) }
+
+        return NotificationSettingResponse.from(setting)
+    }
+
+    @Transactional
+    override fun updateNotificationSetting(userId: UUID, request: UpdateNotificationSettingRequest): NotificationSettingResponse {
+        val setting = userNotificationSettingRepository.findByUserId(userId)
+            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_SETTING_NOT_FOUND) }
+
+        setting.update(
+            pushEnabled = request.pushEnabled,
+            scheduleNotification = request.scheduleNotification,
+            diaryNotification = request.diaryNotification,
+            commentNotification = request.commentNotification,
+            marketingConsent = request.marketingConsent
+        )
+
+        return NotificationSettingResponse.from(setting)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
@@ -1,0 +1,56 @@
+package digdaserver.domain.user.application.service.impl
+
+import digdaserver.domain.user.application.service.UserProfileService
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.domain.user.presentation.dto.req.UpdateProfileRequest
+import digdaserver.domain.user.presentation.dto.res.MyProfileResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class UserProfileServiceImpl(
+    private val userRepository: UserRepository
+) : UserProfileService {
+
+    override fun getMyProfile(userId: UUID): MyProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        return MyProfileResponse.from(user)
+    }
+
+    @Transactional
+    override fun updateProfile(userId: UUID, request: UpdateProfileRequest): MyProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        request.name?.let { name ->
+            if (name.length < 2) throw DigdaException(ErrorCode.NAME_TOO_SHORT)
+            if (name.length > 20) throw DigdaException(ErrorCode.NAME_TOO_LONG)
+            user.name = name
+        }
+
+        request.statusMessage?.let { msg ->
+            if (msg.isEmpty()) {
+                user.clearStatusMessage()
+            } else {
+                if (msg.length > 100) throw DigdaException(ErrorCode.STATUS_MESSAGE_TOO_LONG)
+                user.statusMessage = msg
+            }
+        }
+
+        request.profileImageId?.let { optional ->
+            if (optional.isPresent) {
+                user.profileImage = optional.get()
+            } else {
+                user.resetProfileImage()
+            }
+        }
+
+        return MyProfileResponse.from(user)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/presentation/controller/UserNotificationSettingController.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/controller/UserNotificationSettingController.kt
@@ -1,0 +1,42 @@
+package digdaserver.domain.user.presentation.controller
+
+import digdaserver.domain.user.application.service.UserNotificationSettingService
+import digdaserver.domain.user.presentation.dto.req.UpdateNotificationSettingRequest
+import digdaserver.domain.user.presentation.dto.res.NotificationSettingResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/users/me/notification-settings")
+@Tag(name = "User", description = "사용자 API")
+class UserNotificationSettingController(
+    private val userNotificationSettingService: UserNotificationSettingService
+) {
+
+    @Operation(summary = "알림 설정 조회", description = "로그인한 사용자의 알림 설정을 조회합니다.")
+    @GetMapping
+    fun getNotificationSetting(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<NotificationSettingResponse> {
+        val response = userNotificationSettingService.getNotificationSetting(UUID.fromString(userId))
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "알림 설정 수정", description = "알림 설정을 수정합니다. 변경할 필드만 전송합니다.")
+    @PutMapping
+    fun updateNotificationSetting(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: UpdateNotificationSettingRequest
+    ): ResponseEntity<NotificationSettingResponse> {
+        val response = userNotificationSettingService.updateNotificationSetting(UUID.fromString(userId), request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/presentation/controller/UserProfileController.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/controller/UserProfileController.kt
@@ -1,0 +1,42 @@
+package digdaserver.domain.user.presentation.controller
+
+import digdaserver.domain.user.application.service.UserProfileService
+import digdaserver.domain.user.presentation.dto.req.UpdateProfileRequest
+import digdaserver.domain.user.presentation.dto.res.MyProfileResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/users")
+@Tag(name = "User", description = "사용자 API")
+class UserProfileController(
+    private val userProfileService: UserProfileService
+) {
+
+    @Operation(summary = "내 프로필 조회", description = "로그인한 사용자의 프로필 정보를 조회합니다.")
+    @GetMapping("/me")
+    fun getMyProfile(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<MyProfileResponse> {
+        val response = userProfileService.getMyProfile(UUID.fromString(userId))
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "프로필 수정", description = "닉네임, 상태 메시지, 프로필 이미지를 수정합니다.")
+    @PutMapping("/me")
+    fun updateProfile(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: UpdateProfileRequest
+    ): ResponseEntity<MyProfileResponse> {
+        val response = userProfileService.updateProfile(UUID.fromString(userId), request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateNotificationSettingRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateNotificationSettingRequest.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.user.presentation.dto.req
+
+data class UpdateNotificationSettingRequest(
+    val pushEnabled: Boolean? = null,
+    val scheduleNotification: Boolean? = null,
+    val diaryNotification: Boolean? = null,
+    val commentNotification: Boolean? = null,
+    val marketingConsent: Boolean? = null
+)

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateProfileRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateProfileRequest.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.user.presentation.dto.req
+
+import java.util.Optional
+
+data class UpdateProfileRequest(
+    val name: String? = null,
+    val statusMessage: String? = null,
+    val profileImageId: Optional<String>? = null
+)

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
@@ -5,7 +5,6 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 data class MyProfileResponse(
-    val id: UUID,
     val name: String,
     val email: String?,
     val profileImage: String?,
@@ -15,7 +14,6 @@ data class MyProfileResponse(
 ) {
     companion object {
         fun from(user: User): MyProfileResponse = MyProfileResponse(
-            id = user.id,
             name = user.name,
             email = user.email,
             profileImage = user.profileImage,

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
@@ -1,0 +1,27 @@
+package digdaserver.domain.user.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class MyProfileResponse(
+    val id: UUID,
+    val name: String,
+    val email: String?,
+    val profileImage: String?,
+    val statusMessage: String?,
+    val provider: String,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(user: User): MyProfileResponse = MyProfileResponse(
+            id = user.id,
+            name = user.name,
+            email = user.email,
+            profileImage = user.profileImage,
+            statusMessage = user.statusMessage,
+            provider = user.socialProvider.name.lowercase(),
+            createdAt = user.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/NotificationSettingResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/NotificationSettingResponse.kt
@@ -1,0 +1,21 @@
+package digdaserver.domain.user.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.UserNotificationSetting
+
+data class NotificationSettingResponse(
+    val pushEnabled: Boolean,
+    val scheduleNotification: Boolean,
+    val diaryNotification: Boolean,
+    val commentNotification: Boolean,
+    val marketingConsent: Boolean
+) {
+    companion object {
+        fun from(setting: UserNotificationSetting): NotificationSettingResponse = NotificationSettingResponse(
+            pushEnabled = setting.pushEnabled,
+            scheduleNotification = setting.scheduleNotification,
+            diaryNotification = setting.diaryNotification,
+            commentNotification = setting.commentNotification,
+            marketingConsent = setting.marketingConsent
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -84,6 +84,7 @@ enum class ErrorCode(
 
     // ── Notification ──
     NOTIFICATION_NOT_FOUND("NOTIFICATION_NOT_FOUND", "존재하지 않는 알림입니다.", 404),
+    NOTIFICATION_SETTING_NOT_FOUND("NOTIFICATION_SETTING_NOT_FOUND", "알림 설정을 찾을 수 없습니다.", 404),
 
     // ── Device ──
     DEVICE_NOT_FOUND("DEVICE_NOT_FOUND", "존재하지 않는 디바이스입니다.", 404),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #9 

## 📝작업 내용

>사용자(User) 도메인의 프로필 및 알림 설정 API를 구현했습니다.

  - GET 내 프로필 조회 — 닉네임, 이메일, 프로필 이미지, 상태 메시지, 소셜 프로바이더, 가입일 반환
  - PUT 프로필 수정 — 닉네임(2~20자), 상태 메시지(최대 100자), 프로필 이미지를 선택적으로 수정 (변경할 필드만
  전송)
  - 프로필 수정 응답에서 불필요한 ID 필드 제거

  알림 설정 API (/users/me/notification-settings)

  - GET 알림 설정 조회 — push, 일정, 일기, 댓글, 마케팅 수신 여부 반환
  - PUT 알림 설정 수정 — 변경할 필드만 전송하여 부분 수정 가능

  기타

  - NOTIFICATION_SETTING_NOT_FOUND ErrorCode 추가
  - Service 인터페이스 / Impl 분리 구조 적용