### PR TITLE
[Feature] 그룹방 CRUD API 구현

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -2,9 +2,12 @@ package digdaserver.domain.group_room.application.service
 
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import java.util.UUID
 
 interface GroupRoomService {
 
     fun createGroupRoom(userId: UUID, request: CreateGroupRoomRequest): CreateGroupRoomResponse
+
+    fun getMyGroupRooms(userId: UUID): GroupRoomListResponse
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -4,6 +4,7 @@ import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
 import java.util.UUID
@@ -17,4 +18,6 @@ interface GroupRoomService {
     fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse
 
     fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse
+
+    fun deleteGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomDeleteResponse
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -1,0 +1,10 @@
+package digdaserver.domain.group_room.application.service
+
+import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import java.util.UUID
+
+interface GroupRoomService {
+
+    fun createGroupRoom(userId: UUID, request: CreateGroupRoomRequest): CreateGroupRoomResponse
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -1,9 +1,11 @@
 package digdaserver.domain.group_room.application.service
 
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
 import java.util.UUID
 
 interface GroupRoomService {
@@ -13,4 +15,6 @@ interface GroupRoomService {
     fun getMyGroupRooms(userId: UUID): GroupRoomListResponse
 
     fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse
+
+    fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -2,6 +2,7 @@ package digdaserver.domain.group_room.application.service
 
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import java.util.UUID
 
@@ -10,4 +11,6 @@ interface GroupRoomService {
     fun createGroupRoom(userId: UUID, request: CreateGroupRoomRequest): CreateGroupRoomResponse
 
     fun getMyGroupRooms(userId: UUID): GroupRoomListResponse
+
+    fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -20,4 +20,6 @@ interface GroupRoomService {
     fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse
 
     fun deleteGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomDeleteResponse
+
+    fun recoverGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomResponse
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -6,6 +6,8 @@ import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListItem
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
 import digdaserver.domain.invite.domain.entity.InviteCode
 import digdaserver.domain.invite.domain.repository.InviteCodeRepository
@@ -66,6 +68,17 @@ class GroupRoomServiceImpl(
             inviteCode = inviteCode.code,
             inviteCodeExpiresAt = inviteCode.expiresAt
         )
+    }
+
+    override fun getMyGroupRooms(userId: UUID): GroupRoomListResponse {
+        val memberships = membershipRepository.findAllByUserIdWithGroupRoom(userId)
+
+        val groupRoomItems = memberships.map { membership ->
+            val memberCount = membershipRepository.countByGroupRoomId(membership.groupRoom.id)
+            GroupRoomListItem.from(membership.groupRoom, memberCount, membership.role)
+        }
+
+        return GroupRoomListResponse(groupRooms = groupRoomItems)
     }
 
     private fun validateGroupRoomName(name: String) {

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -79,7 +79,15 @@ class GroupRoomServiceImpl(
 
         val groupRoomItems = memberships.map { membership ->
             val memberCount = membershipRepository.countByGroupRoomId(membership.groupRoom.id)
-            GroupRoomListItem.from(membership.groupRoom, memberCount, membership.role)
+            val inviteCode = if (membership.isOwner) {
+                inviteCodeRepository.findFirstByGroupRoomIdOrderByCreatedAtDesc(membership.groupRoom.id)
+                    .filter { !it.isExpired }
+                    .map { it.code }
+                    .orElse(null)
+            } else {
+                null
+            }
+            GroupRoomListItem.from(membership.groupRoom, memberCount, membership.role, inviteCode)
         }
 
         return GroupRoomListResponse(groupRooms = groupRoomItems)
@@ -97,20 +105,10 @@ class GroupRoomServiceImpl(
         val memberships = membershipRepository.findAllByGroupRoomId(groupRoomId)
         val memberCount = memberships.size
 
-        val inviteCode = if (membership.isOwner) {
-            inviteCodeRepository.findFirstByGroupRoomIdOrderByCreatedAtDesc(groupRoomId)
-                .filter { !it.isExpired }
-                .map { it.code }
-                .orElse(null)
-        } else {
-            null
-        }
-
         return GroupRoomDetailResponse(
             groupRoom = GroupRoomResponse.from(groupRoom, memberCount),
             memberships = memberships.map { MembershipSummary.from(it) },
-            myRole = membership.role.name.lowercase(),
-            inviteCode = inviteCode
+            myRole = membership.role.name.lowercase()
         )
     }
 
@@ -139,6 +137,7 @@ class GroupRoomServiceImpl(
             thumbnailImage = null
         )
 
+        // thumbnailImageId: null(미전송)=변경없음, Optional.empty=삭제, Optional(값)=변경
         request.thumbnailImageId?.let { optional ->
             if (optional.isPresent) {
                 groupRoom.thumbnailImage = optional.get()

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -6,9 +6,11 @@ import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListItem
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.MembershipSummary
 import digdaserver.domain.invite.domain.entity.InviteCode
 import digdaserver.domain.invite.domain.repository.InviteCodeRepository
 import digdaserver.domain.membership.domain.entity.Membership
@@ -79,6 +81,35 @@ class GroupRoomServiceImpl(
         }
 
         return GroupRoomListResponse(groupRooms = groupRoomItems)
+    }
+
+    override fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val memberships = membershipRepository.findAllByGroupRoomId(groupRoomId)
+        val memberCount = memberships.size
+
+        val inviteCode = if (membership.isOwner) {
+            inviteCodeRepository.findFirstByGroupRoomIdOrderByCreatedAtDesc(groupRoomId)
+                .filter { !it.isExpired }
+                .map { it.code }
+                .orElse(null)
+        } else {
+            null
+        }
+
+        return GroupRoomDetailResponse(
+            groupRoom = GroupRoomResponse.from(groupRoom, memberCount),
+            memberships = memberships.map { MembershipSummary.from(it) },
+            myRole = membership.role.name.lowercase(),
+            inviteCode = inviteCode
+        )
     }
 
     private fun validateGroupRoomName(name: String) {

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -7,6 +7,7 @@ import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListItem
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
@@ -148,6 +149,25 @@ class GroupRoomServiceImpl(
 
         val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
         return GroupRoomResponse.from(groupRoom, memberCount)
+    }
+
+    @Transactional
+    override fun deleteGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomDeleteResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        groupRoom.scheduleDelete()
+
+        return GroupRoomDeleteResponse(
+            deleteScheduledAt = groupRoom.deleteScheduledAt!!
+        )
     }
 
     private fun validateGroupRoomName(name: String) {

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -170,6 +170,26 @@ class GroupRoomServiceImpl(
         )
     }
 
+    @Transactional
+    override fun recoverGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        if (!groupRoom.isDeleteScheduled) throw DigdaException(ErrorCode.GROUP_ROOM_NOT_SCHEDULED_FOR_DELETION)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        groupRoom.recover()
+
+        val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
+        return GroupRoomResponse.from(groupRoom, memberCount)
+    }
+
     private fun validateGroupRoomName(name: String) {
         if (name.length < 2) throw DigdaException(ErrorCode.GROUP_ROOM_NAME_TOO_SHORT)
         if (name.length > 20) throw DigdaException(ErrorCode.GROUP_ROOM_NAME_TOO_LONG)

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -5,6 +5,7 @@ import digdaserver.domain.group_room.domain.entity.GroupRoom
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListItem
@@ -110,6 +111,43 @@ class GroupRoomServiceImpl(
             myRole = membership.role.name.lowercase(),
             inviteCode = inviteCode
         )
+    }
+
+    @Transactional
+    override fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        request.name?.let { validateGroupRoomName(it) }
+
+        request.maxMembers?.let { newMax ->
+            val currentCount = membershipRepository.countByGroupRoomId(groupRoomId)
+            if (newMax < currentCount) throw DigdaException(ErrorCode.MAX_MEMBERS_BELOW_CURRENT)
+        }
+
+        groupRoom.update(
+            name = request.name,
+            maxMembers = request.maxMembers,
+            thumbnailImage = null
+        )
+
+        request.thumbnailImageId?.let { optional ->
+            if (optional.isPresent) {
+                groupRoom.thumbnailImage = optional.get()
+            } else {
+                groupRoom.removeThumbnail()
+            }
+        }
+
+        val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
+        return GroupRoomResponse.from(groupRoom, memberCount)
     }
 
     private fun validateGroupRoomName(name: String) {

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -1,0 +1,85 @@
+package digdaserver.domain.group_room.application.service.impl
+
+import digdaserver.domain.group_room.application.service.GroupRoomService
+import digdaserver.domain.group_room.domain.entity.GroupRoom
+import digdaserver.domain.group_room.domain.entity.GroupRoomRole
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
+import digdaserver.domain.invite.domain.entity.InviteCode
+import digdaserver.domain.invite.domain.repository.InviteCodeRepository
+import digdaserver.domain.membership.domain.entity.Membership
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class GroupRoomServiceImpl(
+    private val groupRoomRepository: GroupRoomRepository,
+    private val userRepository: UserRepository,
+    private val membershipRepository: MembershipRepository,
+    private val inviteCodeRepository: InviteCodeRepository
+) : GroupRoomService {
+
+    @Transactional
+    override fun createGroupRoom(userId: UUID, request: CreateGroupRoomRequest): CreateGroupRoomResponse {
+        validateGroupRoomName(request.name)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val groupRoom = groupRoomRepository.save(
+            GroupRoom(
+                name = request.name,
+                maxMembers = request.maxMembers,
+                owner = user,
+                thumbnailImage = request.thumbnailImageId
+            )
+        )
+
+        membershipRepository.save(
+            Membership(
+                user = user,
+                groupRoom = groupRoom,
+                role = GroupRoomRole.OWNER,
+                color = generateRandomColor()
+            )
+        )
+
+        val inviteCode = inviteCodeRepository.save(
+            InviteCode(
+                groupRoom = groupRoom,
+                code = generateInviteCode(),
+                expiresAt = LocalDateTime.now().plusHours(24)
+            )
+        )
+
+        return CreateGroupRoomResponse(
+            groupRoom = GroupRoomResponse.from(groupRoom, 1),
+            inviteCode = inviteCode.code,
+            inviteCodeExpiresAt = inviteCode.expiresAt
+        )
+    }
+
+    private fun validateGroupRoomName(name: String) {
+        if (name.length < 2) throw DigdaException(ErrorCode.GROUP_ROOM_NAME_TOO_SHORT)
+        if (name.length > 20) throw DigdaException(ErrorCode.GROUP_ROOM_NAME_TOO_LONG)
+    }
+
+    private fun generateInviteCode(): String {
+        val chars = ('A'..'Z') + ('0'..'9')
+        return (1..6).map { chars.random() }.joinToString("")
+    }
+
+    private fun generateRandomColor(): String {
+        val colors = listOf("#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8")
+        return colors.random()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -3,6 +3,7 @@ package digdaserver.domain.group_room.presentation.controller
 import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -39,6 +41,16 @@ class GroupRoomController(
         @AuthenticationPrincipal userId: String
     ): ResponseEntity<GroupRoomListResponse> {
         val response = groupRoomService.getMyGroupRooms(UUID.fromString(userId))
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "그룹방 상세 조회", description = "그룹방의 상세 정보를 조회합니다. 구성원만 접근 가능합니다.")
+    @GetMapping("/{groupRoomId}")
+    fun getGroupRoomDetail(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<GroupRoomDetailResponse> {
+        val response = groupRoomService.getGroupRoomDetail(UUID.fromString(userId), groupRoomId)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -4,7 +4,9 @@ import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
+import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -13,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -51,6 +54,17 @@ class GroupRoomController(
         @PathVariable groupRoomId: Long
     ): ResponseEntity<GroupRoomDetailResponse> {
         val response = groupRoomService.getGroupRoomDetail(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "그룹방 수정", description = "그룹방 정보를 수정합니다. 방장만 가능합니다.")
+    @PutMapping("/{groupRoomId}")
+    fun updateGroupRoom(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestBody request: UpdateGroupRoomRequest
+    ): ResponseEntity<GroupRoomResponse> {
+        val response = groupRoomService.updateGroupRoom(UUID.fromString(userId), groupRoomId, request)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -3,6 +3,7 @@ package digdaserver.domain.group_room.presentation.controller
 import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -65,6 +67,16 @@ class GroupRoomController(
         @RequestBody request: UpdateGroupRoomRequest
     ): ResponseEntity<GroupRoomResponse> {
         val response = groupRoomService.updateGroupRoom(UUID.fromString(userId), groupRoomId, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "그룹방 삭제", description = "그룹방을 삭제 예약합니다. 7일 후 영구 삭제됩니다. 방장만 가능합니다.")
+    @DeleteMapping("/{groupRoomId}")
+    fun deleteGroupRoom(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<GroupRoomDeleteResponse> {
+        val response = groupRoomService.deleteGroupRoom(UUID.fromString(userId), groupRoomId)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -3,11 +3,13 @@ package digdaserver.domain.group_room.presentation.controller
 import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,5 +31,14 @@ class GroupRoomController(
     ): ResponseEntity<CreateGroupRoomResponse> {
         val response = groupRoomService.createGroupRoom(UUID.fromString(userId), request)
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "내 그룹방 목록", description = "내가 속한 모든 그룹방을 최근 활동순으로 조회합니다.")
+    @GetMapping
+    fun getMyGroupRooms(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<GroupRoomListResponse> {
+        val response = groupRoomService.getMyGroupRooms(UUID.fromString(userId))
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -1,0 +1,33 @@
+package digdaserver.domain.group_room.presentation.controller
+
+import digdaserver.domain.group_room.application.service.GroupRoomService
+import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/group-rooms")
+@Tag(name = "GroupRoom", description = "그룹방 API")
+class GroupRoomController(
+    private val groupRoomService: GroupRoomService
+) {
+
+    @Operation(summary = "그룹방 생성", description = "그룹방을 생성합니다. 생성자가 방장이 되며 초대 코드가 자동 발급됩니다.")
+    @PostMapping
+    fun createGroupRoom(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: CreateGroupRoomRequest
+    ): ResponseEntity<CreateGroupRoomResponse> {
+        val response = groupRoomService.createGroupRoom(UUID.fromString(userId), request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -79,4 +79,14 @@ class GroupRoomController(
         val response = groupRoomService.deleteGroupRoom(UUID.fromString(userId), groupRoomId)
         return ResponseEntity.ok(response)
     }
+
+    @Operation(summary = "그룹방 복구", description = "삭제 예약된 그룹방을 복구합니다. 삭제 예약 기간(7일) 내에만 가능하며 방장만 가능합니다.")
+    @PostMapping("/{groupRoomId}/recover")
+    fun recoverGroupRoom(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<GroupRoomResponse> {
+        val response = groupRoomService.recoverGroupRoom(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/req/CreateGroupRoomRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/req/CreateGroupRoomRequest.kt
@@ -1,0 +1,7 @@
+package digdaserver.domain.group_room.presentation.dto.req
+
+data class CreateGroupRoomRequest(
+    val name: String,
+    val maxMembers: Int,
+    val thumbnailImageId: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/req/UpdateGroupRoomRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/req/UpdateGroupRoomRequest.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.group_room.presentation.dto.req
+
+import java.util.Optional
+
+data class UpdateGroupRoomRequest(
+    val name: String? = null,
+    val maxMembers: Int? = null,
+    val thumbnailImageId: Optional<String>? = null
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/CreateGroupRoomResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/CreateGroupRoomResponse.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import java.time.LocalDateTime
+
+data class CreateGroupRoomResponse(
+    val groupRoom: GroupRoomResponse,
+    val inviteCode: String,
+    val inviteCodeExpiresAt: LocalDateTime
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDeleteResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDeleteResponse.kt
@@ -1,0 +1,7 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import java.time.LocalDateTime
+
+data class GroupRoomDeleteResponse(
+    val deleteScheduledAt: LocalDateTime
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDetailResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDetailResponse.kt
@@ -3,6 +3,5 @@ package digdaserver.domain.group_room.presentation.dto.res
 data class GroupRoomDetailResponse(
     val groupRoom: GroupRoomResponse,
     val memberships: List<MembershipSummary>,
-    val myRole: String,
-    val inviteCode: String? = null
+    val myRole: String
 )

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDetailResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomDetailResponse.kt
@@ -1,0 +1,8 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+data class GroupRoomDetailResponse(
+    val groupRoom: GroupRoomResponse,
+    val memberships: List<MembershipSummary>,
+    val myRole: String,
+    val inviteCode: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
@@ -1,0 +1,29 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import digdaserver.domain.group_room.domain.entity.GroupRoom
+import digdaserver.domain.group_room.domain.entity.GroupRoomRole
+import java.time.LocalDateTime
+
+data class GroupRoomListItem(
+    val id: Long,
+    val name: String,
+    val thumbnailImage: String?,
+    val memberCount: Int,
+    val maxMembers: Int,
+    val myRole: String,
+    val lastActivityAt: LocalDateTime,
+    val isDeleteScheduled: Boolean
+) {
+    companion object {
+        fun from(groupRoom: GroupRoom, memberCount: Int, myRole: GroupRoomRole): GroupRoomListItem = GroupRoomListItem(
+            id = groupRoom.id,
+            name = groupRoom.name,
+            thumbnailImage = groupRoom.thumbnailImage,
+            memberCount = memberCount,
+            maxMembers = groupRoom.maxMembers,
+            myRole = myRole.name.lowercase(),
+            lastActivityAt = groupRoom.lastActivityAt,
+            isDeleteScheduled = groupRoom.isDeleteScheduled
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
@@ -12,10 +12,11 @@ data class GroupRoomListItem(
     val maxMembers: Int,
     val myRole: String,
     val lastActivityAt: LocalDateTime,
-    val isDeleteScheduled: Boolean
+    val isDeleteScheduled: Boolean,
+    val inviteCode: String? = null
 ) {
     companion object {
-        fun from(groupRoom: GroupRoom, memberCount: Int, myRole: GroupRoomRole): GroupRoomListItem = GroupRoomListItem(
+        fun from(groupRoom: GroupRoom, memberCount: Int, myRole: GroupRoomRole, inviteCode: String? = null): GroupRoomListItem = GroupRoomListItem(
             id = groupRoom.id,
             name = groupRoom.name,
             thumbnailImage = groupRoom.thumbnailImage,
@@ -23,7 +24,8 @@ data class GroupRoomListItem(
             maxMembers = groupRoom.maxMembers,
             myRole = myRole.name.lowercase(),
             lastActivityAt = groupRoom.lastActivityAt,
-            isDeleteScheduled = groupRoom.isDeleteScheduled
+            isDeleteScheduled = groupRoom.isDeleteScheduled,
+            inviteCode = inviteCode
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListResponse.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+data class GroupRoomListResponse(
+    val groupRooms: List<GroupRoomListItem>
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomResponse.kt
@@ -1,0 +1,24 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import digdaserver.domain.group_room.domain.entity.GroupRoom
+import java.time.LocalDateTime
+
+data class GroupRoomResponse(
+    val id: Long,
+    val name: String,
+    val thumbnailImage: String?,
+    val maxMembers: Int,
+    val memberCount: Int,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(groupRoom: GroupRoom, memberCount: Int): GroupRoomResponse = GroupRoomResponse(
+            id = groupRoom.id,
+            name = groupRoom.name,
+            thumbnailImage = groupRoom.thumbnailImage,
+            maxMembers = groupRoom.maxMembers,
+            memberCount = memberCount,
+            createdAt = groupRoom.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
@@ -1,0 +1,21 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import digdaserver.domain.membership.domain.entity.Membership
+
+data class MembershipSummary(
+    val userId: String,
+    val name: String,
+    val profileImage: String?,
+    val role: String,
+    val color: String
+) {
+    companion object {
+        fun from(membership: Membership): MembershipSummary = MembershipSummary(
+            userId = membership.user.id.toString(),
+            name = membership.user.name,
+            profileImage = membership.user.profileImage,
+            role = membership.role.name.lowercase(),
+            color = membership.color
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
@@ -3,7 +3,6 @@ package digdaserver.domain.group_room.presentation.dto.res
 import digdaserver.domain.membership.domain.entity.Membership
 
 data class MembershipSummary(
-    val userId: String,
     val name: String,
     val profileImage: String?,
     val role: String,
@@ -11,7 +10,6 @@ data class MembershipSummary(
 ) {
     companion object {
         fun from(membership: Membership): MembershipSummary = MembershipSummary(
-            userId = membership.user.id.toString(),
             name = membership.user.name,
             profileImage = membership.user.profileImage,
             role = membership.role.name.lowercase(),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #11 

## 📝작업 내용

>  그룹방(GroupRoom) 도메인의 CRUD API를 구현했습니다.

  ### 그룹방 API (6개)
  | # | 메서드 | 엔드포인트 | 설명 |
  |---|--------|-----------|------|
  | 1 | POST | `/group-rooms` | 그룹방 생성 (초대코드 자동 발급) |
  | 2 | GET | `/group-rooms` | 내 그룹방 목록 조회 |
  | 3 | GET | `/group-rooms/:groupRoomId` | 그룹방 상세 조회 |
  | 4 | PUT | `/group-rooms/:groupRoomId` | 그룹방 수정 (방장만) |
  | 5 | DELETE | `/group-rooms/:groupRoomId` | 그룹방 삭제 예약 (방장만) |
  | 6 | POST | `/group-rooms/:groupRoomId/recover` | 그룹방 삭제 취소 (방장만) |

  ### 리팩토링
  - 초대코드 응답 위치 변경: 그룹방 상세 조회 → 목록 조회로 이동
  - MembershipSummary 응답에서 불필요한 userId 필드 제거

  ### 주요 구현 사항
  - Service 인터페이스 / Impl 분리 구조 적용
  - 그룹방 삭제 시 즉시 삭제가 아닌 삭제 예약(soft delete) 방식
  - 초대코드는 방장(OWNER)에게만 유효한 코드 반환
  - 그룹방 수정 시 thumbnailImageId null/empty/값 분기 처리