### PR TITLE
[Feature] 초대 코드 API 구현 (생성, 검증, 참여)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/invite/application/service/InviteService.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/application/service/InviteService.kt
@@ -1,0 +1,15 @@
+package digdaserver.domain.invite.application.service
+
+import digdaserver.domain.invite.presentation.dto.res.InviteCodeResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteJoinResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteValidateResponse
+import java.util.UUID
+
+interface InviteService {
+
+    fun regenerateInviteCode(userId: UUID, groupRoomId: Long): InviteCodeResponse
+
+    fun validateInviteCode(userId: UUID, code: String): InviteValidateResponse
+
+    fun joinByInviteCode(userId: UUID, code: String): InviteJoinResponse
+}

--- a/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
@@ -1,0 +1,138 @@
+package digdaserver.domain.invite.application.service.impl
+
+import digdaserver.domain.group_room.domain.entity.GroupRoomRole
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.MembershipSummary
+import digdaserver.domain.invite.application.service.InviteService
+import digdaserver.domain.invite.domain.entity.InviteCode
+import digdaserver.domain.invite.domain.repository.InviteCodeRepository
+import digdaserver.domain.invite.presentation.dto.res.InviteCodeResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteJoinResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteValidateResponse
+import digdaserver.domain.membership.domain.entity.Membership
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class InviteServiceImpl(
+    private val inviteCodeRepository: InviteCodeRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val membershipRepository: MembershipRepository,
+    private val userRepository: UserRepository
+) : InviteService {
+
+    @Transactional
+    override fun regenerateInviteCode(userId: UUID, groupRoomId: Long): InviteCodeResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        inviteCodeRepository.deleteAllByGroupRoomId(groupRoomId)
+        inviteCodeRepository.flush()
+
+        val inviteCode = inviteCodeRepository.save(
+            InviteCode(
+                groupRoom = groupRoom,
+                code = generateInviteCode(),
+                expiresAt = LocalDateTime.now().plusHours(24)
+            )
+        )
+
+        return InviteCodeResponse(
+            code = inviteCode.code,
+            expiresAt = inviteCode.expiresAt
+        )
+    }
+
+    override fun validateInviteCode(userId: UUID, code: String): InviteValidateResponse {
+        val inviteCode = inviteCodeRepository.findByCode(code.uppercase())
+            .orElseThrow { DigdaException(ErrorCode.INVITE_CODE_INVALID) }
+
+        if (inviteCode.isExpired) throw DigdaException(ErrorCode.INVITE_CODE_EXPIRED)
+
+        val groupRoom = inviteCode.groupRoom
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.INVITE_CODE_INVALID)
+
+        val memberCount = membershipRepository.countByGroupRoomId(groupRoom.id)
+
+        if (memberCount >= groupRoom.maxMembers) throw DigdaException(ErrorCode.GROUP_ROOM_FULL)
+
+        if (membershipRepository.existsByGroupRoomIdAndUserId(groupRoom.id, userId)) {
+            throw DigdaException(ErrorCode.ALREADY_JOINED)
+        }
+
+        return InviteValidateResponse(
+            groupRoomName = groupRoom.name,
+            thumbnailImage = groupRoom.thumbnailImage,
+            memberCount = memberCount,
+            maxMembers = groupRoom.maxMembers,
+            expiresAt = inviteCode.expiresAt
+        )
+    }
+
+    @Transactional
+    override fun joinByInviteCode(userId: UUID, code: String): InviteJoinResponse {
+        val inviteCode = inviteCodeRepository.findByCode(code.uppercase())
+            .orElseThrow { DigdaException(ErrorCode.INVITE_CODE_INVALID) }
+
+        if (inviteCode.isExpired) throw DigdaException(ErrorCode.INVITE_CODE_EXPIRED)
+
+        val groupRoom = inviteCode.groupRoom
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.INVITE_CODE_INVALID)
+
+        val memberCount = membershipRepository.countByGroupRoomId(groupRoom.id)
+
+        if (memberCount >= groupRoom.maxMembers) throw DigdaException(ErrorCode.GROUP_ROOM_FULL)
+
+        if (membershipRepository.existsByGroupRoomIdAndUserId(groupRoom.id, userId)) {
+            throw DigdaException(ErrorCode.ALREADY_JOINED)
+        }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        membershipRepository.save(
+            Membership(
+                user = user,
+                groupRoom = groupRoom,
+                role = GroupRoomRole.MEMBER,
+                color = generateRandomColor()
+            )
+        )
+
+        groupRoom.updateLastActivity()
+
+        val memberships = membershipRepository.findAllByGroupRoomId(groupRoom.id)
+
+        return InviteJoinResponse(
+            groupRoom = GroupRoomResponse.from(groupRoom, memberships.size),
+            memberships = memberships.map { MembershipSummary.from(it) }
+        )
+    }
+
+    private fun generateInviteCode(): String {
+        val chars = ('A'..'Z') + ('0'..'9')
+        return (1..6).map { chars.random() }.joinToString("")
+    }
+
+    private fun generateRandomColor(): String {
+        val colors = listOf("#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8")
+        return colors.random()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/invite/presentation/controller/InviteController.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/presentation/controller/InviteController.kt
@@ -1,0 +1,54 @@
+package digdaserver.domain.invite.presentation.controller
+
+import digdaserver.domain.invite.application.service.InviteService
+import digdaserver.domain.invite.presentation.dto.req.InviteCodeRequest
+import digdaserver.domain.invite.presentation.dto.res.InviteCodeResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteJoinResponse
+import digdaserver.domain.invite.presentation.dto.res.InviteValidateResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Invite", description = "초대 코드 API")
+class InviteController(
+    private val inviteService: InviteService
+) {
+
+    @Operation(summary = "초대 코드 생성 (재발급)", description = "기존 코드를 무효화하고 새 초대 코드를 발급합니다. 방장만 가능합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/invites")
+    fun regenerateInviteCode(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<InviteCodeResponse> {
+        val response = inviteService.regenerateInviteCode(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "초대 코드 검증", description = "초대 코드를 입력하면 그룹방 미리보기 정보를 반환합니다.")
+    @PostMapping("/invites/validate")
+    fun validateInviteCode(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: InviteCodeRequest
+    ): ResponseEntity<InviteValidateResponse> {
+        val response = inviteService.validateInviteCode(UUID.fromString(userId), request.code)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "초대 코드로 참여", description = "초대 코드를 통해 그룹방에 참여합니다.")
+    @PostMapping("/invites/join")
+    fun joinByInviteCode(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: InviteCodeRequest
+    ): ResponseEntity<InviteJoinResponse> {
+        val response = inviteService.joinByInviteCode(UUID.fromString(userId), request.code)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/invite/presentation/dto/req/InviteCodeRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/presentation/dto/req/InviteCodeRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.invite.presentation.dto.req
+
+data class InviteCodeRequest(
+    val code: String
+)

--- a/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteCodeResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteCodeResponse.kt
@@ -1,0 +1,8 @@
+package digdaserver.domain.invite.presentation.dto.res
+
+import java.time.LocalDateTime
+
+data class InviteCodeResponse(
+    val code: String,
+    val expiresAt: LocalDateTime
+)

--- a/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteJoinResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteJoinResponse.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.invite.presentation.dto.res
+
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.MembershipSummary
+
+data class InviteJoinResponse(
+    val groupRoom: GroupRoomResponse,
+    val memberships: List<MembershipSummary>
+)

--- a/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteValidateResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/presentation/dto/res/InviteValidateResponse.kt
@@ -1,0 +1,11 @@
+package digdaserver.domain.invite.presentation.dto.res
+
+import java.time.LocalDateTime
+
+data class InviteValidateResponse(
+    val groupRoomName: String,
+    val thumbnailImage: String?,
+    val memberCount: Int,
+    val maxMembers: Int,
+    val expiresAt: LocalDateTime
+)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #13 

## 📝작업 내용

초대 코드(Invite) 도메인의 API를 구현했습니다.

  ### 초대 코드 API (3개)
  | # | 메서드 | 엔드포인트 | 설명 |
  |---|--------|-----------|------|
  | 1 | POST | `/group-rooms/:groupRoomId/invite-code` | 초대 코드 재생성 (방장만, 24시간 만료) |
  | 2 | GET | `/invites/validate?code=` | 초대 코드 검증 (그룹방 정보 반환) |
  | 3 | POST | `/invites/join` | 초대 코드로 그룹방 참여 |

  ### 주요 구현 사항
  - 초대 코드는 영대문자+숫자 6자리 랜덤 생성
  - 생성 시 기존 코드 삭제 후 새 코드 발급 (그룹방당 1개 유지)
  - 만료 검증은 엔티티의 `isExpired` 프로퍼티로 애플리케이션 레벨에서 처리
  - 검증 시 그룹방 삭제 여부, 정원 초과, 이미 참여 여부 체크
  - Service 인터페이스 / Impl 분리 구조 적용