### PR TITLE
[Feature] 구성원 관리 API 구현 (목록 조회, 내보내기, 역할 변경, 탈퇴)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/membership/application/service/MembershipService.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/application/service/MembershipService.kt
@@ -1,0 +1,15 @@
+package digdaserver.domain.membership.application.service
+
+import digdaserver.domain.membership.presentation.dto.res.MembershipListResponse
+import java.util.UUID
+
+interface MembershipService {
+
+    fun getMemberships(userId: UUID, groupRoomId: Long): MembershipListResponse
+
+    fun removeMember(userId: UUID, groupRoomId: Long, targetUserId: UUID)
+
+    fun changeRole(userId: UUID, groupRoomId: Long, targetUserId: UUID, role: String): MembershipListResponse
+
+    fun leaveGroupRoom(userId: UUID, groupRoomId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
@@ -1,0 +1,105 @@
+package digdaserver.domain.membership.application.service.impl
+
+import digdaserver.domain.group_room.domain.entity.GroupRoomRole
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.application.service.MembershipService
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.membership.presentation.dto.res.MembershipListResponse
+import digdaserver.domain.membership.presentation.dto.res.MembershipResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class MembershipServiceImpl(
+    private val membershipRepository: MembershipRepository,
+    private val groupRoomRepository: GroupRoomRepository
+) : MembershipService {
+
+    override fun getMemberships(userId: UUID, groupRoomId: Long): MembershipListResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val memberships = membershipRepository.findAllByGroupRoomId(groupRoomId)
+
+        return MembershipListResponse(
+            memberships = memberships.map { MembershipResponse.from(it) }
+        )
+    }
+
+    @Transactional
+    override fun removeMember(userId: UUID, groupRoomId: Long, targetUserId: UUID) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        val targetMembership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, targetUserId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_IN_GROUP_ROOM) }
+
+        if (targetMembership.isOwner) throw DigdaException(ErrorCode.CANNOT_REMOVE_OWNER)
+
+        membershipRepository.delete(targetMembership)
+    }
+
+    @Transactional
+    override fun changeRole(userId: UUID, groupRoomId: Long, targetUserId: UUID, role: String): MembershipListResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
+
+        val targetMembership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, targetUserId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_IN_GROUP_ROOM) }
+
+        val newRole = try {
+            GroupRoomRole.valueOf(role.uppercase())
+        } catch (e: IllegalArgumentException) {
+            throw DigdaException(ErrorCode.INVALID_ROLE)
+        }
+
+        if (newRole != GroupRoomRole.OWNER) throw DigdaException(ErrorCode.INVALID_ROLE)
+
+        membership.changeRole(GroupRoomRole.MEMBER)
+        targetMembership.changeRole(GroupRoomRole.OWNER)
+
+        val memberships = membershipRepository.findAllByGroupRoomId(groupRoomId)
+
+        return MembershipListResponse(
+            memberships = memberships.map { MembershipResponse.from(it) }
+        )
+    }
+
+    @Transactional
+    override fun leaveGroupRoom(userId: UUID, groupRoomId: Long) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (membership.isOwner) throw DigdaException(ErrorCode.OWNER_CANNOT_LEAVE)
+
+        membershipRepository.delete(membership)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/membership/presentation/controller/MembershipController.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/presentation/controller/MembershipController.kt
@@ -1,0 +1,67 @@
+package digdaserver.domain.membership.presentation.controller
+
+import digdaserver.domain.membership.application.service.MembershipService
+import digdaserver.domain.membership.presentation.dto.req.ChangeRoleRequest
+import digdaserver.domain.membership.presentation.dto.res.MembershipListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Membership", description = "구성원 관리 API")
+class MembershipController(
+    private val membershipService: MembershipService
+) {
+
+    @Operation(summary = "구성원 목록 조회", description = "그룹방의 전체 구성원 목록을 조회합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/memberships")
+    fun getMemberships(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<MembershipListResponse> {
+        val response = membershipService.getMemberships(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "구성원 내보내기 (추방)", description = "방장이 특정 구성원을 그룹방에서 내보냅니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/memberships/{targetUserId}")
+    fun removeMember(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable targetUserId: UUID
+    ): ResponseEntity<Void> {
+        membershipService.removeMember(UUID.fromString(userId), groupRoomId, targetUserId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "역할 변경 (방장 양도)", description = "방장이 다른 구성원에게 방장 권한을 양도합니다.")
+    @PutMapping("/group-rooms/{groupRoomId}/memberships/{targetUserId}/role")
+    fun changeRole(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable targetUserId: UUID,
+        @RequestBody request: ChangeRoleRequest
+    ): ResponseEntity<MembershipListResponse> {
+        val response = membershipService.changeRole(UUID.fromString(userId), groupRoomId, targetUserId, request.role)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "그룹방 탈퇴", description = "현재 사용자가 그룹방에서 자발적으로 탈퇴합니다. 방장은 양도 후에만 가능합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/leave")
+    fun leaveGroupRoom(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<Void> {
+        membershipService.leaveGroupRoom(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/membership/presentation/dto/req/ChangeRoleRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/presentation/dto/req/ChangeRoleRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.membership.presentation.dto.req
+
+data class ChangeRoleRequest(
+    val role: String
+)

--- a/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipListResponse.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.membership.presentation.dto.res
+
+data class MembershipListResponse(
+    val memberships: List<MembershipResponse>
+)

--- a/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipResponse.kt
@@ -1,0 +1,25 @@
+package digdaserver.domain.membership.presentation.dto.res
+
+import digdaserver.domain.membership.domain.entity.Membership
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class MembershipResponse(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?,
+    val color: String,
+    val role: String,
+    val joinedAt: LocalDateTime
+) {
+    companion object {
+        fun from(membership: Membership): MembershipResponse = MembershipResponse(
+            userId = membership.user.id,
+            name = membership.user.name,
+            profileImage = membership.user.profileImage,
+            color = membership.color,
+            role = membership.role.name.lowercase(),
+            joinedAt = membership.joinedAt
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #15

## 📝작업 내용

> 구성원 관리(Membership) 도메인 API 4개를 구현했습니다.

### 구성원 관리 API (4개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | GET | `/group-rooms/:groupRoomId/memberships` | 구성원 목록 조회 |
| 2 | DELETE | `/group-rooms/:groupRoomId/memberships/:userId` | 구성원 내보내기 — 방장만 가능 |
| 3 | PUT | `/group-rooms/:groupRoomId/memberships/:userId/role` | 역할 변경 — 방장 양도 (기존 방장 → 일반) |
| 4 | POST | `/group-rooms/:groupRoomId/leave` | 그룹방 탈퇴 — 방장은 양도 후에만 가능 |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리 구조 적용
- 권한 체크: 구성원 여부 → 방장 여부 순서
- 방장 양도 시 기존 방장은 일반 구성원으로 자동 변경
- 방장은 내보내기 불가 (`CANNOT_REMOVE_OWNER`)
- 방장은 양도 후에만 탈퇴 가능 (`OWNER_CANNOT_LEAVE`)
- 기존 `Membership` 엔티티 및 `MembershipRepository` 활용