### PR TITLE
[Feature] 일정 API 구현 (목록 조회, 상세, 생성, 수정, 삭제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/ScheduleService.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/ScheduleService.kt
@@ -1,0 +1,22 @@
+package digdaserver.domain.schedule.application.service
+
+import digdaserver.domain.schedule.presentation.dto.req.CreateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.req.UpdateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleDetailResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleListResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleResponse
+import java.time.LocalDate
+import java.util.UUID
+
+interface ScheduleService {
+
+    fun getSchedules(userId: UUID, groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): ScheduleListResponse
+
+    fun getScheduleDetail(userId: UUID, groupRoomId: Long, scheduleId: Long): ScheduleDetailResponse
+
+    fun createSchedule(userId: UUID, groupRoomId: Long, request: CreateScheduleRequest): ScheduleResponse
+
+    fun updateSchedule(userId: UUID, groupRoomId: Long, scheduleId: Long, request: UpdateScheduleRequest): ScheduleResponse
+
+    fun deleteSchedule(userId: UUID, groupRoomId: Long, scheduleId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
@@ -1,0 +1,206 @@
+package digdaserver.domain.schedule.application.service.impl
+
+import digdaserver.domain.comment.domain.entity.CommentTargetType
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.schedule.application.service.ScheduleService
+import digdaserver.domain.schedule.domain.entity.Schedule
+import digdaserver.domain.schedule.domain.entity.ScheduleParticipant
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.domain.schedule.presentation.dto.req.CreateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.req.UpdateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.res.CommentResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleDetailResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleListResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class ScheduleServiceImpl(
+    private val scheduleRepository: ScheduleRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val membershipRepository: MembershipRepository,
+    private val commentRepository: CommentRepository,
+    private val userRepository: UserRepository
+) : ScheduleService {
+
+    override fun getSchedules(userId: UUID, groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): ScheduleListResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val schedules = scheduleRepository.findAllByGroupRoomIdAndDateRange(groupRoomId, startDate, endDate)
+
+        return ScheduleListResponse(
+            schedules = schedules.map { schedule ->
+                val commentCount = commentRepository.countByTargetTypeAndTargetId(CommentTargetType.SCHEDULE, schedule.id)
+                ScheduleResponse.from(schedule, commentCount)
+            }
+        )
+    }
+
+    override fun getScheduleDetail(userId: UUID, groupRoomId: Long, scheduleId: Long): ScheduleDetailResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val schedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        val commentCount = commentRepository.countByTargetTypeAndTargetId(CommentTargetType.SCHEDULE, scheduleId)
+        val comments = commentRepository.findAllByTargetTypeAndTargetIdOrderByCreatedAtAsc(CommentTargetType.SCHEDULE, scheduleId)
+
+        return ScheduleDetailResponse(
+            schedule = ScheduleResponse.from(schedule, commentCount),
+            comments = comments.map { CommentResponse.from(it) }
+        )
+    }
+
+    @Transactional
+    override fun createSchedule(userId: UUID, groupRoomId: Long, request: CreateScheduleRequest): ScheduleResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        validateDateRange(request.startDate, request.endDate, request.startTime, request.endTime, request.allDay)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val schedule = scheduleRepository.save(
+            Schedule(
+                groupRoom = groupRoom,
+                title = request.title,
+                color = request.color,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                startTime = if (request.allDay) null else request.startTime,
+                endTime = if (request.allDay) null else request.endTime,
+                allDay = request.allDay,
+                createdBy = user
+            )
+        )
+
+        request.participantIds?.let { ids ->
+            addParticipants(schedule, groupRoomId, ids)
+        }
+
+        groupRoom.updateLastActivity()
+
+        return ScheduleResponse.from(schedule, 0)
+    }
+
+    @Transactional
+    override fun updateSchedule(userId: UUID, groupRoomId: Long, scheduleId: Long, request: UpdateScheduleRequest): ScheduleResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val schedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        if (schedule.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        val newStartDate = request.startDate ?: schedule.startDate
+        val newEndDate = request.endDate ?: schedule.endDate
+        val newAllDay = request.allDay ?: schedule.allDay
+        val newStartTime = if (newAllDay) null else (request.startTime ?: schedule.startTime)
+        val newEndTime = if (newAllDay) null else (request.endTime ?: schedule.endTime)
+
+        validateDateRange(newStartDate, newEndDate, newStartTime, newEndTime, newAllDay)
+
+        schedule.update(
+            title = request.title,
+            color = request.color,
+            startDate = request.startDate,
+            endDate = request.endDate,
+            startTime = newStartTime,
+            endTime = newEndTime,
+            allDay = request.allDay
+        )
+
+        request.participantIds?.let { ids ->
+            schedule.clearParticipants()
+            addParticipants(schedule, groupRoomId, ids)
+        }
+
+        groupRoom.updateLastActivity()
+
+        val commentCount = commentRepository.countByTargetTypeAndTargetId(CommentTargetType.SCHEDULE, scheduleId)
+        return ScheduleResponse.from(schedule, commentCount)
+    }
+
+    @Transactional
+    override fun deleteSchedule(userId: UUID, groupRoomId: Long, scheduleId: Long) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val schedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        if (schedule.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        scheduleRepository.delete(schedule)
+    }
+
+    private fun validateDateRange(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        startTime: java.time.LocalTime?,
+        endTime: java.time.LocalTime?,
+        allDay: Boolean
+    ) {
+        if (endDate.isBefore(startDate)) throw DigdaException(ErrorCode.END_DATE_BEFORE_START)
+
+        if (!allDay && startDate == endDate && startTime != null && endTime != null) {
+            if (endTime.isBefore(startTime)) throw DigdaException(ErrorCode.END_TIME_BEFORE_START)
+        }
+    }
+
+    private fun addParticipants(schedule: Schedule, groupRoomId: Long, participantIds: List<UUID>) {
+        participantIds.forEach { participantId ->
+            val participantMembership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, participantId)
+                .orElseThrow { DigdaException(ErrorCode.INVALID_PARTICIPANT) }
+
+            schedule.addParticipant(
+                ScheduleParticipant(
+                    schedule = schedule,
+                    user = participantMembership.user
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/controller/ScheduleController.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/controller/ScheduleController.kt
@@ -1,0 +1,88 @@
+package digdaserver.domain.schedule.presentation.controller
+
+import digdaserver.domain.schedule.application.service.ScheduleService
+import digdaserver.domain.schedule.presentation.dto.req.CreateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.req.UpdateScheduleRequest
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleDetailResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleListResponse
+import digdaserver.domain.schedule.presentation.dto.res.ScheduleResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.UUID
+
+@RestController
+@Tag(name = "Schedule", description = "일정 API")
+class ScheduleController(
+    private val scheduleService: ScheduleService
+) {
+
+    @Operation(summary = "일정 목록 조회 (기간)", description = "시작일~종료일 범위의 일정 목록을 조회합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/schedules")
+    fun getSchedules(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
+    ): ResponseEntity<ScheduleListResponse> {
+        val response = scheduleService.getSchedules(UUID.fromString(userId), groupRoomId, startDate, endDate)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일정 상세 조회", description = "일정 상세 정보와 댓글 목록을 조회합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/schedules/{scheduleId}")
+    fun getScheduleDetail(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable scheduleId: Long
+    ): ResponseEntity<ScheduleDetailResponse> {
+        val response = scheduleService.getScheduleDetail(UUID.fromString(userId), groupRoomId, scheduleId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일정 생성", description = "새 일정을 생성합니다. 참여자를 지정할 수 있습니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/schedules")
+    fun createSchedule(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestBody request: CreateScheduleRequest
+    ): ResponseEntity<ScheduleResponse> {
+        val response = scheduleService.createSchedule(UUID.fromString(userId), groupRoomId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "일정 수정", description = "일정을 수정합니다. 작성자 또는 방장만 가능합니다.")
+    @PutMapping("/group-rooms/{groupRoomId}/schedules/{scheduleId}")
+    fun updateSchedule(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable scheduleId: Long,
+        @RequestBody request: UpdateScheduleRequest
+    ): ResponseEntity<ScheduleResponse> {
+        val response = scheduleService.updateSchedule(UUID.fromString(userId), groupRoomId, scheduleId, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일정 삭제", description = "일정을 삭제합니다. 작성자 또는 방장만 가능합니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/schedules/{scheduleId}")
+    fun deleteSchedule(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable scheduleId: Long
+    ): ResponseEntity<Void> {
+        scheduleService.deleteSchedule(UUID.fromString(userId), groupRoomId, scheduleId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/req/CreateScheduleRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/req/CreateScheduleRequest.kt
@@ -1,0 +1,16 @@
+package digdaserver.domain.schedule.presentation.dto.req
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+data class CreateScheduleRequest(
+    val title: String,
+    val color: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val startTime: LocalTime? = null,
+    val endTime: LocalTime? = null,
+    val allDay: Boolean,
+    val participantIds: List<UUID>? = null
+)

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/req/UpdateScheduleRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/req/UpdateScheduleRequest.kt
@@ -1,0 +1,16 @@
+package digdaserver.domain.schedule.presentation.dto.req
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+data class UpdateScheduleRequest(
+    val title: String? = null,
+    val color: String? = null,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+    val startTime: LocalTime? = null,
+    val endTime: LocalTime? = null,
+    val allDay: Boolean? = null,
+    val participantIds: List<UUID>? = null
+)

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/CommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/CommentResponse.kt
@@ -1,0 +1,20 @@
+package digdaserver.domain.schedule.presentation.dto.res
+
+import digdaserver.domain.comment.domain.entity.Comment
+import java.time.LocalDateTime
+
+data class CommentResponse(
+    val id: Long,
+    val text: String,
+    val createdBy: UserSummary,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(comment: Comment): CommentResponse = CommentResponse(
+            id = comment.id,
+            text = comment.text,
+            createdBy = UserSummary.from(comment.createdBy),
+            createdAt = comment.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleDetailResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleDetailResponse.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.schedule.presentation.dto.res
+
+data class ScheduleDetailResponse(
+    val schedule: ScheduleResponse,
+    val comments: List<CommentResponse>
+)

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleListResponse.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.schedule.presentation.dto.res
+
+data class ScheduleListResponse(
+    val schedules: List<ScheduleResponse>
+)

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleResponse.kt
@@ -1,0 +1,38 @@
+package digdaserver.domain.schedule.presentation.dto.res
+
+import digdaserver.domain.schedule.domain.entity.Schedule
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class ScheduleResponse(
+    val id: Long,
+    val title: String,
+    val color: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val startTime: LocalTime?,
+    val endTime: LocalTime?,
+    val allDay: Boolean,
+    val participants: List<UserSummary>,
+    val createdBy: UserSummary,
+    val commentCount: Int,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(schedule: Schedule, commentCount: Int): ScheduleResponse = ScheduleResponse(
+            id = schedule.id,
+            title = schedule.title,
+            color = schedule.color,
+            startDate = schedule.startDate,
+            endDate = schedule.endDate,
+            startTime = schedule.startTime,
+            endTime = schedule.endTime,
+            allDay = schedule.allDay,
+            participants = schedule.participants.map { UserSummary.from(it.user) },
+            createdBy = UserSummary.from(schedule.createdBy),
+            commentCount = commentCount,
+            createdAt = schedule.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/UserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/UserSummary.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.schedule.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import java.util.UUID
+
+data class UserSummary(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?
+) {
+    companion object {
+        fun from(user: User): UserSummary = UserSummary(
+            userId = user.id,
+            name = user.name,
+            profileImage = user.profileImage
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #17

## 📝작업 내용

> 일정(Schedule) 도메인 API 5개를 구현했습니다.

### 일정 API (5개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | GET | `/group-rooms/:groupRoomId/schedules` | 일정 목록 (기간 조회, startDate/endDate 필수) |
| 2 | GET | `/group-rooms/:groupRoomId/schedules/:scheduleId` | 일정 상세 + 댓글 목록 |
| 3 | POST | `/group-rooms/:groupRoomId/schedules` | 일정 생성 (참여자 지정 가능) |
| 4 | PUT | `/group-rooms/:groupRoomId/schedules/:scheduleId` | 일정 수정 (작성자 또는 방장만) |
| 5 | DELETE | `/group-rooms/:groupRoomId/schedules/:scheduleId` | 일정 삭제 (작성자 또는 방장만) |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리 구조 적용
- 종일 여부(allDay)에 따라 시간 필드 자동 처리
- 종료일/시간 검증 (`END_DATE_BEFORE_START`, `END_TIME_BEFORE_START`)
- 참여자 지정 시 그룹방 구성원 여부 검증 (`INVALID_PARTICIPANT`)
- 수정/삭제는 작성자 또는 방장만 가능
- 댓글은 기존 Comment 엔티티 활용 (targetType: SCHEDULE)