### PR TITLE
[Feature] 일기 API 구현 (목록, 캘린더, 상세, 작성, 수정, 삭제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
@@ -1,0 +1,25 @@
+package digdaserver.domain.diary.application.service
+
+import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
+import java.time.YearMonth
+import java.util.UUID
+
+interface DiaryService {
+
+    fun getDiaries(userId: UUID, groupRoomId: Long, month: YearMonth?, limit: Int, offset: Int): DiaryListResponse
+
+    fun getDiaryCalendar(userId: UUID, groupRoomId: Long, month: YearMonth): DiaryCalendarResponse
+
+    fun getDiaryDetail(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDetailResponse
+
+    fun createDiary(userId: UUID, groupRoomId: Long, request: CreateDiaryRequest): DiaryResponse
+
+    fun updateDiary(userId: UUID, groupRoomId: Long, diaryId: Long, request: UpdateDiaryRequest): DiaryResponse
+
+    fun deleteDiary(userId: UUID, groupRoomId: Long, diaryId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -1,0 +1,202 @@
+package digdaserver.domain.diary.application.service.impl
+
+import digdaserver.domain.comment.domain.entity.CommentTargetType
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.diary.application.service.DiaryService
+import digdaserver.domain.diary.domain.entity.Diary
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryCommentResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
+import digdaserver.domain.diary.presentation.dto.res.DiarySummaryResponse
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class DiaryServiceImpl(
+    private val diaryRepository: DiaryRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val membershipRepository: MembershipRepository,
+    private val commentRepository: CommentRepository,
+    private val userRepository: UserRepository
+) : DiaryService {
+
+    override fun getDiaries(userId: UUID, groupRoomId: Long, month: YearMonth?, limit: Int, offset: Int): DiaryListResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+
+        val page = if (month != null) {
+            val startDate = month.atDay(1)
+            val endDate = month.atEndOfMonth()
+            diaryRepository.findAllByGroupRoomIdAndDateBetween(groupRoomId, startDate, endDate, pageable)
+        } else {
+            diaryRepository.findAllByGroupRoomId(groupRoomId, pageable)
+        }
+
+        return DiaryListResponse(
+            diaries = page.content.map { diary ->
+                val commentCount = commentRepository.countByTargetTypeAndTargetId(CommentTargetType.DIARY, diary.id)
+                DiarySummaryResponse.from(diary, commentCount)
+            },
+            total = page.totalElements
+        )
+    }
+
+    override fun getDiaryCalendar(userId: UUID, groupRoomId: Long, month: YearMonth): DiaryCalendarResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val startDate = month.atDay(1)
+        val endDate = month.atEndOfMonth()
+        val dates = diaryRepository.findDistinctDatesByGroupRoomIdAndMonth(groupRoomId, startDate, endDate)
+
+        return DiaryCalendarResponse(dates = dates)
+    }
+
+    override fun getDiaryDetail(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDetailResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        val comments = commentRepository.findAllByTargetTypeAndTargetIdOrderByCreatedAtAsc(CommentTargetType.DIARY, diaryId)
+
+        return DiaryDetailResponse(
+            diary = DiaryResponse.from(diary),
+            comments = comments.map { DiaryCommentResponse.from(it) }
+        )
+    }
+
+    @Transactional
+    override fun createDiary(userId: UUID, groupRoomId: Long, request: CreateDiaryRequest): DiaryResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        if (request.date.isAfter(LocalDate.now())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
+        validateWeather(request.weather)
+        validateMood(request.mood)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val diary = diaryRepository.save(
+            Diary(
+                groupRoom = groupRoom,
+                title = request.title,
+                content = request.content,
+                date = request.date,
+                weather = request.weather,
+                mood = request.mood,
+                imageUrl = request.imageId,
+                createdBy = user
+            )
+        )
+
+        groupRoom.updateLastActivity()
+
+        return DiaryResponse.from(diary)
+    }
+
+    @Transactional
+    override fun updateDiary(userId: UUID, groupRoomId: Long, diaryId: Long, request: UpdateDiaryRequest): DiaryResponse {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        if (diary.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        request.date?.let {
+            if (it.isAfter(LocalDate.now())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
+        }
+        request.weather?.let { validateWeather(it) }
+        request.mood?.let { validateMood(it) }
+
+        diary.update(
+            title = request.title,
+            content = request.content,
+            date = request.date,
+            weather = request.weather,
+            mood = request.mood,
+            imageUrl = request.imageId
+        )
+
+        groupRoom.updateLastActivity()
+
+        return DiaryResponse.from(diary)
+    }
+
+    @Transactional
+    override fun deleteDiary(userId: UUID, groupRoomId: Long, diaryId: Long) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        if (diary.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        diaryRepository.delete(diary)
+    }
+
+    private fun validateWeather(weather: Int) {
+        if (weather !in 0..3) throw DigdaException(ErrorCode.INVALID_WEATHER_VALUE)
+    }
+
+    private fun validateMood(mood: Int) {
+        if (mood !in 0..3) throw DigdaException(ErrorCode.INVALID_MOOD_VALUE)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
@@ -1,0 +1,100 @@
+package digdaserver.domain.diary.presentation.controller
+
+import digdaserver.domain.diary.application.service.DiaryService
+import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.YearMonth
+import java.util.UUID
+
+@RestController
+@Tag(name = "Diary", description = "일기 API")
+class DiaryController(
+    private val diaryService: DiaryService
+) {
+
+    @Operation(summary = "일기 목록 조회", description = "그룹방의 일기 목록을 조회합니다. 월별 필터 및 페이지네이션을 지원합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/diaries")
+    fun getDiaries(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestParam(required = false) month: YearMonth?,
+        @RequestParam(defaultValue = "20") limit: Int,
+        @RequestParam(defaultValue = "0") offset: Int
+    ): ResponseEntity<DiaryListResponse> {
+        val response = diaryService.getDiaries(UUID.fromString(userId), groupRoomId, month, limit, offset)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일기 캘린더 조회", description = "해당 월에 일기가 존재하는 날짜 배열을 반환합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/diaries/calendar")
+    fun getDiaryCalendar(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestParam month: YearMonth
+    ): ResponseEntity<DiaryCalendarResponse> {
+        val response = diaryService.getDiaryCalendar(UUID.fromString(userId), groupRoomId, month)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일기 상세 조회", description = "일기 상세 정보와 댓글 목록을 조회합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}")
+    fun getDiaryDetail(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long
+    ): ResponseEntity<DiaryDetailResponse> {
+        val response = diaryService.getDiaryDetail(UUID.fromString(userId), groupRoomId, diaryId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일기 작성", description = "새 일기를 작성합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/diaries")
+    fun createDiary(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestBody request: CreateDiaryRequest
+    ): ResponseEntity<DiaryResponse> {
+        val response = diaryService.createDiary(UUID.fromString(userId), groupRoomId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "일기 수정", description = "일기를 수정합니다. 작성자 또는 방장만 가능합니다.")
+    @PutMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}")
+    fun updateDiary(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long,
+        @RequestBody request: UpdateDiaryRequest
+    ): ResponseEntity<DiaryResponse> {
+        val response = diaryService.updateDiary(UUID.fromString(userId), groupRoomId, diaryId, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일기 삭제", description = "일기를 삭제합니다. 작성자 또는 방장만 가능합니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}")
+    fun deleteDiary(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long
+    ): ResponseEntity<Void> {
+        diaryService.deleteDiary(UUID.fromString(userId), groupRoomId, diaryId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.diary.presentation.dto.req
+
+import java.time.LocalDate
+
+data class CreateDiaryRequest(
+    val title: String,
+    val content: String,
+    val date: LocalDate,
+    val weather: Int,
+    val mood: Int,
+    val imageId: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.diary.presentation.dto.req
+
+import java.time.LocalDate
+
+data class UpdateDiaryRequest(
+    val title: String? = null,
+    val content: String? = null,
+    val date: LocalDate? = null,
+    val weather: Int? = null,
+    val mood: Int? = null,
+    val imageId: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
@@ -1,0 +1,7 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import java.time.LocalDate
+
+data class DiaryCalendarResponse(
+    val dates: List<LocalDate>
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
@@ -1,0 +1,20 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.comment.domain.entity.Comment
+import java.time.LocalDateTime
+
+data class DiaryCommentResponse(
+    val id: Long,
+    val text: String,
+    val createdBy: DiaryUserSummary,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(comment: Comment): DiaryCommentResponse = DiaryCommentResponse(
+            id = comment.id,
+            text = comment.text,
+            createdBy = DiaryUserSummary.from(comment.createdBy),
+            createdAt = comment.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryDetailResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryDetailResponse.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+data class DiaryDetailResponse(
+    val diary: DiaryResponse,
+    val comments: List<DiaryCommentResponse>
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryListResponse.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+data class DiaryListResponse(
+    val diaries: List<DiarySummaryResponse>,
+    val total: Long
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
@@ -1,0 +1,33 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.diary.domain.entity.Diary
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class DiaryResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val date: LocalDate,
+    val weather: Int,
+    val mood: Int,
+    val imageUrl: String?,
+    val createdBy: DiaryUserSummary,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(diary: Diary): DiaryResponse = DiaryResponse(
+            id = diary.id,
+            title = diary.title,
+            content = diary.content,
+            date = diary.date,
+            weather = diary.weather,
+            mood = diary.mood,
+            imageUrl = diary.imageUrl,
+            createdBy = DiaryUserSummary.from(diary.createdBy),
+            createdAt = diary.createdAt,
+            updatedAt = diary.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
@@ -1,0 +1,31 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.diary.domain.entity.Diary
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class DiarySummaryResponse(
+    val id: Long,
+    val title: String,
+    val date: LocalDate,
+    val weather: Int,
+    val mood: Int,
+    val imageUrl: String?,
+    val createdBy: DiaryUserSummary,
+    val commentCount: Int,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(diary: Diary, commentCount: Int): DiarySummaryResponse = DiarySummaryResponse(
+            id = diary.id,
+            title = diary.title,
+            date = diary.date,
+            weather = diary.weather,
+            mood = diary.mood,
+            imageUrl = diary.imageUrl,
+            createdBy = DiaryUserSummary.from(diary.createdBy),
+            commentCount = commentCount,
+            createdAt = diary.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryUserSummary.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import java.util.UUID
+
+data class DiaryUserSummary(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?
+) {
+    companion object {
+        fun from(user: User): DiaryUserSummary = DiaryUserSummary(
+            userId = user.id,
+            name = user.name,
+            profileImage = user.profileImage
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19

## 📝작업 내용

> 일기(Diary) 도메인 API 6개를 구현했습니다.

### 일기 API (6개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | GET | `/group-rooms/:groupRoomId/diaries` | 일기 목록 (월별 필터, 페이지네이션) |
| 2 | GET | `/group-rooms/:groupRoomId/diaries/calendar` | 캘린더용 날짜 배열 (dot marker용) |
| 3 | GET | `/group-rooms/:groupRoomId/diaries/:diaryId` | 일기 상세 + 댓글 목록 |
| 4 | POST | `/group-rooms/:groupRoomId/diaries` | 일기 작성 (날씨/기분/이미지 포함) |
| 5 | PUT | `/group-rooms/:groupRoomId/diaries/:diaryId` | 일기 수정 (작성자 또는 방장만) |
| 6 | DELETE | `/group-rooms/:groupRoomId/diaries/:diaryId` | 일기 삭제 (작성자 또는 방장만) |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리 구조 적용
- 월별 필터 + offset/limit 페이지네이션
- 캘린더 API는 일기가 존재하는 날짜만 반환 (경량 조회)
- 미래 날짜 작성 불가 (`FUTURE_DATE_NOT_ALLOWED`)
- 날씨(0~3), 기분(0~3) 범위 검증
- 수정/삭제는 작성자 또는 방장만 가능
- 댓글은 기존 Comment 엔티티 활용 (targetType: DIARY)