### PR TITLE
[Feature] 댓글 API 구현 (일정/일기 댓글 작성, 삭제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/comment/application/service/CommentService.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/CommentService.kt
@@ -1,0 +1,15 @@
+package digdaserver.domain.comment.application.service
+
+import digdaserver.domain.comment.presentation.dto.res.CreateCommentResponse
+import java.util.UUID
+
+interface CommentService {
+
+    fun createScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, text: String): CreateCommentResponse
+
+    fun createDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, text: String): CreateCommentResponse
+
+    fun deleteScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, commentId: Long)
+
+    fun deleteDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, commentId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
@@ -1,0 +1,119 @@
+package digdaserver.domain.comment.application.service.impl
+
+import digdaserver.domain.comment.application.service.CommentService
+import digdaserver.domain.comment.domain.entity.Comment
+import digdaserver.domain.comment.domain.entity.CommentTargetType
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.comment.presentation.dto.res.CreateCommentResponse
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class CommentServiceImpl(
+    private val commentRepository: CommentRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val membershipRepository: MembershipRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val diaryRepository: DiaryRepository,
+    private val userRepository: UserRepository
+) : CommentService {
+
+    @Transactional
+    override fun createScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, text: String): CreateCommentResponse {
+        validateGroupRoomMember(groupRoomId, userId)
+        validateCommentText(text)
+
+        scheduleRepository.findById(scheduleId)
+            .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val comment = commentRepository.save(
+            Comment(
+                targetType = CommentTargetType.SCHEDULE,
+                targetId = scheduleId,
+                text = text,
+                createdBy = user
+            )
+        )
+
+        return CreateCommentResponse.from(comment)
+    }
+
+    @Transactional
+    override fun createDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, text: String): CreateCommentResponse {
+        validateGroupRoomMember(groupRoomId, userId)
+        validateCommentText(text)
+
+        diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val comment = commentRepository.save(
+            Comment(
+                targetType = CommentTargetType.DIARY,
+                targetId = diaryId,
+                text = text,
+                createdBy = user
+            )
+        )
+
+        return CreateCommentResponse.from(comment)
+    }
+
+    @Transactional
+    override fun deleteScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, commentId: Long) {
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val comment = commentRepository.findById(commentId)
+            .orElseThrow { DigdaException(ErrorCode.COMMENT_NOT_FOUND) }
+
+        if (comment.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        commentRepository.delete(comment)
+    }
+
+    @Transactional
+    override fun deleteDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, commentId: Long) {
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val comment = commentRepository.findById(commentId)
+            .orElseThrow { DigdaException(ErrorCode.COMMENT_NOT_FOUND) }
+
+        if (comment.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        commentRepository.delete(comment)
+    }
+
+    private fun validateGroupRoomMember(groupRoomId: Long, userId: UUID) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+    }
+
+    private fun validateCommentText(text: String) {
+        if (text.length > 200) throw DigdaException(ErrorCode.COMMENT_TOO_LONG)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/controller/CommentController.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/controller/CommentController.kt
@@ -1,0 +1,71 @@
+package digdaserver.domain.comment.presentation.controller
+
+import digdaserver.domain.comment.application.service.CommentService
+import digdaserver.domain.comment.presentation.dto.req.CreateCommentRequest
+import digdaserver.domain.comment.presentation.dto.res.CreateCommentResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Comment", description = "댓글 API")
+class CommentController(
+    private val commentService: CommentService
+) {
+
+    @Operation(summary = "일정 댓글 작성", description = "일정에 댓글을 작성합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/schedules/{scheduleId}/comments")
+    fun createScheduleComment(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable scheduleId: Long,
+        @RequestBody request: CreateCommentRequest
+    ): ResponseEntity<CreateCommentResponse> {
+        val response = commentService.createScheduleComment(UUID.fromString(userId), groupRoomId, scheduleId, request.text)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "일기 댓글 작성", description = "일기에 댓글을 작성합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}/comments")
+    fun createDiaryComment(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long,
+        @RequestBody request: CreateCommentRequest
+    ): ResponseEntity<CreateCommentResponse> {
+        val response = commentService.createDiaryComment(UUID.fromString(userId), groupRoomId, diaryId, request.text)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "일정 댓글 삭제", description = "일정 댓글을 삭제합니다. 작성자 또는 방장만 가능합니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/schedules/{scheduleId}/comments/{commentId}")
+    fun deleteScheduleComment(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable scheduleId: Long,
+        @PathVariable commentId: Long
+    ): ResponseEntity<Void> {
+        commentService.deleteScheduleComment(UUID.fromString(userId), groupRoomId, scheduleId, commentId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "일기 댓글 삭제", description = "일기 댓글을 삭제합니다. 작성자 또는 방장만 가능합니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}/comments/{commentId}")
+    fun deleteDiaryComment(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long,
+        @PathVariable commentId: Long
+    ): ResponseEntity<Void> {
+        commentService.deleteDiaryComment(UUID.fromString(userId), groupRoomId, diaryId, commentId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/req/CreateCommentRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/req/CreateCommentRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.comment.presentation.dto.req
+
+data class CreateCommentRequest(
+    val text: String
+)

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CommentUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CommentUserSummary.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.comment.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import java.util.UUID
+
+data class CommentUserSummary(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?
+) {
+    companion object {
+        fun from(user: User): CommentUserSummary = CommentUserSummary(
+            userId = user.id,
+            name = user.name,
+            profileImage = user.profileImage
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CreateCommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CreateCommentResponse.kt
@@ -1,0 +1,20 @@
+package digdaserver.domain.comment.presentation.dto.res
+
+import digdaserver.domain.comment.domain.entity.Comment
+import java.time.LocalDateTime
+
+data class CreateCommentResponse(
+    val id: Long,
+    val text: String,
+    val createdBy: CommentUserSummary,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(comment: Comment): CreateCommentResponse = CreateCommentResponse(
+            id = comment.id,
+            text = comment.text,
+            createdBy = CommentUserSummary.from(comment.createdBy),
+            createdAt = comment.createdAt
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21

## 📝작업 내용

> 댓글(Comment) 도메인 API 4개를 구현했습니다.

### 댓글 API (4개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | POST | `/group-rooms/:groupRoomId/schedules/:scheduleId/comments` | 일정 댓글 작성 |
| 2 | POST | `/group-rooms/:groupRoomId/diaries/:diaryId/comments` | 일기 댓글 작성 |
| 3 | DELETE | `/group-rooms/:groupRoomId/schedules/:scheduleId/comments/:commentId` | 일정 댓글 삭제 (작성자 또는 방장) |
| 4 | DELETE | `/group-rooms/:groupRoomId/diaries/:diaryId/comments/:commentId` | 일기 댓글 삭제 (작성자 또는 방장) |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리 구조 적용
- 댓글 내용 200자 제한 (`COMMENT_TOO_LONG`)
- 삭제는 댓글 작성자 또는 방장만 가능
- 기존 Comment 엔티티 활용 (targetType: SCHEDULE / DIARY)
- 일정/일기 존재 여부 검증 후 댓글 생성