### PR TITLE
[Feature] Todo API 구현 (할 일 목록, 생성, 완료 토글, 삭제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/todo/application/service/TodoService.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/application/service/TodoService.kt
@@ -1,0 +1,16 @@
+package digdaserver.domain.todo.application.service
+
+import digdaserver.domain.todo.presentation.dto.res.TodoListResponse
+import digdaserver.domain.todo.presentation.dto.res.TodoResponse
+import java.util.UUID
+
+interface TodoService {
+
+    fun getTodos(userId: UUID, groupRoomId: Long): TodoListResponse
+
+    fun createTodo(userId: UUID, groupRoomId: Long, text: String): TodoResponse
+
+    fun toggleTodo(userId: UUID, groupRoomId: Long, todoId: Long, completed: Boolean): TodoResponse
+
+    fun deleteTodo(userId: UUID, groupRoomId: Long, todoId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/todo/application/service/impl/TodoServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/application/service/impl/TodoServiceImpl.kt
@@ -1,0 +1,110 @@
+package digdaserver.domain.todo.application.service.impl
+
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.todo.application.service.TodoService
+import digdaserver.domain.todo.domain.entity.Todo
+import digdaserver.domain.todo.domain.repository.TodoRepository
+import digdaserver.domain.todo.presentation.dto.res.ProgressResponse
+import digdaserver.domain.todo.presentation.dto.res.TodoListResponse
+import digdaserver.domain.todo.presentation.dto.res.TodoResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class TodoServiceImpl(
+    private val todoRepository: TodoRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val membershipRepository: MembershipRepository,
+    private val userRepository: UserRepository
+) : TodoService {
+
+    override fun getTodos(userId: UUID, groupRoomId: Long): TodoListResponse {
+        validateGroupRoomMember(groupRoomId, userId)
+
+        val todos = todoRepository.findAllByGroupRoomIdOrdered(groupRoomId)
+        val total = todos.size
+        val completed = todos.count { it.completed }
+        val percent = if (total == 0) 0 else (completed * 100) / total
+
+        return TodoListResponse(
+            todos = todos.map { TodoResponse.from(it) },
+            progress = ProgressResponse(
+                total = total,
+                completed = completed,
+                percent = percent
+            )
+        )
+    }
+
+    @Transactional
+    override fun createTodo(userId: UUID, groupRoomId: Long, text: String): TodoResponse {
+        validateGroupRoomMember(groupRoomId, userId)
+        validateTodoText(text)
+
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val todo = todoRepository.save(
+            Todo(
+                groupRoom = groupRoom,
+                text = text,
+                createdBy = user
+            )
+        )
+
+        return TodoResponse.from(todo)
+    }
+
+    @Transactional
+    override fun toggleTodo(userId: UUID, groupRoomId: Long, todoId: Long, completed: Boolean): TodoResponse {
+        validateGroupRoomMember(groupRoomId, userId)
+
+        val todo = todoRepository.findById(todoId)
+            .orElseThrow { DigdaException(ErrorCode.TODO_NOT_FOUND) }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        todo.toggleComplete(user)
+
+        return TodoResponse.from(todo)
+    }
+
+    @Transactional
+    override fun deleteTodo(userId: UUID, groupRoomId: Long, todoId: Long) {
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val todo = todoRepository.findById(todoId)
+            .orElseThrow { DigdaException(ErrorCode.TODO_NOT_FOUND) }
+
+        if (todo.createdBy.id != userId && !membership.isOwner) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        todoRepository.delete(todo)
+    }
+
+    private fun validateGroupRoomMember(groupRoomId: Long, userId: UUID) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+    }
+
+    private fun validateTodoText(text: String) {
+        if (text.length > 100) throw DigdaException(ErrorCode.TODO_TEXT_TOO_LONG)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/controller/TodoController.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/controller/TodoController.kt
@@ -1,0 +1,71 @@
+package digdaserver.domain.todo.presentation.controller
+
+import digdaserver.domain.todo.application.service.TodoService
+import digdaserver.domain.todo.presentation.dto.req.CreateTodoRequest
+import digdaserver.domain.todo.presentation.dto.req.ToggleTodoRequest
+import digdaserver.domain.todo.presentation.dto.res.TodoListResponse
+import digdaserver.domain.todo.presentation.dto.res.TodoResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Todo", description = "할 일 API")
+class TodoController(
+    private val todoService: TodoService
+) {
+
+    @Operation(summary = "할 일 목록 조회", description = "그룹방의 할 일 목록을 조회합니다. 미완료 → 완료 순서로 정렬됩니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/todos")
+    fun getTodos(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<TodoListResponse> {
+        val response = todoService.getTodos(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "할 일 생성", description = "그룹방에 새 할 일을 추가합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/todos")
+    fun createTodo(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestBody request: CreateTodoRequest
+    ): ResponseEntity<TodoResponse> {
+        val response = todoService.createTodo(UUID.fromString(userId), groupRoomId, request.text)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "할 일 완료 토글", description = "할 일의 완료 여부를 토글합니다. 모든 구성원이 가능합니다.")
+    @PatchMapping("/group-rooms/{groupRoomId}/todos/{todoId}")
+    fun toggleTodo(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable todoId: Long,
+        @RequestBody request: ToggleTodoRequest
+    ): ResponseEntity<TodoResponse> {
+        val response = todoService.toggleTodo(UUID.fromString(userId), groupRoomId, todoId, request.completed)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "할 일 삭제", description = "할 일을 삭제합니다. 작성자 또는 방장만 가능합니다.")
+    @DeleteMapping("/group-rooms/{groupRoomId}/todos/{todoId}")
+    fun deleteTodo(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable todoId: Long
+    ): ResponseEntity<Void> {
+        todoService.deleteTodo(UUID.fromString(userId), groupRoomId, todoId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/req/CreateTodoRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/req/CreateTodoRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.todo.presentation.dto.req
+
+data class CreateTodoRequest(
+    val text: String
+)

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/req/ToggleTodoRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/req/ToggleTodoRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.todo.presentation.dto.req
+
+data class ToggleTodoRequest(
+    val completed: Boolean
+)

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/ProgressResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/ProgressResponse.kt
@@ -1,0 +1,7 @@
+package digdaserver.domain.todo.presentation.dto.res
+
+data class ProgressResponse(
+    val total: Int,
+    val completed: Int,
+    val percent: Int
+)

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoListResponse.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.todo.presentation.dto.res
+
+data class TodoListResponse(
+    val todos: List<TodoResponse>,
+    val progress: ProgressResponse
+)

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoResponse.kt
@@ -1,0 +1,26 @@
+package digdaserver.domain.todo.presentation.dto.res
+
+import digdaserver.domain.todo.domain.entity.Todo
+import java.time.LocalDateTime
+
+data class TodoResponse(
+    val id: Long,
+    val text: String,
+    val completed: Boolean,
+    val completedAt: LocalDateTime?,
+    val completedBy: TodoUserSummary?,
+    val createdBy: TodoUserSummary,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(todo: Todo): TodoResponse = TodoResponse(
+            id = todo.id,
+            text = todo.text,
+            completed = todo.completed,
+            completedAt = todo.completedAt,
+            completedBy = todo.completedBy?.let { TodoUserSummary.from(it) },
+            createdBy = TodoUserSummary.from(todo.createdBy),
+            createdAt = todo.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoUserSummary.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.todo.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import java.util.UUID
+
+data class TodoUserSummary(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?
+) {
+    companion object {
+        fun from(user: User): TodoUserSummary = TodoUserSummary(
+            userId = user.id,
+            name = user.name,
+            profileImage = user.profileImage
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23

## 📝작업 내용

> Todo 도메인 API 4개를 구현했습니다.

### Todo API (4개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | GET | `/group-rooms/:groupRoomId/todos` | 할 일 목록 (미완료→완료 순, 진행률 포함) |
| 2 | POST | `/group-rooms/:groupRoomId/todos` | 할 일 생성 |
| 3 | PATCH | `/group-rooms/:groupRoomId/todos/:todoId` | 할 일 완료 토글 |
| 4 | DELETE | `/group-rooms/:groupRoomId/todos/:todoId` | 할 일 삭제 |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리 구조 적용
- `@Transactional(readOnly = true)` 클래스 레벨, 쓰기 메서드만 `@Transactional`
- 권한 체크: 그룹방 존재 → 삭제 여부 → 구성원 여부 → 작성자/방장 여부 순서
- 목록 조회 시 Progress 객체(total, completed, percent) 포함
- 삭제는 작성자 또는 방장만 가능, 완료 토글은 모든 구성원 가능
- Swagger 어노테이션 (`@Tag`, `@Operation`) 적용