### PR TITLE
[Feature] Notification API 구현 (알림 목록, 읽음 처리, 전체 읽음, 삭제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
@@ -1,0 +1,15 @@
+package digdaserver.domain.notification.application.service
+
+import digdaserver.domain.notification.presentation.dto.res.NotificationListResponse
+import java.util.UUID
+
+interface NotificationService {
+
+    fun getNotifications(userId: UUID, limit: Int, offset: Int): NotificationListResponse
+
+    fun markAsRead(userId: UUID, notificationId: Long, isRead: Boolean)
+
+    fun markAllAsRead(userId: UUID)
+
+    fun deleteNotification(userId: UUID, notificationId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -1,0 +1,68 @@
+package digdaserver.domain.notification.application.service.impl
+
+import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.domain.notification.domain.repository.NotificationRepository
+import digdaserver.domain.notification.presentation.dto.res.NotificationListResponse
+import digdaserver.domain.notification.presentation.dto.res.NotificationResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class NotificationServiceImpl(
+    private val notificationRepository: NotificationRepository
+) : NotificationService {
+
+    override fun getNotifications(userId: UUID, limit: Int, offset: Int): NotificationListResponse {
+        val safeLimit = limit.coerceIn(1, 100)
+        val safeOffset = offset.coerceAtLeast(0)
+        val pageable = PageRequest.of(safeOffset / safeLimit, safeLimit)
+
+        val page = notificationRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable)
+        val unreadCount = notificationRepository.countByUserIdAndIsReadFalse(userId)
+
+        return NotificationListResponse(
+            notifications = page.content.map { NotificationResponse.from(it) },
+            total = page.totalElements,
+            unreadCount = unreadCount,
+            limit = safeLimit,
+            offset = safeOffset,
+            hasMore = (safeOffset + page.content.size) < page.totalElements
+        )
+    }
+
+    @Transactional
+    override fun markAsRead(userId: UUID, notificationId: Long, isRead: Boolean) {
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_NOT_FOUND) }
+
+        if (notification.user.id != userId) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        if (isRead) {
+            notification.markAsRead()
+        }
+    }
+
+    @Transactional
+    override fun markAllAsRead(userId: UUID) {
+        notificationRepository.markAllAsReadByUserId(userId)
+    }
+
+    @Transactional
+    override fun deleteNotification(userId: UUID, notificationId: Long) {
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_NOT_FOUND) }
+
+        if (notification.user.id != userId) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        notificationRepository.delete(notification)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/notification/presentation/controller/NotificationController.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/presentation/controller/NotificationController.kt
@@ -1,0 +1,66 @@
+package digdaserver.domain.notification.presentation.controller
+
+import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.domain.notification.presentation.dto.req.UpdateNotificationReadRequest
+import digdaserver.domain.notification.presentation.dto.res.NotificationListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Notification", description = "알림 API")
+class NotificationController(
+    private val notificationService: NotificationService
+) {
+
+    @Operation(summary = "알림 목록 조회", description = "내 알림 목록을 최신순으로 조회합니다.")
+    @GetMapping("/notifications")
+    fun getNotifications(
+        @AuthenticationPrincipal userId: String,
+        @RequestParam(defaultValue = "20") limit: Int,
+        @RequestParam(defaultValue = "0") offset: Int
+    ): ResponseEntity<NotificationListResponse> {
+        val response = notificationService.getNotifications(UUID.fromString(userId), limit, offset)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    @PatchMapping("/notifications/{notificationId}")
+    fun markAsRead(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable notificationId: Long,
+        @RequestBody request: UpdateNotificationReadRequest
+    ): ResponseEntity<Void> {
+        notificationService.markAsRead(UUID.fromString(userId), notificationId, request.isRead)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "전체 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+    @PostMapping("/notifications/read-all")
+    fun markAllAsRead(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<Void> {
+        notificationService.markAllAsRead(UUID.fromString(userId))
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "알림 삭제", description = "특정 알림을 삭제합니다.")
+    @DeleteMapping("/notifications/{notificationId}")
+    fun deleteNotification(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable notificationId: Long
+    ): ResponseEntity<Void> {
+        notificationService.deleteNotification(UUID.fromString(userId), notificationId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/notification/presentation/dto/req/UpdateNotificationReadRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/presentation/dto/req/UpdateNotificationReadRequest.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.notification.presentation.dto.req
+
+data class UpdateNotificationReadRequest(
+    val isRead: Boolean
+)

--- a/src/main/kotlin/digdaserver/domain/notification/presentation/dto/res/NotificationListResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/presentation/dto/res/NotificationListResponse.kt
@@ -1,0 +1,10 @@
+package digdaserver.domain.notification.presentation.dto.res
+
+data class NotificationListResponse(
+    val notifications: List<NotificationResponse>,
+    val total: Long,
+    val unreadCount: Int,
+    val limit: Int,
+    val offset: Int,
+    val hasMore: Boolean
+)

--- a/src/main/kotlin/digdaserver/domain/notification/presentation/dto/res/NotificationResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/presentation/dto/res/NotificationResponse.kt
@@ -1,0 +1,33 @@
+package digdaserver.domain.notification.presentation.dto.res
+
+import digdaserver.domain.notification.domain.entity.Notification
+import digdaserver.domain.notification.domain.entity.NotificationType
+import java.time.LocalDateTime
+
+data class NotificationResponse(
+    val id: Long,
+    val type: NotificationType,
+    val title: String,
+    val message: String,
+    val groupRoomId: Long?,
+    val groupRoomName: String?,
+    val relatedId: Long?,
+    val relatedType: String?,
+    val isRead: Boolean,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResponse = NotificationResponse(
+            id = notification.id,
+            type = notification.type,
+            title = notification.title,
+            message = notification.message,
+            groupRoomId = notification.groupRoomId,
+            groupRoomName = notification.groupRoomName,
+            relatedId = notification.relatedId,
+            relatedType = notification.relatedType,
+            isRead = notification.isRead,
+            createdAt = notification.createdAt
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26

## 📝작업 내용

> Notification 도메인 API 4개를 구현했습니다.

### Notification API (4개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | GET | `/notifications` | 알림 목록 (최신순, 페이지네이션, unreadCount 포함) |
| 2 | PATCH | `/notifications/:notificationId` | 알림 읽음 처리 |
| 3 | POST | `/notifications/read-all` | 전체 알림 읽음 처리 |
| 4 | DELETE | `/notifications/:notificationId` | 알림 삭제 |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리, 클래스 레벨 `@Transactional(readOnly = true)`
- 본인 알림만 수정/삭제 가능 (`FORBIDDEN` 에러 처리)
- 페이지네이션 응답: `total`, `unreadCount`, `limit`, `offset`, `hasMore` 포함
- 전체 읽음: `@Modifying` JPQL 일괄 업데이트
- Swagger `@Tag`, `@Operation` 어노테이션 적용