### PR TITLE
[Feature] Upload API 구현 (이미지 업로드)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/upload/application/service/UploadService.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/UploadService.kt
@@ -1,0 +1,10 @@
+package digdaserver.domain.upload.application.service
+
+import digdaserver.domain.upload.presentation.dto.res.UploadImageResponse
+import org.springframework.web.multipart.MultipartFile
+import java.util.UUID
+
+interface UploadService {
+
+    fun uploadImage(userId: UUID, file: MultipartFile, purpose: String): UploadImageResponse
+}

--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -1,0 +1,87 @@
+package digdaserver.domain.upload.application.service.impl
+
+import digdaserver.domain.upload.application.service.UploadService
+import digdaserver.domain.upload.domain.entity.ImagePurpose
+import digdaserver.domain.upload.domain.entity.UploadedImage
+import digdaserver.domain.upload.domain.repository.UploadedImageRepository
+import digdaserver.domain.upload.presentation.dto.res.UploadImageResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import digdaserver.global.infra.s3.presentation.application.S3Service
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+import javax.imageio.ImageIO
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class UploadServiceImpl(
+    private val uploadedImageRepository: UploadedImageRepository,
+    private val userRepository: UserRepository,
+    private val s3Service: S3Service
+) : UploadService {
+
+    companion object {
+        private const val MAX_SIZE_BYTES = 5L * 1024 * 1024
+        private val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/jpg")
+    }
+
+    @Transactional
+    override fun uploadImage(userId: UUID, file: MultipartFile, purpose: String): UploadImageResponse {
+        validateFile(file)
+
+        val imagePurpose = parsePurpose(purpose)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val (width, height) = readImageDimensions(file)
+
+        val url = s3Service.storeImage(file, userId.toString())
+            ?: throw DigdaException(ErrorCode.SERVER_ERROR)
+
+        val saved = uploadedImageRepository.save(
+            UploadedImage(
+                user = user,
+                url = url,
+                width = width,
+                height = height,
+                purpose = imagePurpose
+            )
+        )
+
+        return UploadImageResponse.from(saved)
+    }
+
+    private fun validateFile(file: MultipartFile) {
+        if (file.isEmpty) throw DigdaException(ErrorCode.INVALID_FILE_TYPE)
+        if (file.size > MAX_SIZE_BYTES) throw DigdaException(ErrorCode.FILE_TOO_LARGE)
+
+        val contentType = file.contentType?.lowercase()
+        if (contentType !in ALLOWED_CONTENT_TYPES) {
+            throw DigdaException(ErrorCode.INVALID_FILE_TYPE)
+        }
+    }
+
+    private fun parsePurpose(purpose: String): ImagePurpose {
+        return when (purpose.lowercase()) {
+            "profile" -> ImagePurpose.PROFILE
+            "group_thumbnail" -> ImagePurpose.GROUP_THUMBNAIL
+            "diary" -> ImagePurpose.DIARY
+            else -> throw DigdaException(ErrorCode.INVALID_PARAMETER)
+        }
+    }
+
+    private fun readImageDimensions(file: MultipartFile): Pair<Int, Int> {
+        return try {
+            file.inputStream.use { stream ->
+                val image = ImageIO.read(stream) ?: return 0 to 0
+                image.width to image.height
+            }
+        } catch (_: Exception) {
+            0 to 0
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/upload/presentation/controller/UploadController.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/presentation/controller/UploadController.kt
@@ -1,0 +1,32 @@
+package digdaserver.domain.upload.presentation.controller
+
+import digdaserver.domain.upload.application.service.UploadService
+import digdaserver.domain.upload.presentation.dto.res.UploadImageResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import java.util.UUID
+
+@RestController
+@Tag(name = "Upload", description = "이미지 업로드 API")
+class UploadController(
+    private val uploadService: UploadService
+) {
+
+    @Operation(summary = "이미지 업로드", description = "프로필/그룹방 썸네일/일기 이미지를 업로드합니다. PNG/JPEG만 지원, 최대 5MB.")
+    @PostMapping("/uploads/images", consumes = ["multipart/form-data"])
+    fun uploadImage(
+        @AuthenticationPrincipal userId: String,
+        @RequestParam("file") file: MultipartFile,
+        @RequestParam("purpose") purpose: String
+    ): ResponseEntity<UploadImageResponse> {
+        val response = uploadService.uploadImage(UUID.fromString(userId), file, purpose)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/upload/presentation/dto/res/UploadImageResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/presentation/dto/res/UploadImageResponse.kt
@@ -1,0 +1,19 @@
+package digdaserver.domain.upload.presentation.dto.res
+
+import digdaserver.domain.upload.domain.entity.UploadedImage
+
+data class UploadImageResponse(
+    val id: Long,
+    val url: String,
+    val width: Int,
+    val height: Int
+) {
+    companion object {
+        fun from(image: UploadedImage): UploadImageResponse = UploadImageResponse(
+            id = image.id,
+            url = image.url,
+            width = image.width,
+            height = image.height
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28

## 📝작업 내용

> Upload 도메인 API 1개를 구현했습니다.

### Upload API (1개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | POST | `/uploads/images` | 이미지 업로드 (multipart, PNG/JPEG, 5MB) |

### 주요 구현 사항
- Multipart form-data (`file`, `purpose`) 수신
- 파일 크기(5MB) / 타입(PNG·JPEG) 검증, 에러 `FILE_TOO_LARGE` / `INVALID_FILE_TYPE`
- 기존 `S3Service`로 S3에 업로드 후 URL 생성
- `ImageIO`로 width/height 추출
- `uploaded_image` 테이블에 메타데이터 저장 후 `id`/`url`/`width`/`height` 응답
- Swagger `@Tag`, `@Operation` 어노테이션 적용