### PR TITLE
[Feature] Device API 구현 (디바이스 토큰 등록, 해제)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/device/application/service/DeviceService.kt
+++ b/src/main/kotlin/digdaserver/domain/device/application/service/DeviceService.kt
@@ -1,0 +1,11 @@
+package digdaserver.domain.device.application.service
+
+import digdaserver.domain.device.presentation.dto.res.RegisterDeviceResponse
+import java.util.UUID
+
+interface DeviceService {
+
+    fun registerDevice(userId: UUID, token: String, platform: String): RegisterDeviceResponse
+
+    fun unregisterDevice(userId: UUID, deviceId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/device/application/service/impl/DeviceServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/device/application/service/impl/DeviceServiceImpl.kt
@@ -1,0 +1,69 @@
+package digdaserver.domain.device.application.service.impl
+
+import digdaserver.domain.device.application.service.DeviceService
+import digdaserver.domain.device.domain.entity.Device
+import digdaserver.domain.device.domain.entity.Platform
+import digdaserver.domain.device.domain.repository.DeviceRepository
+import digdaserver.domain.device.presentation.dto.res.RegisterDeviceResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class DeviceServiceImpl(
+    private val deviceRepository: DeviceRepository,
+    private val userRepository: UserRepository
+) : DeviceService {
+
+    @Transactional
+    override fun registerDevice(userId: UUID, token: String, platform: String): RegisterDeviceResponse {
+        if (token.isBlank()) throw DigdaException(ErrorCode.INVALID_PARAMETER)
+        val parsedPlatform = parsePlatform(platform)
+
+        val existing = deviceRepository.findByToken(token)
+        if (existing.isPresent) {
+            val device = existing.get()
+            if (device.user.id != userId) {
+                throw DigdaException(ErrorCode.FORBIDDEN)
+            }
+            return RegisterDeviceResponse(deviceId = device.id)
+        }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val saved = deviceRepository.save(
+            Device(
+                user = user,
+                token = token,
+                platform = parsedPlatform
+            )
+        )
+
+        return RegisterDeviceResponse(deviceId = saved.id)
+    }
+
+    @Transactional
+    override fun unregisterDevice(userId: UUID, deviceId: Long) {
+        val device = deviceRepository.findById(deviceId)
+            .orElseThrow { DigdaException(ErrorCode.DEVICE_NOT_FOUND) }
+
+        if (device.user.id != userId) {
+            throw DigdaException(ErrorCode.FORBIDDEN)
+        }
+
+        deviceRepository.delete(device)
+    }
+
+    private fun parsePlatform(platform: String): Platform {
+        return when (platform.lowercase()) {
+            "ios" -> Platform.IOS
+            "android" -> Platform.ANDROID
+            else -> throw DigdaException(ErrorCode.INVALID_PARAMETER)
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/device/presentation/controller/DeviceController.kt
+++ b/src/main/kotlin/digdaserver/domain/device/presentation/controller/DeviceController.kt
@@ -1,0 +1,43 @@
+package digdaserver.domain.device.presentation.controller
+
+import digdaserver.domain.device.application.service.DeviceService
+import digdaserver.domain.device.presentation.dto.req.RegisterDeviceRequest
+import digdaserver.domain.device.presentation.dto.res.RegisterDeviceResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Device", description = "디바이스(FCM) API")
+class DeviceController(
+    private val deviceService: DeviceService
+) {
+
+    @Operation(summary = "디바이스 토큰 등록", description = "앱 시작 시 또는 토큰 갱신 시 FCM 토큰을 등록합니다. 동일 토큰이면 upsert.")
+    @PostMapping("/devices")
+    fun registerDevice(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: RegisterDeviceRequest
+    ): ResponseEntity<RegisterDeviceResponse> {
+        val response = deviceService.registerDevice(UUID.fromString(userId), request.token, request.platform)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "디바이스 토큰 해제", description = "로그아웃 시 또는 토큰 만료 시 디바이스를 해제합니다.")
+    @DeleteMapping("/devices/{deviceId}")
+    fun unregisterDevice(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable deviceId: Long
+    ): ResponseEntity<Void> {
+        deviceService.unregisterDevice(UUID.fromString(userId), deviceId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/device/presentation/dto/req/RegisterDeviceRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/device/presentation/dto/req/RegisterDeviceRequest.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.device.presentation.dto.req
+
+data class RegisterDeviceRequest(
+    val token: String,
+    val platform: String
+)

--- a/src/main/kotlin/digdaserver/domain/device/presentation/dto/res/RegisterDeviceResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/device/presentation/dto/res/RegisterDeviceResponse.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.device.presentation.dto.res
+
+data class RegisterDeviceResponse(
+    val deviceId: Long
+)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30

## 📝작업 내용

> Device 도메인 API 2개를 구현했습니다.

### Device API (2개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | POST | `/devices` | 디바이스 토큰 등록 (동일 토큰 upsert) |
| 2 | DELETE | `/devices/:deviceId` | 디바이스 토큰 해제 |

### 주요 구현 사항
- Service 인터페이스 / Impl 분리, 클래스 레벨 `@Transactional(readOnly = true)`
- 등록: 동일 토큰 재요청 시 기존 `deviceId` 반환 (upsert), 타 사용자 토큰 충돌 시 `FORBIDDEN`
- 해제: 본인 디바이스만 가능, 미존재 시 `DEVICE_NOT_FOUND` 404
- `platform` 문자열을 `Platform` enum(`IOS`/`ANDROID`)으로 파싱, 잘못된 값은 `INVALID_PARAMETER`
- Swagger `@Tag`, `@Operation` 어노테이션 적용