### PR TITLE
[Feature] FCM 푸시 알림 연동

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     implementation("software.amazon.awssdk:s3:2.20.56")
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
+    // Firebase Cloud Messaging
+    implementation("com.google.firebase:firebase-admin:9.3.0")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/digdaserver/domain/device/domain/repository/DeviceRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/device/domain/repository/DeviceRepository.kt
@@ -13,5 +13,9 @@ interface DeviceRepository : JpaRepository<Device, Long> {
 
     fun findAllByUserId(userId: UUID): List<Device>
 
+    fun findAllByUserIdIn(userIds: Collection<UUID>): List<Device>
+
     fun deleteAllByUserId(userId: UUID)
+
+    fun deleteAllByTokenIn(tokens: Collection<String>)
 }

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -1,5 +1,6 @@
 package digdaserver.domain.notification.application.service.impl
 
+import digdaserver.domain.device.domain.repository.DeviceRepository
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
 import digdaserver.domain.notification.application.service.NotificationService
@@ -9,9 +10,12 @@ import digdaserver.domain.notification.domain.repository.NotificationRepository
 import digdaserver.domain.notification.presentation.dto.res.NotificationListResponse
 import digdaserver.domain.notification.presentation.dto.res.NotificationResponse
 import digdaserver.domain.user.domain.entity.User
+import digdaserver.domain.user.domain.entity.UserNotificationSetting
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import digdaserver.global.infra.fcm.presentation.application.FcmService
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -23,8 +27,12 @@ class NotificationServiceImpl(
     private val notificationRepository: NotificationRepository,
     private val membershipRepository: MembershipRepository,
     private val groupRoomRepository: GroupRoomRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val deviceRepository: DeviceRepository,
+    private val fcmService: FcmService
 ) : NotificationService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getNotifications(userId: UUID, limit: Int, offset: Int): NotificationListResponse {
         val safeLimit = limit.coerceIn(1, 100)
@@ -302,5 +310,60 @@ class NotificationServiceImpl(
             )
         }
         notificationRepository.saveAll(notifications)
+
+        sendPushNotifications(recipients, type, title, message, groupRoomId, relatedId, relatedType)
+    }
+
+    private fun sendPushNotifications(
+        recipients: List<User>,
+        type: NotificationType,
+        title: String,
+        message: String,
+        groupRoomId: Long?,
+        relatedId: Long?,
+        relatedType: String?
+    ) {
+        try {
+            val eligibleUserIds = recipients
+                .filter { shouldSendPush(it.notificationSetting, type) }
+                .map { it.id }
+
+            if (eligibleUserIds.isEmpty()) return
+
+            val devices = deviceRepository.findAllByUserIdIn(eligibleUserIds)
+            if (devices.isEmpty()) return
+
+            val tokens = devices.map { it.token }
+            val data = buildMap {
+                put("type", type.name)
+                groupRoomId?.let { put("groupRoomId", it.toString()) }
+                relatedId?.let { put("relatedId", it.toString()) }
+                relatedType?.let { put("relatedType", it) }
+            }
+
+            val result = fcmService.sendToTokens(tokens, title, message, data)
+
+            if (result.invalidTokens.isNotEmpty()) {
+                deviceRepository.deleteAllByTokenIn(result.invalidTokens)
+            }
+        } catch (e: Exception) {
+            log.error("FCM push send failed for type={}: {}", type, e.message, e)
+        }
+    }
+
+    private fun shouldSendPush(setting: UserNotificationSetting?, type: NotificationType): Boolean {
+        if (setting == null || !setting.pushEnabled) return false
+        return when (type) {
+            NotificationType.SCHEDULE_CREATED,
+            NotificationType.SCHEDULE_UPDATED -> setting.scheduleNotification
+            NotificationType.DIARY_WRITTEN -> setting.diaryNotification
+            NotificationType.COMMENT_ON_SCHEDULE,
+            NotificationType.COMMENT_ON_DIARY -> setting.commentNotification
+            NotificationType.MEMBER_JOINED,
+            NotificationType.MEMBER_LEFT,
+            NotificationType.MEMBER_REMOVED,
+            NotificationType.OWNERSHIP_TRANSFERRED,
+            NotificationType.GROUP_DELETE_SCHEDULED -> true
+        }
     }
 }

--- a/src/main/kotlin/digdaserver/global/config/FirebaseConfig.kt
+++ b/src/main/kotlin/digdaserver/global/config/FirebaseConfig.kt
@@ -1,0 +1,37 @@
+package digdaserver.global.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ResourceLoader
+import java.io.InputStream
+
+@Configuration
+class FirebaseConfig(
+    private val resourceLoader: ResourceLoader
+) {
+
+    @Value("\${fcm.credentials-path}")
+    private lateinit var credentialsPath: String
+
+    @PostConstruct
+    fun initialize() {
+        if (FirebaseApp.getApps().isNotEmpty()) return
+
+        val stream: InputStream = resourceLoader.getResource(credentialsPath).inputStream
+
+        val options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(stream))
+            .build()
+
+        FirebaseApp.initializeApp(options)
+    }
+
+    @Bean
+    fun firebaseMessaging(): FirebaseMessaging = FirebaseMessaging.getInstance()
+}

--- a/src/main/kotlin/digdaserver/global/infra/fcm/dto/FcmSendResult.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/dto/FcmSendResult.kt
@@ -1,0 +1,11 @@
+package digdaserver.global.infra.fcm.dto
+
+data class FcmSendResult(
+    val successCount: Int,
+    val failureCount: Int,
+    val invalidTokens: List<String>
+) {
+    companion object {
+        fun empty(): FcmSendResult = FcmSendResult(0, 0, emptyList())
+    }
+}

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/FcmService.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/FcmService.kt
@@ -1,0 +1,13 @@
+package digdaserver.global.infra.fcm.presentation.application
+
+import digdaserver.global.infra.fcm.dto.FcmSendResult
+
+interface FcmService {
+
+    fun sendToTokens(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String> = emptyMap()
+    ): FcmSendResult
+}

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
@@ -1,0 +1,74 @@
+package digdaserver.global.infra.fcm.presentation.application.impl
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.MessagingErrorCode
+import com.google.firebase.messaging.MulticastMessage
+import com.google.firebase.messaging.Notification
+import digdaserver.global.infra.fcm.dto.FcmSendResult
+import digdaserver.global.infra.fcm.presentation.application.FcmService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class FcmServiceImpl(
+    private val firebaseMessaging: FirebaseMessaging
+) : FcmService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun sendToTokens(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String>
+    ): FcmSendResult {
+        if (tokens.isEmpty()) return FcmSendResult.empty()
+
+        val distinctTokens = tokens.distinct()
+        val invalidTokens = mutableListOf<String>()
+        var successCount = 0
+        var failureCount = 0
+
+        distinctTokens.chunked(500).forEach { chunk ->
+            val message = MulticastMessage.builder()
+                .setNotification(
+                    Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build()
+                )
+                .putAllData(data)
+                .addAllTokens(chunk)
+                .build()
+
+            try {
+                val response = firebaseMessaging.sendEachForMulticast(message)
+                successCount += response.successCount
+                failureCount += response.failureCount
+
+                response.responses.forEachIndexed { idx, resp ->
+                    if (!resp.isSuccessful) {
+                        val errorCode = resp.exception?.messagingErrorCode
+                        if (errorCode == MessagingErrorCode.UNREGISTERED ||
+                            errorCode == MessagingErrorCode.INVALID_ARGUMENT
+                        ) {
+                            invalidTokens.add(chunk[idx])
+                        } else {
+                            log.warn("FCM send failed for token ({}): {}", errorCode, resp.exception?.message)
+                        }
+                    }
+                }
+            } catch (e: FirebaseMessagingException) {
+                failureCount += chunk.size
+                log.error("FCM multicast send failed: {}", e.message, e)
+            }
+        }
+
+        return FcmSendResult(
+            successCount = successCount,
+            failureCount = failureCount,
+            invalidTokens = invalidTokens
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33

## 📝작업 내용

> 기존 NotificationService가 DB에 알림을 저장하던 흐름 위에 Firebase Cloud Messaging(FCM) 푸시 발송을 연동했습니다. 알림이 쌓이는 모든 이벤트가 사용자 기기로 실시간 푸시됩니다.

### FCM 푸시가 나가는 알림 (7종)
| # | 이벤트 | Type | 수신자 필터 |
|---|--------|------|-------------|
| 1 | 그룹방 삭제 예약 | `GROUP_DELETE_SCHEDULED` | `pushEnabled` |
| 2 | 그룹방 참여 | `MEMBER_JOINED` | `pushEnabled` |
| 3 | 일기 작성 | `DIARY_WRITTEN` | `pushEnabled` + `diaryNotification` |
| 4 | 일정 생성 (참가자 있음) | `SCHEDULE_CREATED` | `pushEnabled` + `scheduleNotification` |
| 5 | 그룹 탈퇴 | `MEMBER_LEFT` | `pushEnabled` |
| 6 | 방장 권한 이양 | `OWNERSHIP_TRANSFERRED` | `pushEnabled` |
| 7 | 일정 수정 참가자 추가 | `SCHEDULE_UPDATED` | `pushEnabled` + `scheduleNotification` |

> 기존 `NotificationServiceImpl.saveNotifications` 호출부는 그대로이며, 저장 직후 푸시가 자동으로 나가도록 연결되어 있습니다. 수신자별 `UserNotificationSetting`에 따라 DB 알림은 저장되지만 푸시만 스킵되는 식으로 동작합니다.

### 주요 구현 사항

- **의존성**: `com.google.firebase:firebase-admin:9.3.0`
- **FirebaseConfig**: `fcm.credentials-path` 환경변수로 서비스 계정 키 로드, `FirebaseApp` 초기화 후 `FirebaseMessaging` 빈 등록
- **FcmService / FcmServiceImpl**:
  - 토큰 500개 단위 chunk로 `sendEachForMulticast` 호출 (FCM 한도)
  - 응답별로 `UNREGISTERED` / `INVALID_ARGUMENT` 토큰을 수집해 정리 대상 반환
  - `FirebaseMessagingException`은 로그만 남기고 실패 카운트에 합산 (다른 chunk 발송에 영향 없음)
- **NotificationServiceImpl 통합**:
  - `saveNotifications` 이후 `sendPushNotifications` 호출
  - `UserNotificationSetting.pushEnabled` + 타입별 토글(`scheduleNotification` / `diaryNotification` / `commentNotification`) 기준으로 수신자 필터링
  - `DeviceRepository.findAllByUserIdIn`으로 토큰 일괄 조회 후 FCM 발송
  - 결과의 `invalidTokens`는 `DeviceRepository.deleteAllByTokenIn`으로 DB에서 정리
  - FCM 발송은 `try/catch`로 감싸 네트워크/권한 실패가 알림 저장 트랜잭션을 롤백시키지 않음
- **DeviceRepository**: `findAllByUserIdIn`, `deleteAllByTokenIn` 추가
- **푸시 payload**: `data`에 `type`, `groupRoomId`, `relatedId`, `relatedType`을 담아 클라이언트 라우팅에 활용

### 로컬 설정 (env/yml)

| 키 | 예시값 | 위치 |
|----|--------|------|
| `FCM_CREDENTIALS_PATH` | `file:env/firebase-service-account.json` | `env/dev.env`, `env/prod.env` |
| `fcm.credentials-path` | `${FCM_CREDENTIALS_PATH}` | `application-dev.yml`, `application-prod.yml` |

> 서비스 계정 JSON 키 파일은 로컬/서버에 개별 배치 (gitignore 대상)
