### PR TITLE
[Refactor] FCM/알림 푸시 코드 구조 정리

### DIFF
--- a/src/main/kotlin/digdaserver/domain/notification/application/dto/NotificationPayload.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/dto/NotificationPayload.kt
@@ -1,0 +1,13 @@
+package digdaserver.domain.notification.application.dto
+
+import digdaserver.domain.notification.domain.entity.NotificationType
+
+data class NotificationPayload(
+    val type: NotificationType,
+    val title: String,
+    val message: String,
+    val groupRoomId: Long? = null,
+    val groupRoomName: String? = null,
+    val relatedId: Long? = null,
+    val relatedType: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -1,8 +1,9 @@
 package digdaserver.domain.notification.application.service.impl
 
-import digdaserver.domain.device.domain.repository.DeviceRepository
+import digdaserver.domain.group_room.domain.entity.GroupRoom
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.notification.application.dto.NotificationPayload
 import digdaserver.domain.notification.application.service.NotificationService
 import digdaserver.domain.notification.domain.entity.Notification
 import digdaserver.domain.notification.domain.entity.NotificationType
@@ -10,12 +11,10 @@ import digdaserver.domain.notification.domain.repository.NotificationRepository
 import digdaserver.domain.notification.presentation.dto.res.NotificationListResponse
 import digdaserver.domain.notification.presentation.dto.res.NotificationResponse
 import digdaserver.domain.user.domain.entity.User
-import digdaserver.domain.user.domain.entity.UserNotificationSetting
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
-import digdaserver.global.infra.fcm.presentation.application.FcmService
-import org.slf4j.LoggerFactory
+import digdaserver.global.infra.fcm.presentation.application.NotificationPushDispatcher
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,11 +27,8 @@ class NotificationServiceImpl(
     private val membershipRepository: MembershipRepository,
     private val groupRoomRepository: GroupRoomRepository,
     private val userRepository: UserRepository,
-    private val deviceRepository: DeviceRepository,
-    private val fcmService: FcmService
+    private val pushDispatcher: NotificationPushDispatcher
 ) : NotificationService {
-
-    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getNotifications(userId: UUID, limit: Int, offset: Int): NotificationListResponse {
         val safeLimit = limit.coerceIn(1, 100)
@@ -54,16 +50,8 @@ class NotificationServiceImpl(
 
     @Transactional
     override fun markAsRead(userId: UUID, notificationId: Long, isRead: Boolean) {
-        val notification = notificationRepository.findById(notificationId)
-            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_NOT_FOUND) }
-
-        if (notification.user.id != userId) {
-            throw DigdaException(ErrorCode.FORBIDDEN)
-        }
-
-        if (isRead) {
-            notification.markAsRead()
-        }
+        val notification = requireOwnedNotification(userId, notificationId)
+        if (isRead) notification.markAsRead()
     }
 
     @Transactional
@@ -73,91 +61,64 @@ class NotificationServiceImpl(
 
     @Transactional
     override fun deleteNotification(userId: UUID, notificationId: Long) {
-        val notification = notificationRepository.findById(notificationId)
-            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_NOT_FOUND) }
-
-        if (notification.user.id != userId) {
-            throw DigdaException(ErrorCode.FORBIDDEN)
-        }
-
+        val notification = requireOwnedNotification(userId, notificationId)
         notificationRepository.delete(notification)
     }
 
     @Transactional
     override fun notifyGroupRoomDeleteScheduled(groupRoomId: Long, actorUserId: UUID) {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        val groupRoom = findGroupRoom(groupRoomId)
+        val recipients = memberRecipientsExcept(groupRoomId, actorUserId)
 
-        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != actorUserId }
-
-        val title = "그룹방 삭제 예약"
-        val message = "'${groupRoom.name}' 그룹방이 삭제 예약되었습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.GROUP_DELETE_SCHEDULED,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = groupRoomId,
-            relatedType = "GROUP_ROOM"
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.GROUP_DELETE_SCHEDULED,
+                title = "그룹방 삭제 예약",
+                message = "'${groupRoom.name}' 그룹방이 삭제 예약되었습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = groupRoomId,
+                relatedType = "GROUP_ROOM"
+            )
         )
     }
 
     @Transactional
     override fun notifyMemberJoined(groupRoomId: Long, joinedUserId: UUID) {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        val groupRoom = findGroupRoom(groupRoomId)
+        val joinedUser = findUser(joinedUserId)
+        val recipients = memberRecipientsExcept(groupRoomId, joinedUserId)
 
-        val joinedUser = userRepository.findById(joinedUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
-        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != joinedUserId }
-
-        val title = "새 구성원 참여"
-        val message = "${joinedUser.name}님이 '${groupRoom.name}' 그룹방에 참여했습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.MEMBER_JOINED,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = null,
-            relatedType = null
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.MEMBER_JOINED,
+                title = "새 구성원 참여",
+                message = "${joinedUser.name}님이 '${groupRoom.name}' 그룹방에 참여했습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name
+            )
         )
     }
 
     @Transactional
     override fun notifyDiaryWritten(groupRoomId: Long, diaryId: Long, authorUserId: UUID, diaryTitle: String) {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        val groupRoom = findGroupRoom(groupRoomId)
+        val author = findUser(authorUserId)
+        val recipients = memberRecipientsExcept(groupRoomId, authorUserId)
 
-        val author = userRepository.findById(authorUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
-        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != authorUserId }
-
-        val title = "새 일기"
-        val message = "${author.name}님이 '${diaryTitle}' 일기를 작성했습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.DIARY_WRITTEN,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = diaryId,
-            relatedType = "DIARY"
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.DIARY_WRITTEN,
+                title = "새 일기",
+                message = "${author.name}님이 '${diaryTitle}' 일기를 작성했습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = diaryId,
+                relatedType = "DIARY"
+            )
         )
     }
 
@@ -169,85 +130,62 @@ class NotificationServiceImpl(
         scheduleTitle: String,
         participantUserIds: List<UUID>
     ) {
-        if (participantUserIds.isEmpty()) return
-
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
-
-        val creator = userRepository.findById(creatorUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
         val recipientIds = participantUserIds.filter { it != creatorUserId }
         if (recipientIds.isEmpty()) return
 
+        val groupRoom = findGroupRoom(groupRoomId)
+        val creator = findUser(creatorUserId)
         val recipients = userRepository.findAllById(recipientIds).toList()
 
-        val title = "새 일정"
-        val message = "${creator.name}님이 '${scheduleTitle}' 일정에 회원님을 참가자로 추가했습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.SCHEDULE_CREATED,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = scheduleId,
-            relatedType = "SCHEDULE"
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.SCHEDULE_CREATED,
+                title = "새 일정",
+                message = "${creator.name}님이 '${scheduleTitle}' 일정에 회원님을 참가자로 추가했습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = scheduleId,
+                relatedType = "SCHEDULE"
+            )
         )
     }
 
     @Transactional
     override fun notifyMemberLeft(groupRoomId: Long, leaverUserId: UUID) {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        val groupRoom = findGroupRoom(groupRoomId)
+        val leaver = findUser(leaverUserId)
+        val recipients = memberRecipientsExcept(groupRoomId, leaverUserId)
 
-        val leaver = userRepository.findById(leaverUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
-        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != leaverUserId }
-
-        val title = "구성원 탈퇴"
-        val message = "${leaver.name}님이 '${groupRoom.name}' 그룹방에서 나갔습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.MEMBER_LEFT,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = null,
-            relatedType = null
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.MEMBER_LEFT,
+                title = "구성원 탈퇴",
+                message = "${leaver.name}님이 '${groupRoom.name}' 그룹방에서 나갔습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name
+            )
         )
     }
 
     @Transactional
     override fun notifyOwnershipTransferred(groupRoomId: Long, actorUserId: UUID, newOwnerUserId: UUID) {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        val groupRoom = findGroupRoom(groupRoomId)
+        val newOwner = findUser(newOwnerUserId)
+        val recipients = memberRecipientsExcept(groupRoomId, actorUserId)
 
-        val newOwner = userRepository.findById(newOwnerUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
-        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != actorUserId }
-
-        val title = "방장 권한 이양"
-        val message = "'${groupRoom.name}' 그룹방의 방장이 ${newOwner.name}님으로 변경되었습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.OWNERSHIP_TRANSFERRED,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = groupRoomId,
-            relatedType = "GROUP_ROOM"
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.OWNERSHIP_TRANSFERRED,
+                title = "방장 권한 이양",
+                message = "'${groupRoom.name}' 그룹방의 방장이 ${newOwner.name}님으로 변경되었습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = groupRoomId,
+                relatedType = "GROUP_ROOM"
+            )
         )
     }
 
@@ -262,108 +200,62 @@ class NotificationServiceImpl(
         val recipientIds = addedParticipantUserIds.filter { it != actorUserId }
         if (recipientIds.isEmpty()) return
 
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
-
-        val actor = userRepository.findById(actorUserId)
-            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
-
+        val groupRoom = findGroupRoom(groupRoomId)
+        val actor = findUser(actorUserId)
         val recipients = userRepository.findAllById(recipientIds).toList()
 
-        val title = "일정 참가자 추가"
-        val message = "${actor.name}님이 '${scheduleTitle}' 일정에 회원님을 참가자로 추가했습니다."
-
-        saveNotifications(
-            recipients = recipients,
-            type = NotificationType.SCHEDULE_UPDATED,
-            title = title,
-            message = message,
-            groupRoomId = groupRoomId,
-            groupRoomName = groupRoom.name,
-            relatedId = scheduleId,
-            relatedType = "SCHEDULE"
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.SCHEDULE_UPDATED,
+                title = "일정 참가자 추가",
+                message = "${actor.name}님이 '${scheduleTitle}' 일정에 회원님을 참가자로 추가했습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = scheduleId,
+                relatedType = "SCHEDULE"
+            )
         )
     }
 
-    private fun saveNotifications(
-        recipients: List<User>,
-        type: NotificationType,
-        title: String,
-        message: String,
-        groupRoomId: Long?,
-        groupRoomName: String?,
-        relatedId: Long?,
-        relatedType: String?
-    ) {
+    private fun notify(recipients: List<User>, payload: NotificationPayload) {
         if (recipients.isEmpty()) return
 
-        val notifications = recipients.map { user ->
-            Notification(
-                user = user,
-                type = type,
-                title = title,
-                message = message,
-                groupRoomId = groupRoomId,
-                groupRoomName = groupRoomName,
-                relatedId = relatedId,
-                relatedType = relatedType
-            )
-        }
+        val notifications = recipients.map { user -> payload.toEntity(user) }
         notificationRepository.saveAll(notifications)
 
-        sendPushNotifications(recipients, type, title, message, groupRoomId, relatedId, relatedType)
+        pushDispatcher.dispatch(recipients, payload)
     }
 
-    private fun sendPushNotifications(
-        recipients: List<User>,
-        type: NotificationType,
-        title: String,
-        message: String,
-        groupRoomId: Long?,
-        relatedId: Long?,
-        relatedType: String?
-    ) {
-        try {
-            val eligibleUserIds = recipients
-                .filter { shouldSendPush(it.notificationSetting, type) }
-                .map { it.id }
+    private fun NotificationPayload.toEntity(recipient: User): Notification =
+        Notification(
+            user = recipient,
+            type = type,
+            title = title,
+            message = message,
+            groupRoomId = groupRoomId,
+            groupRoomName = groupRoomName,
+            relatedId = relatedId,
+            relatedType = relatedType
+        )
 
-            if (eligibleUserIds.isEmpty()) return
-
-            val devices = deviceRepository.findAllByUserIdIn(eligibleUserIds)
-            if (devices.isEmpty()) return
-
-            val tokens = devices.map { it.token }
-            val data = buildMap {
-                put("type", type.name)
-                groupRoomId?.let { put("groupRoomId", it.toString()) }
-                relatedId?.let { put("relatedId", it.toString()) }
-                relatedType?.let { put("relatedType", it) }
-            }
-
-            val result = fcmService.sendToTokens(tokens, title, message, data)
-
-            if (result.invalidTokens.isNotEmpty()) {
-                deviceRepository.deleteAllByTokenIn(result.invalidTokens)
-            }
-        } catch (e: Exception) {
-            log.error("FCM push send failed for type={}: {}", type, e.message, e)
-        }
+    private fun requireOwnedNotification(userId: UUID, notificationId: Long): Notification {
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { DigdaException(ErrorCode.NOTIFICATION_NOT_FOUND) }
+        if (notification.user.id != userId) throw DigdaException(ErrorCode.FORBIDDEN)
+        return notification
     }
 
-    private fun shouldSendPush(setting: UserNotificationSetting?, type: NotificationType): Boolean {
-        if (setting == null || !setting.pushEnabled) return false
-        return when (type) {
-            NotificationType.SCHEDULE_CREATED,
-            NotificationType.SCHEDULE_UPDATED -> setting.scheduleNotification
-            NotificationType.DIARY_WRITTEN -> setting.diaryNotification
-            NotificationType.COMMENT_ON_SCHEDULE,
-            NotificationType.COMMENT_ON_DIARY -> setting.commentNotification
-            NotificationType.MEMBER_JOINED,
-            NotificationType.MEMBER_LEFT,
-            NotificationType.MEMBER_REMOVED,
-            NotificationType.OWNERSHIP_TRANSFERRED,
-            NotificationType.GROUP_DELETE_SCHEDULED -> true
-        }
-    }
+    private fun findGroupRoom(groupRoomId: Long): GroupRoom =
+        groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+    private fun findUser(userId: UUID): User =
+        userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+    private fun memberRecipientsExcept(groupRoomId: Long, excludedUserId: UUID): List<User> =
+        membershipRepository.findAllByGroupRoomId(groupRoomId)
+            .map { it.user }
+            .filter { it.id != excludedUserId }
 }

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/NotificationPushDispatcher.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/NotificationPushDispatcher.kt
@@ -1,0 +1,9 @@
+package digdaserver.global.infra.fcm.presentation.application
+
+import digdaserver.domain.notification.application.dto.NotificationPayload
+import digdaserver.domain.user.domain.entity.User
+
+interface NotificationPushDispatcher {
+
+    fun dispatch(recipients: List<User>, payload: NotificationPayload)
+}

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessagingException
 import com.google.firebase.messaging.MessagingErrorCode
 import com.google.firebase.messaging.MulticastMessage
 import com.google.firebase.messaging.Notification
+import com.google.firebase.messaging.SendResponse
 import digdaserver.global.infra.fcm.dto.FcmSendResult
 import digdaserver.global.infra.fcm.presentation.application.FcmService
 import org.slf4j.LoggerFactory
@@ -25,40 +26,18 @@ class FcmServiceImpl(
     ): FcmSendResult {
         if (tokens.isEmpty()) return FcmSendResult.empty()
 
-        val distinctTokens = tokens.distinct()
-        val invalidTokens = mutableListOf<String>()
         var successCount = 0
         var failureCount = 0
+        val invalidTokens = mutableListOf<String>()
 
-        distinctTokens.chunked(500).forEach { chunk ->
-            val message = MulticastMessage.builder()
-                .setNotification(
-                    Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build()
-                )
-                .putAllData(data)
-                .addAllTokens(chunk)
-                .build()
-
+        tokens.distinct().chunked(MULTICAST_CHUNK_SIZE).forEach { chunk ->
             try {
-                val response = firebaseMessaging.sendEachForMulticast(message)
+                val response = firebaseMessaging.sendEachForMulticast(
+                    buildMulticast(chunk, title, body, data)
+                )
                 successCount += response.successCount
                 failureCount += response.failureCount
-
-                response.responses.forEachIndexed { idx, resp ->
-                    if (!resp.isSuccessful) {
-                        val errorCode = resp.exception?.messagingErrorCode
-                        if (errorCode == MessagingErrorCode.UNREGISTERED ||
-                            errorCode == MessagingErrorCode.INVALID_ARGUMENT
-                        ) {
-                            invalidTokens.add(chunk[idx])
-                        } else {
-                            log.warn("FCM send failed for token ({}): {}", errorCode, resp.exception?.message)
-                        }
-                    }
-                }
+                invalidTokens += extractInvalidTokens(chunk, response.responses)
             } catch (e: FirebaseMessagingException) {
                 failureCount += chunk.size
                 log.error("FCM multicast send failed: {}", e.message, e)
@@ -69,6 +48,47 @@ class FcmServiceImpl(
             successCount = successCount,
             failureCount = failureCount,
             invalidTokens = invalidTokens
+        )
+    }
+
+    private fun buildMulticast(
+        tokens: List<String>,
+        title: String,
+        body: String,
+        data: Map<String, String>
+    ): MulticastMessage = MulticastMessage.builder()
+        .setNotification(
+            Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build()
+        )
+        .putAllData(data)
+        .addAllTokens(tokens)
+        .build()
+
+    private fun extractInvalidTokens(
+        chunk: List<String>,
+        responses: List<SendResponse>
+    ): List<String> {
+        val invalid = mutableListOf<String>()
+        responses.forEachIndexed { idx, resp ->
+            if (resp.isSuccessful) return@forEachIndexed
+            val errorCode = resp.exception?.messagingErrorCode
+            if (errorCode in INVALID_TOKEN_ERRORS) {
+                invalid += chunk[idx]
+            } else {
+                log.warn("FCM send failed for token ({}): {}", errorCode, resp.exception?.message)
+            }
+        }
+        return invalid
+    }
+
+    companion object {
+        private const val MULTICAST_CHUNK_SIZE = 500
+        private val INVALID_TOKEN_ERRORS = setOf(
+            MessagingErrorCode.UNREGISTERED,
+            MessagingErrorCode.INVALID_ARGUMENT
         )
     }
 }

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/NotificationPushDispatcherImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/NotificationPushDispatcherImpl.kt
@@ -1,0 +1,71 @@
+package digdaserver.global.infra.fcm.presentation.application.impl
+
+import digdaserver.domain.device.domain.repository.DeviceRepository
+import digdaserver.domain.notification.application.dto.NotificationPayload
+import digdaserver.domain.notification.domain.entity.NotificationType
+import digdaserver.domain.user.domain.entity.User
+import digdaserver.domain.user.domain.entity.UserNotificationSetting
+import digdaserver.global.infra.fcm.presentation.application.FcmService
+import digdaserver.global.infra.fcm.presentation.application.NotificationPushDispatcher
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationPushDispatcherImpl(
+    private val fcmService: FcmService,
+    private val deviceRepository: DeviceRepository
+) : NotificationPushDispatcher {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun dispatch(recipients: List<User>, payload: NotificationPayload) {
+        if (recipients.isEmpty()) return
+
+        try {
+            val eligibleUserIds = recipients
+                .filter { isPushEligible(it.notificationSetting, payload.type) }
+                .map { it.id }
+
+            if (eligibleUserIds.isEmpty()) return
+
+            val tokens = deviceRepository.findAllByUserIdIn(eligibleUserIds).map { it.token }
+            if (tokens.isEmpty()) return
+
+            val result = fcmService.sendToTokens(
+                tokens = tokens,
+                title = payload.title,
+                body = payload.message,
+                data = buildDataPayload(payload)
+            )
+
+            if (result.invalidTokens.isNotEmpty()) {
+                deviceRepository.deleteAllByTokenIn(result.invalidTokens)
+            }
+        } catch (e: Exception) {
+            log.error("Push dispatch failed for type={}: {}", payload.type, e.message, e)
+        }
+    }
+
+    private fun isPushEligible(setting: UserNotificationSetting?, type: NotificationType): Boolean {
+        if (setting == null || !setting.pushEnabled) return false
+        return when (type) {
+            NotificationType.SCHEDULE_CREATED,
+            NotificationType.SCHEDULE_UPDATED -> setting.scheduleNotification
+            NotificationType.DIARY_WRITTEN -> setting.diaryNotification
+            NotificationType.COMMENT_ON_SCHEDULE,
+            NotificationType.COMMENT_ON_DIARY -> setting.commentNotification
+            NotificationType.MEMBER_JOINED,
+            NotificationType.MEMBER_LEFT,
+            NotificationType.MEMBER_REMOVED,
+            NotificationType.OWNERSHIP_TRANSFERRED,
+            NotificationType.GROUP_DELETE_SCHEDULED -> true
+        }
+    }
+
+    private fun buildDataPayload(payload: NotificationPayload): Map<String, String> = buildMap {
+        put("type", payload.type.name)
+        payload.groupRoomId?.let { put("groupRoomId", it.toString()) }
+        payload.relatedId?.let { put("relatedId", it.toString()) }
+        payload.relatedType?.let { put("relatedType", it) }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35

## 📝작업 내용

> FCM 연동 이후 `NotificationServiceImpl`에 FCM 발송 로직이 뒤섞이고 7개 notify 메서드에 중복 패턴이 누적되어, 책임 분리와 헬퍼 추출로 코드 구조를 정리했습니다. **기능 변경 없음**.

### Before / After (NotificationServiceImpl)

- 370줄 → 약 240줄
- 8-파라미터 `saveNotifications` → `NotificationPayload` 값 객체 + `notify(recipients, payload)`
- FCM 발송/토큰 조회/무효 토큰 정리 로직 → `NotificationPushDispatcher`로 이동
- 각 notify 메서드 반복 로직 → `findGroupRoom`, `findUser`, `memberRecipientsExcept`, `requireOwnedNotification` 헬퍼로 추출

### 주요 구현 사항

- **`NotificationPayload`** (신규 값 객체)
  - 타입/제목/메시지/그룹방 정보/관련 리소스 정보를 한 데이터 클래스로 묶음
  - `NotificationServiceImpl.notify`에서 엔티티 변환, `NotificationPushDispatcher.dispatch`에서 FCM 페이로드 변환
- **`NotificationPushDispatcher`** (신규 인터페이스 + Impl, `global/infra/fcm`)
  - 수신자 필터링(`UserNotificationSetting`), 토큰 일괄 조회, FCM 발송, 무효 토큰 정리 책임 단일화
  - FCM 실패는 내부에서 `try/catch`로 흡수 (기존과 동일하게 알림 저장 트랜잭션에 영향 없음)
- **`NotificationServiceImpl`**
  - `DeviceRepository`, `FcmService`, `Logger` 의존성 제거 → `NotificationPushDispatcher` 하나만 주입
  - 헬퍼 추출로 각 notify 메서드의 boilerplate 제거
- **`FcmServiceImpl`**
  - `buildMulticast`, `extractInvalidTokens` 분리 → `sendToTokens` 본문 가독성 개선
  - `MULTICAST_CHUNK_SIZE`(500), `INVALID_TOKEN_ERRORS`(UNREGISTERED/INVALID_ARGUMENT) 상수화

### 검증

- `./gradlew compileKotlin --rerun-tasks` BUILD SUCCESSFUL
- 기존 알림 트리거 7종 + FCM 발송 흐름 모두 동일