### PR TITLE
[Feature] Admin API 구현 (인증/대시보드/도메인 관리/DB 조회/로그)

### DIFF
--- a/src/main/kotlin/digdaserver/admin/auth/application/service/AdminAuthService.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/application/service/AdminAuthService.kt
@@ -1,0 +1,9 @@
+package digdaserver.admin.auth.application.service
+
+import digdaserver.admin.auth.presentation.dto.req.AdminLoginRequest
+import digdaserver.admin.auth.presentation.dto.res.AdminLoginResponse
+
+interface AdminAuthService {
+
+    fun login(request: AdminLoginRequest): AdminLoginResponse
+}

--- a/src/main/kotlin/digdaserver/admin/auth/application/service/impl/AdminAuthServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/application/service/impl/AdminAuthServiceImpl.kt
@@ -1,0 +1,48 @@
+package digdaserver.admin.auth.application.service.impl
+
+import digdaserver.admin.auth.application.service.AdminAuthService
+import digdaserver.admin.auth.domain.repository.AdminCredentialRepository
+import digdaserver.admin.auth.presentation.dto.req.AdminLoginRequest
+import digdaserver.admin.auth.presentation.dto.res.AdminLoginResponse
+import digdaserver.domain.oauth2.application.service.CreateAccessTokenAndRefreshTokenService
+import digdaserver.domain.user.domain.entity.Role
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminAuthServiceImpl(
+    private val adminCredentialRepository: AdminCredentialRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val createAccessTokenAndRefreshTokenService: CreateAccessTokenAndRefreshTokenService
+) : AdminAuthService {
+
+    @Transactional
+    override fun login(request: AdminLoginRequest): AdminLoginResponse {
+        val credential = adminCredentialRepository.findByEmail(request.email)
+            .orElseThrow { DigdaException(ErrorCode.ADMIN_NOT_FOUND) }
+
+        if (!passwordEncoder.matches(request.password, credential.password)) {
+            throw DigdaException(ErrorCode.ADMIN_PASSWORD_MISMATCH)
+        }
+
+        val user = credential.user
+        if (user.role != Role.ADMIN) {
+            throw DigdaException(ErrorCode.NOT_ADMIN_USER)
+        }
+
+        val token = createAccessTokenAndRefreshTokenService
+            .createAccessTokenAndRefreshToken(user.id.toString(), Role.ADMIN, user.email)
+
+        return AdminLoginResponse.of(
+            adminId = user.id.toString(),
+            email = credential.email,
+            name = user.name,
+            accessToken = token.accessToken,
+            refreshToken = token.refreshToken
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/auth/application/service/impl/AdminAuthServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/application/service/impl/AdminAuthServiceImpl.kt
@@ -4,6 +4,8 @@ import digdaserver.admin.auth.application.service.AdminAuthService
 import digdaserver.admin.auth.domain.repository.AdminCredentialRepository
 import digdaserver.admin.auth.presentation.dto.req.AdminLoginRequest
 import digdaserver.admin.auth.presentation.dto.res.AdminLoginResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
 import digdaserver.domain.oauth2.application.service.CreateAccessTokenAndRefreshTokenService
 import digdaserver.domain.user.domain.entity.Role
 import digdaserver.global.infra.exception.error.DigdaException
@@ -17,7 +19,8 @@ import org.springframework.transaction.annotation.Transactional
 class AdminAuthServiceImpl(
     private val adminCredentialRepository: AdminCredentialRepository,
     private val passwordEncoder: PasswordEncoder,
-    private val createAccessTokenAndRefreshTokenService: CreateAccessTokenAndRefreshTokenService
+    private val createAccessTokenAndRefreshTokenService: CreateAccessTokenAndRefreshTokenService,
+    private val adminActionLogService: AdminActionLogService
 ) : AdminAuthService {
 
     @Transactional
@@ -36,6 +39,14 @@ class AdminAuthServiceImpl(
 
         val token = createAccessTokenAndRefreshTokenService
             .createAccessTokenAndRefreshToken(user.id.toString(), Role.ADMIN, user.email)
+
+        adminActionLogService.record(
+            actorId = user.id,
+            action = AdminAction.LOGIN,
+            targetType = "ADMIN",
+            targetId = user.id.toString(),
+            detail = "관리자 로그인: ${credential.email}"
+        )
 
         return AdminLoginResponse.of(
             adminId = user.id.toString(),

--- a/src/main/kotlin/digdaserver/admin/auth/domain/entity/AdminCredential.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/domain/entity/AdminCredential.kt
@@ -1,0 +1,46 @@
+package digdaserver.admin.auth.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "admin_credential",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_admin_credential_email", columnNames = ["email"]),
+        UniqueConstraint(name = "uk_admin_credential_user", columnNames = ["user_id"])
+    ]
+)
+class AdminCredential(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_credential_id")
+    val id: Long = 0L,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false, length = 100)
+    var email: String,
+
+    @Column(nullable = false, length = 100)
+    var password: String
+
+) : BaseTimeEntity() {
+
+    fun updatePassword(encodedPassword: String) {
+        this.password = encodedPassword
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/auth/domain/repository/AdminCredentialRepository.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/domain/repository/AdminCredentialRepository.kt
@@ -1,0 +1,12 @@
+package digdaserver.admin.auth.domain.repository
+
+import digdaserver.admin.auth.domain.entity.AdminCredential
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface AdminCredentialRepository : JpaRepository<AdminCredential, Long> {
+
+    fun findByEmail(email: String): Optional<AdminCredential>
+}

--- a/src/main/kotlin/digdaserver/admin/auth/presentation/controller/AdminAuthController.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/presentation/controller/AdminAuthController.kt
@@ -1,0 +1,29 @@
+package digdaserver.admin.auth.presentation.controller
+
+import digdaserver.admin.auth.application.service.AdminAuthService
+import digdaserver.admin.auth.presentation.dto.req.AdminLoginRequest
+import digdaserver.admin.auth.presentation.dto.res.AdminLoginResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/auth")
+@Tag(name = "Admin - Auth", description = "관리자 인증 API")
+class AdminAuthController(
+    private val adminAuthService: AdminAuthService
+) {
+
+    @Operation(summary = "관리자 로그인", description = "이메일/비밀번호 기반 관리자 로그인. ADMIN 역할만 허용하며 JWT Access/Refresh 토큰을 발급합니다.")
+    @PostMapping("/login")
+    fun login(
+        @Valid @RequestBody request: AdminLoginRequest
+    ): ResponseEntity<AdminLoginResponse> {
+        return ResponseEntity.ok(adminAuthService.login(request))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/auth/presentation/dto/req/AdminLoginRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/presentation/dto/req/AdminLoginRequest.kt
@@ -1,0 +1,18 @@
+package digdaserver.admin.auth.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "관리자 로그인 요청")
+data class AdminLoginRequest(
+
+    @field:NotBlank
+    @field:Email
+    @Schema(description = "관리자 이메일", example = "admin@digda.com")
+    val email: String,
+
+    @field:NotBlank
+    @Schema(description = "관리자 비밀번호", example = "P@ssw0rd!")
+    val password: String
+)

--- a/src/main/kotlin/digdaserver/admin/auth/presentation/dto/res/AdminLoginResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/presentation/dto/res/AdminLoginResponse.kt
@@ -1,0 +1,38 @@
+package digdaserver.admin.auth.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "관리자 로그인 응답")
+data class AdminLoginResponse(
+
+    @Schema(description = "관리자 사용자 ID(UUID)")
+    val adminId: String,
+
+    @Schema(description = "관리자 이메일")
+    val email: String,
+
+    @Schema(description = "관리자 이름")
+    val name: String,
+
+    @Schema(description = "JWT Access Token")
+    val accessToken: String,
+
+    @Schema(description = "JWT Refresh Token")
+    val refreshToken: String
+) {
+    companion object {
+        fun of(
+            adminId: String,
+            email: String,
+            name: String,
+            accessToken: String,
+            refreshToken: String
+        ): AdminLoginResponse = AdminLoginResponse(
+            adminId = adminId,
+            email = email,
+            name = name,
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/common/dto/res/AdminPageResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/common/dto/res/AdminPageResponse.kt
@@ -1,0 +1,41 @@
+package digdaserver.admin.common.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+
+@Schema(description = "어드민 페이지네이션 응답")
+data class AdminPageResponse<T>(
+
+    @Schema(description = "현재 페이지(0-base)")
+    val page: Int,
+
+    @Schema(description = "페이지 크기")
+    val size: Int,
+
+    @Schema(description = "총 요소 수")
+    val totalElements: Long,
+
+    @Schema(description = "총 페이지 수")
+    val totalPages: Int,
+
+    @Schema(description = "데이터 목록")
+    val content: List<T>
+) {
+    companion object {
+        fun <T> of(page: Page<T>): AdminPageResponse<T> = AdminPageResponse(
+            page = page.number,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            content = page.content
+        )
+
+        fun <T, R> of(page: Page<T>, mapper: (T) -> R): AdminPageResponse<R> = AdminPageResponse(
+            page = page.number,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            content = page.content.map(mapper)
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/dashboard/application/service/AdminDashboardService.kt
+++ b/src/main/kotlin/digdaserver/admin/dashboard/application/service/AdminDashboardService.kt
@@ -1,0 +1,8 @@
+package digdaserver.admin.dashboard.application.service
+
+import digdaserver.admin.dashboard.presentation.dto.res.DashboardSummaryResponse
+
+interface AdminDashboardService {
+
+    fun getSummary(): DashboardSummaryResponse
+}

--- a/src/main/kotlin/digdaserver/admin/dashboard/application/service/impl/AdminDashboardServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/dashboard/application/service/impl/AdminDashboardServiceImpl.kt
@@ -1,0 +1,42 @@
+package digdaserver.admin.dashboard.application.service.impl
+
+import digdaserver.admin.dashboard.application.service.AdminDashboardService
+import digdaserver.admin.dashboard.presentation.dto.res.DashboardSummaryResponse
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.notification.domain.repository.NotificationRepository
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.domain.todo.domain.repository.TodoRepository
+import digdaserver.domain.user.domain.entity.Role
+import digdaserver.domain.user.domain.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminDashboardServiceImpl(
+    private val userRepository: UserRepository,
+    private val groupRoomRepository: GroupRoomRepository,
+    private val diaryRepository: DiaryRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val commentRepository: CommentRepository,
+    private val todoRepository: TodoRepository,
+    private val notificationRepository: NotificationRepository
+) : AdminDashboardService {
+
+    override fun getSummary(): DashboardSummaryResponse {
+        return DashboardSummaryResponse(
+            totalUsers = userRepository.count(),
+            adminUsers = userRepository.countByRole(Role.ADMIN),
+            totalGroupRooms = groupRoomRepository.count(),
+            activeGroupRooms = groupRoomRepository.countByDeletedAtIsNull(),
+            deleteScheduledGroupRooms = groupRoomRepository.countByDeleteScheduledAtIsNotNullAndDeletedAtIsNull(),
+            totalDiaries = diaryRepository.count(),
+            totalSchedules = scheduleRepository.count(),
+            totalComments = commentRepository.count(),
+            totalTodos = todoRepository.count(),
+            totalNotifications = notificationRepository.count()
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/dashboard/presentation/controller/AdminDashboardController.kt
+++ b/src/main/kotlin/digdaserver/admin/dashboard/presentation/controller/AdminDashboardController.kt
@@ -1,0 +1,24 @@
+package digdaserver.admin.dashboard.presentation.controller
+
+import digdaserver.admin.dashboard.application.service.AdminDashboardService
+import digdaserver.admin.dashboard.presentation.dto.res.DashboardSummaryResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/dashboard")
+@Tag(name = "Admin - Dashboard", description = "관리자 대시보드 API")
+class AdminDashboardController(
+    private val adminDashboardService: AdminDashboardService
+) {
+
+    @Operation(summary = "대시보드 요약 통계", description = "총 사용자/그룹방/일기/일정/댓글/할일 등 핵심 지표를 반환합니다.")
+    @GetMapping("/summary")
+    fun getSummary(): ResponseEntity<DashboardSummaryResponse> {
+        return ResponseEntity.ok(adminDashboardService.getSummary())
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/dashboard/presentation/dto/res/DashboardSummaryResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/dashboard/presentation/dto/res/DashboardSummaryResponse.kt
@@ -1,0 +1,37 @@
+package digdaserver.admin.dashboard.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 대시보드 주요 통계")
+data class DashboardSummaryResponse(
+
+    @Schema(description = "총 사용자 수")
+    val totalUsers: Long,
+
+    @Schema(description = "관리자 수")
+    val adminUsers: Long,
+
+    @Schema(description = "총 그룹방 수")
+    val totalGroupRooms: Long,
+
+    @Schema(description = "활성 그룹방 수 (삭제되지 않음)")
+    val activeGroupRooms: Long,
+
+    @Schema(description = "삭제 예약된 그룹방 수")
+    val deleteScheduledGroupRooms: Long,
+
+    @Schema(description = "총 일기 수")
+    val totalDiaries: Long,
+
+    @Schema(description = "총 일정 수")
+    val totalSchedules: Long,
+
+    @Schema(description = "총 댓글 수")
+    val totalComments: Long,
+
+    @Schema(description = "총 할 일 수")
+    val totalTodos: Long,
+
+    @Schema(description = "총 알림 수")
+    val totalNotifications: Long
+)

--- a/src/main/kotlin/digdaserver/admin/db/application/service/AdminDbService.kt
+++ b/src/main/kotlin/digdaserver/admin/db/application/service/AdminDbService.kt
@@ -1,0 +1,14 @@
+package digdaserver.admin.db.application.service
+
+import digdaserver.admin.db.presentation.dto.res.AdminColumnInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableRowsResponse
+
+interface AdminDbService {
+
+    fun listTables(): List<AdminTableInfoResponse>
+
+    fun listColumns(tableName: String): List<AdminColumnInfoResponse>
+
+    fun readRows(tableName: String, page: Int, size: Int, orderBy: String?, direction: String?): AdminTableRowsResponse
+}

--- a/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
@@ -1,0 +1,152 @@
+package digdaserver.admin.db.application.service.impl
+
+import digdaserver.admin.db.application.service.AdminDbService
+import digdaserver.admin.db.presentation.dto.res.AdminColumnInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableRowsResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminDbServiceImpl(
+    private val jdbcTemplate: JdbcTemplate
+) : AdminDbService {
+
+    companion object {
+        private val IDENTIFIER_REGEX = Regex("^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+        private val ALLOWED_DIRECTIONS = setOf("ASC", "DESC")
+        private const val MAX_PAGE_SIZE = 200
+    }
+
+    override fun listTables(): List<AdminTableInfoResponse> {
+        val sql = """
+            SELECT TABLE_NAME, TABLE_COMMENT, TABLE_ROWS
+            FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE'
+            ORDER BY TABLE_NAME
+        """.trimIndent()
+
+        return jdbcTemplate.query(sql) { rs, _ ->
+            AdminTableInfoResponse(
+                tableName = rs.getString("TABLE_NAME"),
+                tableComment = rs.getString("TABLE_COMMENT").takeUnless { it.isNullOrBlank() },
+                approxRowCount = rs.getObject("TABLE_ROWS")?.let { (it as Number).toLong() }
+            )
+        }
+    }
+
+    override fun listColumns(tableName: String): List<AdminColumnInfoResponse> {
+        val safeTable = validateIdentifier(tableName, ErrorCode.ADMIN_TABLE_NOT_ALLOWED)
+        ensureTableExists(safeTable)
+
+        val sql = """
+            SELECT COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY, COLUMN_COMMENT, ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            ORDER BY ORDINAL_POSITION
+        """.trimIndent()
+
+        return jdbcTemplate.query(sql, { rs, _ ->
+            AdminColumnInfoResponse(
+                columnName = rs.getString("COLUMN_NAME"),
+                dataType = rs.getString("DATA_TYPE"),
+                columnType = rs.getString("COLUMN_TYPE"),
+                nullable = rs.getString("IS_NULLABLE") == "YES",
+                defaultValue = rs.getString("COLUMN_DEFAULT"),
+                columnKey = rs.getString("COLUMN_KEY").takeUnless { it.isNullOrBlank() },
+                comment = rs.getString("COLUMN_COMMENT").takeUnless { it.isNullOrBlank() },
+                ordinalPosition = rs.getInt("ORDINAL_POSITION")
+            )
+        }, safeTable)
+    }
+
+    override fun readRows(
+        tableName: String,
+        page: Int,
+        size: Int,
+        orderBy: String?,
+        direction: String?
+    ): AdminTableRowsResponse {
+        val safeTable = validateIdentifier(tableName, ErrorCode.ADMIN_TABLE_NOT_ALLOWED)
+        ensureTableExists(safeTable)
+
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, MAX_PAGE_SIZE)
+        val offset = safePage.toLong() * safeSize.toLong()
+
+        val columns = jdbcTemplate.query(
+            """
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            ORDER BY ORDINAL_POSITION
+            """.trimIndent(),
+            { rs, _ -> rs.getString("COLUMN_NAME") },
+            safeTable
+        )
+        if (columns.isEmpty()) {
+            throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
+        }
+
+        val orderClause = buildOrderClause(columns, orderBy, direction)
+
+        val totalElements = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM `$safeTable`",
+            Long::class.java
+        ) ?: 0L
+
+        val rowsSql = "SELECT * FROM `$safeTable`$orderClause LIMIT ? OFFSET ?"
+        val rows = jdbcTemplate.query(rowsSql, { rs, _ ->
+            columns.associateWith { col -> rs.getObject(col) }
+        }, safeSize, offset)
+
+        val totalPages = if (totalElements == 0L) 0 else ((totalElements + safeSize - 1) / safeSize).toInt()
+
+        return AdminTableRowsResponse(
+            tableName = safeTable,
+            columns = columns,
+            page = safePage,
+            size = safeSize,
+            totalElements = totalElements,
+            totalPages = totalPages,
+            rows = rows
+        )
+    }
+
+    private fun validateIdentifier(value: String, errorCode: ErrorCode): String {
+        if (!IDENTIFIER_REGEX.matches(value)) {
+            throw DigdaException(errorCode)
+        }
+        return value
+    }
+
+    private fun ensureTableExists(tableName: String) {
+        val exists = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            """.trimIndent(),
+            Int::class.java,
+            tableName
+        )
+        if (exists == null || exists == 0) {
+            throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
+        }
+    }
+
+    private fun buildOrderClause(columns: List<String>, orderBy: String?, direction: String?): String {
+        if (orderBy.isNullOrBlank()) return ""
+        val column = validateIdentifier(orderBy, ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
+        if (column !in columns) {
+            throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
+        }
+        val dir = (direction ?: "ASC").uppercase()
+        if (dir !in ALLOWED_DIRECTIONS) {
+            throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
+        }
+        return " ORDER BY `$column` $dir"
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
@@ -4,16 +4,21 @@ import digdaserver.admin.db.application.service.AdminDbService
 import digdaserver.admin.db.presentation.dto.res.AdminColumnInfoResponse
 import digdaserver.admin.db.presentation.dto.res.AdminTableInfoResponse
 import digdaserver.admin.db.presentation.dto.res.AdminTableRowsResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 @Transactional(readOnly = true)
 class AdminDbServiceImpl(
-    private val jdbcTemplate: JdbcTemplate
+    private val jdbcTemplate: JdbcTemplate,
+    private val adminActionLogService: AdminActionLogService
 ) : AdminDbService {
 
     companion object {
@@ -105,6 +110,14 @@ class AdminDbServiceImpl(
 
         val totalPages = if (totalElements == 0L) 0 else ((totalElements + safeSize - 1) / safeSize).toInt()
 
+        adminActionLogService.record(
+            actorId = currentActorId(),
+            action = AdminAction.VIEW_DB_TABLE,
+            targetType = "TABLE",
+            targetId = safeTable,
+            detail = "page=$safePage, size=$safeSize, orderBy=${orderBy ?: "-"}, direction=${direction ?: "-"}"
+        )
+
         return AdminTableRowsResponse(
             tableName = safeTable,
             columns = columns,
@@ -135,6 +148,11 @@ class AdminDbServiceImpl(
         if (exists == null || exists == 0) {
             throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
         }
+    }
+
+    private fun currentActorId(): UUID? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal as? String ?: return null
+        return runCatching { UUID.fromString(principal) }.getOrNull()
     }
 
     private fun buildOrderClause(columns: List<String>, orderBy: String?, direction: String?): String {

--- a/src/main/kotlin/digdaserver/admin/db/presentation/controller/AdminDbController.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/controller/AdminDbController.kt
@@ -1,0 +1,48 @@
+package digdaserver.admin.db.presentation.controller
+
+import digdaserver.admin.db.application.service.AdminDbService
+import digdaserver.admin.db.presentation.dto.res.AdminColumnInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableInfoResponse
+import digdaserver.admin.db.presentation.dto.res.AdminTableRowsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/db")
+@Tag(name = "Admin - DB", description = "관리자 DB 메타/데이터 조회 API")
+class AdminDbController(
+    private val adminDbService: AdminDbService
+) {
+
+    @Operation(summary = "전체 테이블 목록 조회", description = "현재 스키마의 BASE TABLE 목록을 반환합니다.")
+    @GetMapping("/tables")
+    fun listTables(): ResponseEntity<List<AdminTableInfoResponse>> {
+        return ResponseEntity.ok(adminDbService.listTables())
+    }
+
+    @Operation(summary = "테이블 컬럼 정보 조회")
+    @GetMapping("/tables/{name}/columns")
+    fun listColumns(
+        @PathVariable name: String
+    ): ResponseEntity<List<AdminColumnInfoResponse>> {
+        return ResponseEntity.ok(adminDbService.listColumns(name))
+    }
+
+    @Operation(summary = "테이블 데이터 조회", description = "페이징 및 컬럼 기반 데이터 반환. size는 최대 200.")
+    @GetMapping("/tables/{name}/rows")
+    fun readRows(
+        @PathVariable name: String,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) orderBy: String?,
+        @RequestParam(required = false) direction: String?
+    ): ResponseEntity<AdminTableRowsResponse> {
+        return ResponseEntity.ok(adminDbService.readRows(name, page, size, orderBy, direction))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminColumnInfoResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminColumnInfoResponse.kt
@@ -1,0 +1,31 @@
+package digdaserver.admin.db.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "DB 컬럼 정보")
+data class AdminColumnInfoResponse(
+
+    @Schema(description = "컬럼명")
+    val columnName: String,
+
+    @Schema(description = "데이터 타입(예: varchar, bigint)")
+    val dataType: String,
+
+    @Schema(description = "컬럼 전체 타입(예: varchar(255))")
+    val columnType: String,
+
+    @Schema(description = "NULL 허용 여부")
+    val nullable: Boolean,
+
+    @Schema(description = "기본값")
+    val defaultValue: String?,
+
+    @Schema(description = "키(PRI/UNI/MUL)")
+    val columnKey: String?,
+
+    @Schema(description = "주석")
+    val comment: String?,
+
+    @Schema(description = "정렬 순서")
+    val ordinalPosition: Int
+)

--- a/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminTableInfoResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminTableInfoResponse.kt
@@ -1,0 +1,16 @@
+package digdaserver.admin.db.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "DB 테이블 정보")
+data class AdminTableInfoResponse(
+
+    @Schema(description = "테이블명")
+    val tableName: String,
+
+    @Schema(description = "주석")
+    val tableComment: String?,
+
+    @Schema(description = "예상 행 개수(통계, 근사값)")
+    val approxRowCount: Long?
+)

--- a/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminTableRowsResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminTableRowsResponse.kt
@@ -1,0 +1,28 @@
+package digdaserver.admin.db.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "DB 테이블 데이터 조회 응답 (컬럼 기반)")
+data class AdminTableRowsResponse(
+
+    @Schema(description = "테이블명")
+    val tableName: String,
+
+    @Schema(description = "컬럼 순서(응답 rows 의 키 순서)")
+    val columns: List<String>,
+
+    @Schema(description = "현재 페이지(0-base)")
+    val page: Int,
+
+    @Schema(description = "페이지 크기")
+    val size: Int,
+
+    @Schema(description = "총 행 수")
+    val totalElements: Long,
+
+    @Schema(description = "총 페이지 수")
+    val totalPages: Int,
+
+    @Schema(description = "행 데이터 목록. 각 행은 컬럼명 → 값")
+    val rows: List<Map<String, Any?>>
+)

--- a/src/main/kotlin/digdaserver/admin/diary/application/service/AdminDiaryService.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/application/service/AdminDiaryService.kt
@@ -1,0 +1,13 @@
+package digdaserver.admin.diary.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.diary.presentation.dto.res.AdminDiaryResponse
+
+interface AdminDiaryService {
+
+    fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminDiaryResponse>
+
+    fun getDetail(diaryId: Long): AdminDiaryResponse
+
+    fun delete(diaryId: Long)
+}

--- a/src/main/kotlin/digdaserver/admin/diary/application/service/impl/AdminDiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/application/service/impl/AdminDiaryServiceImpl.kt
@@ -3,9 +3,13 @@ package digdaserver.admin.diary.application.service.impl
 import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.diary.application.service.AdminDiaryService
 import digdaserver.admin.diary.presentation.dto.res.AdminDiaryResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
 import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.UUID
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -14,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class AdminDiaryServiceImpl(
-    private val diaryRepository: DiaryRepository
+    private val diaryRepository: DiaryRepository,
+    private val adminActionLogService: AdminActionLogService
 ) : AdminDiaryService {
 
     override fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminDiaryResponse> {
@@ -33,6 +38,21 @@ class AdminDiaryServiceImpl(
     override fun delete(diaryId: Long) {
         val diary = diaryRepository.findById(diaryId)
             .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+        val title = diary.title
+        val groupRoomId = diary.groupRoom.id
         diaryRepository.delete(diary)
+
+        adminActionLogService.record(
+            actorId = currentActorId(),
+            action = AdminAction.DELETE_DIARY,
+            targetType = "DIARY",
+            targetId = diaryId.toString(),
+            detail = "groupRoomId=$groupRoomId, title=$title"
+        )
+    }
+
+    private fun currentActorId(): UUID? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal as? String ?: return null
+        return runCatching { UUID.fromString(principal) }.getOrNull()
     }
 }

--- a/src/main/kotlin/digdaserver/admin/diary/application/service/impl/AdminDiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/application/service/impl/AdminDiaryServiceImpl.kt
@@ -1,0 +1,38 @@
+package digdaserver.admin.diary.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.diary.application.service.AdminDiaryService
+import digdaserver.admin.diary.presentation.dto.res.AdminDiaryResponse
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminDiaryServiceImpl(
+    private val diaryRepository: DiaryRepository
+) : AdminDiaryService {
+
+    override fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminDiaryResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = diaryRepository.searchForAdmin(keyword, pageable)
+        return AdminPageResponse.of(result, AdminDiaryResponse::from)
+    }
+
+    override fun getDetail(diaryId: Long): AdminDiaryResponse {
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+        return AdminDiaryResponse.from(diary)
+    }
+
+    @Transactional
+    override fun delete(diaryId: Long) {
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+        diaryRepository.delete(diary)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/diary/presentation/controller/AdminDiaryController.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/presentation/controller/AdminDiaryController.kt
@@ -1,0 +1,45 @@
+package digdaserver.admin.diary.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.diary.application.service.AdminDiaryService
+import digdaserver.admin.diary.presentation.dto.res.AdminDiaryResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/diaries")
+@Tag(name = "Admin - Diary", description = "관리자 일기 관리 API")
+class AdminDiaryController(
+    private val adminDiaryService: AdminDiaryService
+) {
+
+    @Operation(summary = "일기 목록 조회", description = "페이징, 키워드(제목/내용)")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminDiaryResponse>> {
+        return ResponseEntity.ok(adminDiaryService.search(keyword, page, size))
+    }
+
+    @Operation(summary = "일기 상세 조회")
+    @GetMapping("/{diaryId}")
+    fun getDetail(@PathVariable diaryId: Long): ResponseEntity<AdminDiaryResponse> {
+        return ResponseEntity.ok(adminDiaryService.getDetail(diaryId))
+    }
+
+    @Operation(summary = "일기 삭제", description = "관리자 권한으로 일기를 영구 삭제합니다.")
+    @DeleteMapping("/{diaryId}")
+    fun delete(@PathVariable diaryId: Long): ResponseEntity<Void> {
+        adminDiaryService.delete(diaryId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/diary/presentation/dto/res/AdminDiaryResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/presentation/dto/res/AdminDiaryResponse.kt
@@ -1,0 +1,67 @@
+package digdaserver.admin.diary.presentation.dto.res
+
+import digdaserver.domain.diary.domain.entity.Diary
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 일기 정보")
+data class AdminDiaryResponse(
+
+    @Schema(description = "일기 ID")
+    val diaryId: Long,
+
+    @Schema(description = "그룹방 ID")
+    val groupRoomId: Long,
+
+    @Schema(description = "그룹방 이름")
+    val groupRoomName: String,
+
+    @Schema(description = "작성자 ID(UUID)")
+    val createdBy: String,
+
+    @Schema(description = "작성자 이름")
+    val authorName: String,
+
+    @Schema(description = "제목")
+    val title: String,
+
+    @Schema(description = "내용")
+    val content: String,
+
+    @Schema(description = "일기 날짜")
+    val date: LocalDate,
+
+    @Schema(description = "날씨(0~3)")
+    val weather: Int,
+
+    @Schema(description = "기분(0~3)")
+    val mood: Int,
+
+    @Schema(description = "이미지 URL")
+    val imageUrl: String?,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정 시각")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(diary: Diary): AdminDiaryResponse = AdminDiaryResponse(
+            diaryId = diary.id,
+            groupRoomId = diary.groupRoom.id,
+            groupRoomName = diary.groupRoom.name,
+            createdBy = diary.createdBy.id.toString(),
+            authorName = diary.createdBy.name,
+            title = diary.title,
+            content = diary.content,
+            date = diary.date,
+            weather = diary.weather,
+            mood = diary.mood,
+            imageUrl = diary.imageUrl,
+            createdAt = diary.createdAt,
+            updatedAt = diary.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/grouproom/application/service/AdminGroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/application/service/AdminGroupRoomService.kt
@@ -1,0 +1,14 @@
+package digdaserver.admin.grouproom.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.grouproom.presentation.dto.req.GroupRoomAdminAction
+import digdaserver.admin.grouproom.presentation.dto.res.AdminGroupRoomResponse
+
+interface AdminGroupRoomService {
+
+    fun search(keyword: String?, includeDeleted: Boolean, page: Int, size: Int): AdminPageResponse<AdminGroupRoomResponse>
+
+    fun getDetail(groupRoomId: Long): AdminGroupRoomResponse
+
+    fun changeStatus(groupRoomId: Long, action: GroupRoomAdminAction): AdminGroupRoomResponse
+}

--- a/src/main/kotlin/digdaserver/admin/grouproom/application/service/impl/AdminGroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/application/service/impl/AdminGroupRoomServiceImpl.kt
@@ -1,0 +1,50 @@
+package digdaserver.admin.grouproom.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.grouproom.application.service.AdminGroupRoomService
+import digdaserver.admin.grouproom.presentation.dto.req.GroupRoomAdminAction
+import digdaserver.admin.grouproom.presentation.dto.res.AdminGroupRoomResponse
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminGroupRoomServiceImpl(
+    private val groupRoomRepository: GroupRoomRepository
+) : AdminGroupRoomService {
+
+    override fun search(
+        keyword: String?,
+        includeDeleted: Boolean,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminGroupRoomResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = groupRoomRepository.searchForAdmin(keyword, includeDeleted, pageable)
+        return AdminPageResponse.of(result, AdminGroupRoomResponse::from)
+    }
+
+    override fun getDetail(groupRoomId: Long): AdminGroupRoomResponse {
+        val room = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        return AdminGroupRoomResponse.from(room)
+    }
+
+    @Transactional
+    override fun changeStatus(groupRoomId: Long, action: GroupRoomAdminAction): AdminGroupRoomResponse {
+        val room = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        when (action) {
+            GroupRoomAdminAction.RECOVER -> room.recover()
+            GroupRoomAdminAction.SCHEDULE_DELETE -> room.scheduleDelete()
+            GroupRoomAdminAction.HARD_DELETE -> room.markDeleted()
+        }
+        return AdminGroupRoomResponse.from(room)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/grouproom/application/service/impl/AdminGroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/application/service/impl/AdminGroupRoomServiceImpl.kt
@@ -4,9 +4,13 @@ import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.grouproom.application.service.AdminGroupRoomService
 import digdaserver.admin.grouproom.presentation.dto.req.GroupRoomAdminAction
 import digdaserver.admin.grouproom.presentation.dto.res.AdminGroupRoomResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.UUID
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -15,7 +19,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class AdminGroupRoomServiceImpl(
-    private val groupRoomRepository: GroupRoomRepository
+    private val groupRoomRepository: GroupRoomRepository,
+    private val adminActionLogService: AdminActionLogService
 ) : AdminGroupRoomService {
 
     override fun search(
@@ -45,6 +50,20 @@ class AdminGroupRoomServiceImpl(
             GroupRoomAdminAction.SCHEDULE_DELETE -> room.scheduleDelete()
             GroupRoomAdminAction.HARD_DELETE -> room.markDeleted()
         }
+
+        adminActionLogService.record(
+            actorId = currentActorId(),
+            action = AdminAction.CHANGE_GROUP_ROOM_STATUS,
+            targetType = "GROUP_ROOM",
+            targetId = groupRoomId.toString(),
+            detail = "action=$action, name=${room.name}"
+        )
+
         return AdminGroupRoomResponse.from(room)
+    }
+
+    private fun currentActorId(): UUID? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal as? String ?: return null
+        return runCatching { UUID.fromString(principal) }.getOrNull()
     }
 }

--- a/src/main/kotlin/digdaserver/admin/grouproom/presentation/controller/AdminGroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/presentation/controller/AdminGroupRoomController.kt
@@ -1,0 +1,51 @@
+package digdaserver.admin.grouproom.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.grouproom.application.service.AdminGroupRoomService
+import digdaserver.admin.grouproom.presentation.dto.req.AdminGroupRoomStatusRequest
+import digdaserver.admin.grouproom.presentation.dto.res.AdminGroupRoomResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/group-rooms")
+@Tag(name = "Admin - GroupRoom", description = "관리자 그룹방 관리 API")
+class AdminGroupRoomController(
+    private val adminGroupRoomService: AdminGroupRoomService
+) {
+
+    @Operation(summary = "그룹방 목록 조회", description = "페이징, 키워드(이름), 삭제 포함 여부 필터")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "true") includeDeleted: Boolean,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminGroupRoomResponse>> {
+        return ResponseEntity.ok(adminGroupRoomService.search(keyword, includeDeleted, page, size))
+    }
+
+    @Operation(summary = "그룹방 상세 조회")
+    @GetMapping("/{groupRoomId}")
+    fun getDetail(@PathVariable groupRoomId: Long): ResponseEntity<AdminGroupRoomResponse> {
+        return ResponseEntity.ok(adminGroupRoomService.getDetail(groupRoomId))
+    }
+
+    @Operation(summary = "그룹방 상태 변경", description = "RECOVER/SCHEDULE_DELETE/HARD_DELETE")
+    @PatchMapping("/{groupRoomId}/status")
+    fun changeStatus(
+        @PathVariable groupRoomId: Long,
+        @Valid @RequestBody request: AdminGroupRoomStatusRequest
+    ): ResponseEntity<AdminGroupRoomResponse> {
+        return ResponseEntity.ok(adminGroupRoomService.changeStatus(groupRoomId, request.action))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/req/AdminGroupRoomStatusRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/req/AdminGroupRoomStatusRequest.kt
@@ -1,0 +1,18 @@
+package digdaserver.admin.grouproom.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+enum class GroupRoomAdminAction {
+    RECOVER,
+    SCHEDULE_DELETE,
+    HARD_DELETE
+}
+
+@Schema(description = "그룹방 상태 변경 요청")
+data class AdminGroupRoomStatusRequest(
+
+    @field:NotNull
+    @Schema(description = "액션: RECOVER(복구) / SCHEDULE_DELETE(삭제 예약) / HARD_DELETE(즉시 삭제)")
+    val action: GroupRoomAdminAction
+)

--- a/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/res/AdminGroupRoomResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/res/AdminGroupRoomResponse.kt
@@ -1,0 +1,58 @@
+package digdaserver.admin.grouproom.presentation.dto.res
+
+import digdaserver.domain.group_room.domain.entity.GroupRoom
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 그룹방 정보")
+data class AdminGroupRoomResponse(
+
+    @Schema(description = "그룹방 ID")
+    val groupRoomId: Long,
+
+    @Schema(description = "그룹방 이름")
+    val name: String,
+
+    @Schema(description = "썸네일 이미지 URL")
+    val thumbnailImage: String?,
+
+    @Schema(description = "최대 인원")
+    val maxMembers: Int,
+
+    @Schema(description = "방장 ID(UUID)")
+    val ownerId: String,
+
+    @Schema(description = "방장 이름")
+    val ownerName: String,
+
+    @Schema(description = "마지막 활동 시각")
+    val lastActivityAt: LocalDateTime,
+
+    @Schema(description = "삭제 예약 시각")
+    val deleteScheduledAt: LocalDateTime?,
+
+    @Schema(description = "삭제 시각")
+    val deletedAt: LocalDateTime?,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정 시각")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(room: GroupRoom): AdminGroupRoomResponse = AdminGroupRoomResponse(
+            groupRoomId = room.id,
+            name = room.name,
+            thumbnailImage = room.thumbnailImage,
+            maxMembers = room.maxMembers,
+            ownerId = room.owner.id.toString(),
+            ownerName = room.owner.name,
+            lastActivityAt = room.lastActivityAt,
+            deleteScheduledAt = room.deleteScheduledAt,
+            deletedAt = room.deletedAt,
+            createdAt = room.createdAt,
+            updatedAt = room.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/log/application/service/AdminActionLogService.kt
+++ b/src/main/kotlin/digdaserver/admin/log/application/service/AdminActionLogService.kt
@@ -1,0 +1,28 @@
+package digdaserver.admin.log.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.log.domain.entity.AdminAction
+import digdaserver.admin.log.presentation.dto.res.AdminActionLogResponse
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface AdminActionLogService {
+
+    fun record(
+        actorId: UUID?,
+        action: AdminAction,
+        targetType: String?,
+        targetId: String?,
+        detail: String?
+    )
+
+    fun search(
+        actorId: UUID?,
+        action: AdminAction?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminActionLogResponse>
+}

--- a/src/main/kotlin/digdaserver/admin/log/application/service/impl/AdminActionLogServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/log/application/service/impl/AdminActionLogServiceImpl.kt
@@ -1,0 +1,54 @@
+package digdaserver.admin.log.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
+import digdaserver.admin.log.domain.entity.AdminActionLog
+import digdaserver.admin.log.domain.repository.AdminActionLogRepository
+import digdaserver.admin.log.presentation.dto.res.AdminActionLogResponse
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class AdminActionLogServiceImpl(
+    private val adminActionLogRepository: AdminActionLogRepository
+) : AdminActionLogService {
+
+    @Transactional
+    override fun record(
+        actorId: UUID?,
+        action: AdminAction,
+        targetType: String?,
+        targetId: String?,
+        detail: String?
+    ) {
+        adminActionLogRepository.save(
+            AdminActionLog(
+                actorId = actorId,
+                action = action,
+                targetType = targetType,
+                targetId = targetId,
+                detail = detail?.take(500)
+            )
+        )
+    }
+
+    override fun search(
+        actorId: UUID?,
+        action: AdminAction?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminActionLogResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = adminActionLogRepository.searchLogs(actorId, action, from, to, keyword, pageable)
+        return AdminPageResponse.of(result, AdminActionLogResponse::from)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/log/domain/entity/AdminAction.kt
+++ b/src/main/kotlin/digdaserver/admin/log/domain/entity/AdminAction.kt
@@ -1,0 +1,10 @@
+package digdaserver.admin.log.domain.entity
+
+enum class AdminAction {
+    LOGIN,
+    UPDATE_USER_ROLE,
+    CHANGE_GROUP_ROOM_STATUS,
+    DELETE_DIARY,
+    VIEW_DB_TABLE,
+    OTHER
+}

--- a/src/main/kotlin/digdaserver/admin/log/domain/entity/AdminActionLog.kt
+++ b/src/main/kotlin/digdaserver/admin/log/domain/entity/AdminActionLog.kt
@@ -1,0 +1,57 @@
+package digdaserver.admin.log.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import jakarta.persistence.EntityListeners
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+@Table(
+    name = "admin_action_log",
+    indexes = [
+        Index(name = "idx_admin_log_created_at", columnList = "created_at"),
+        Index(name = "idx_admin_log_action", columnList = "action"),
+        Index(name = "idx_admin_log_actor", columnList = "actor_id")
+    ]
+)
+class AdminActionLog(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_action_log_id")
+    val id: Long = 0L,
+
+    @Column(name = "actor_id", columnDefinition = "BINARY(16)")
+    val actorId: UUID?,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    val action: AdminAction,
+
+    @Column(name = "target_type", length = 40)
+    val targetType: String?,
+
+    @Column(name = "target_id", length = 100)
+    val targetId: String?,
+
+    @Column(length = 500)
+    val detail: String?
+
+) {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/src/main/kotlin/digdaserver/admin/log/domain/repository/AdminActionLogRepository.kt
+++ b/src/main/kotlin/digdaserver/admin/log/domain/repository/AdminActionLogRepository.kt
@@ -1,0 +1,37 @@
+package digdaserver.admin.log.domain.repository
+
+import digdaserver.admin.log.domain.entity.AdminAction
+import digdaserver.admin.log.domain.entity.AdminActionLog
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Repository
+interface AdminActionLogRepository : JpaRepository<AdminActionLog, Long> {
+
+    @Query(
+        """
+        SELECT l FROM AdminActionLog l
+        WHERE (:actorId IS NULL OR l.actorId = :actorId)
+          AND (:action IS NULL OR l.action = :action)
+          AND (:from IS NULL OR l.createdAt >= :from)
+          AND (:to IS NULL OR l.createdAt <= :to)
+          AND (:keyword IS NULL OR :keyword = ''
+               OR LOWER(COALESCE(l.detail, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
+               OR LOWER(COALESCE(l.targetId, '')) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchLogs(
+        @Param("actorId") actorId: UUID?,
+        @Param("action") action: AdminAction?,
+        @Param("from") from: LocalDateTime?,
+        @Param("to") to: LocalDateTime?,
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<AdminActionLog>
+}

--- a/src/main/kotlin/digdaserver/admin/log/presentation/controller/AdminActionLogController.kt
+++ b/src/main/kotlin/digdaserver/admin/log/presentation/controller/AdminActionLogController.kt
@@ -1,0 +1,47 @@
+package digdaserver.admin.log.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
+import digdaserver.admin.log.presentation.dto.res.AdminActionLogResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/admin/logs")
+@Tag(name = "Admin - Log", description = "관리자 행위/시스템 로그 조회 API")
+class AdminActionLogController(
+    private val adminActionLogService: AdminActionLogService
+) {
+
+    @Operation(
+        summary = "로그 조회",
+        description = "최신순 정렬. actorId/action/기간/키워드(detail·targetId) 필터 지원."
+    )
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) actorId: UUID?,
+        @RequestParam(required = false) action: AdminAction?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        from: LocalDateTime?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        to: LocalDateTime?,
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminActionLogResponse>> {
+        return ResponseEntity.ok(
+            adminActionLogService.search(actorId, action, from, to, keyword, page, size)
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/log/presentation/dto/res/AdminActionLogResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/log/presentation/dto/res/AdminActionLogResponse.kt
@@ -1,0 +1,42 @@
+package digdaserver.admin.log.presentation.dto.res
+
+import digdaserver.admin.log.domain.entity.AdminActionLog
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "관리자 행위 로그")
+data class AdminActionLogResponse(
+
+    @Schema(description = "로그 ID")
+    val logId: Long,
+
+    @Schema(description = "행위자 ID(UUID). 시스템 로그인 경우 null 가능")
+    val actorId: String?,
+
+    @Schema(description = "액션 타입")
+    val action: String,
+
+    @Schema(description = "대상 타입 (USER/GROUP_ROOM/DIARY/TABLE 등)")
+    val targetType: String?,
+
+    @Schema(description = "대상 ID")
+    val targetId: String?,
+
+    @Schema(description = "상세 메시지")
+    val detail: String?,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(log: AdminActionLog): AdminActionLogResponse = AdminActionLogResponse(
+            logId = log.id,
+            actorId = log.actorId?.toString(),
+            action = log.action.name,
+            targetType = log.targetType,
+            targetId = log.targetId,
+            detail = log.detail,
+            createdAt = log.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/schedule/application/service/AdminScheduleService.kt
+++ b/src/main/kotlin/digdaserver/admin/schedule/application/service/AdminScheduleService.kt
@@ -1,0 +1,11 @@
+package digdaserver.admin.schedule.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.schedule.presentation.dto.res.AdminScheduleResponse
+
+interface AdminScheduleService {
+
+    fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminScheduleResponse>
+
+    fun getDetail(scheduleId: Long): AdminScheduleResponse
+}

--- a/src/main/kotlin/digdaserver/admin/schedule/application/service/impl/AdminScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/schedule/application/service/impl/AdminScheduleServiceImpl.kt
@@ -1,0 +1,31 @@
+package digdaserver.admin.schedule.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.schedule.application.service.AdminScheduleService
+import digdaserver.admin.schedule.presentation.dto.res.AdminScheduleResponse
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminScheduleServiceImpl(
+    private val scheduleRepository: ScheduleRepository
+) : AdminScheduleService {
+
+    override fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminScheduleResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = scheduleRepository.searchForAdmin(keyword, pageable)
+        return AdminPageResponse.of(result, AdminScheduleResponse::from)
+    }
+
+    override fun getDetail(scheduleId: Long): AdminScheduleResponse {
+        val schedule = scheduleRepository.findById(scheduleId)
+            .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
+        return AdminScheduleResponse.from(schedule)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/schedule/presentation/controller/AdminScheduleController.kt
+++ b/src/main/kotlin/digdaserver/admin/schedule/presentation/controller/AdminScheduleController.kt
@@ -1,0 +1,37 @@
+package digdaserver.admin.schedule.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.schedule.application.service.AdminScheduleService
+import digdaserver.admin.schedule.presentation.dto.res.AdminScheduleResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/schedules")
+@Tag(name = "Admin - Schedule", description = "관리자 일정 관리 API")
+class AdminScheduleController(
+    private val adminScheduleService: AdminScheduleService
+) {
+
+    @Operation(summary = "일정 목록 조회", description = "페이징, 키워드(제목)")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminScheduleResponse>> {
+        return ResponseEntity.ok(adminScheduleService.search(keyword, page, size))
+    }
+
+    @Operation(summary = "일정 상세 조회")
+    @GetMapping("/{scheduleId}")
+    fun getDetail(@PathVariable scheduleId: Long): ResponseEntity<AdminScheduleResponse> {
+        return ResponseEntity.ok(adminScheduleService.getDetail(scheduleId))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/schedule/presentation/dto/res/AdminScheduleResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/schedule/presentation/dto/res/AdminScheduleResponse.kt
@@ -1,0 +1,76 @@
+package digdaserver.admin.schedule.presentation.dto.res
+
+import digdaserver.domain.schedule.domain.entity.Schedule
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Schema(description = "어드민용 일정 정보")
+data class AdminScheduleResponse(
+
+    @Schema(description = "일정 ID")
+    val scheduleId: Long,
+
+    @Schema(description = "그룹방 ID")
+    val groupRoomId: Long,
+
+    @Schema(description = "그룹방 이름")
+    val groupRoomName: String,
+
+    @Schema(description = "작성자 ID(UUID)")
+    val createdBy: String,
+
+    @Schema(description = "작성자 이름")
+    val authorName: String,
+
+    @Schema(description = "제목")
+    val title: String,
+
+    @Schema(description = "색상(#RRGGBB)")
+    val color: String,
+
+    @Schema(description = "시작 일자")
+    val startDate: LocalDate,
+
+    @Schema(description = "종료 일자")
+    val endDate: LocalDate,
+
+    @Schema(description = "시작 시간")
+    val startTime: LocalTime?,
+
+    @Schema(description = "종료 시간")
+    val endTime: LocalTime?,
+
+    @Schema(description = "종일 여부")
+    val allDay: Boolean,
+
+    @Schema(description = "참여자 수")
+    val participantCount: Int,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정 시각")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(schedule: Schedule): AdminScheduleResponse = AdminScheduleResponse(
+            scheduleId = schedule.id,
+            groupRoomId = schedule.groupRoom.id,
+            groupRoomName = schedule.groupRoom.name,
+            createdBy = schedule.createdBy.id.toString(),
+            authorName = schedule.createdBy.name,
+            title = schedule.title,
+            color = schedule.color,
+            startDate = schedule.startDate,
+            endDate = schedule.endDate,
+            startTime = schedule.startTime,
+            endTime = schedule.endTime,
+            allDay = schedule.allDay,
+            participantCount = schedule.participants.size,
+            createdAt = schedule.createdAt,
+            updatedAt = schedule.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/user/application/service/AdminUserService.kt
+++ b/src/main/kotlin/digdaserver/admin/user/application/service/AdminUserService.kt
@@ -1,0 +1,15 @@
+package digdaserver.admin.user.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.user.presentation.dto.res.AdminUserResponse
+import digdaserver.domain.user.domain.entity.Role
+import java.util.UUID
+
+interface AdminUserService {
+
+    fun search(keyword: String?, role: Role?, page: Int, size: Int): AdminPageResponse<AdminUserResponse>
+
+    fun getDetail(userId: UUID): AdminUserResponse
+
+    fun updateRole(userId: UUID, role: Role): AdminUserResponse
+}

--- a/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
@@ -1,10 +1,13 @@
 package digdaserver.admin.user.application.service.impl
 
 import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.log.application.service.AdminActionLogService
+import digdaserver.admin.log.domain.entity.AdminAction
 import digdaserver.admin.user.application.service.AdminUserService
 import digdaserver.admin.user.presentation.dto.res.AdminUserResponse
 import digdaserver.domain.user.domain.entity.Role
 import digdaserver.domain.user.domain.repository.UserRepository
+import org.springframework.security.core.context.SecurityContextHolder
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import org.springframework.data.domain.PageRequest
@@ -16,7 +19,8 @@ import java.util.UUID
 @Service
 @Transactional(readOnly = true)
 class AdminUserServiceImpl(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val adminActionLogService: AdminActionLogService
 ) : AdminUserService {
 
     override fun search(keyword: String?, role: Role?, page: Int, size: Int): AdminPageResponse<AdminUserResponse> {
@@ -35,7 +39,22 @@ class AdminUserServiceImpl(
     override fun updateRole(userId: UUID, role: Role): AdminUserResponse {
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        val previous = user.role
         user.role = role
+
+        adminActionLogService.record(
+            actorId = currentActorId(),
+            action = AdminAction.UPDATE_USER_ROLE,
+            targetType = "USER",
+            targetId = userId.toString(),
+            detail = "role: $previous → $role"
+        )
+
         return AdminUserResponse.from(user)
+    }
+
+    private fun currentActorId(): UUID? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal as? String ?: return null
+        return runCatching { UUID.fromString(principal) }.getOrNull()
     }
 }

--- a/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
@@ -1,0 +1,41 @@
+package digdaserver.admin.user.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.user.application.service.AdminUserService
+import digdaserver.admin.user.presentation.dto.res.AdminUserResponse
+import digdaserver.domain.user.domain.entity.Role
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class AdminUserServiceImpl(
+    private val userRepository: UserRepository
+) : AdminUserService {
+
+    override fun search(keyword: String?, role: Role?, page: Int, size: Int): AdminPageResponse<AdminUserResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = userRepository.searchForAdmin(keyword, role, pageable)
+        return AdminPageResponse.of(result, AdminUserResponse::from)
+    }
+
+    override fun getDetail(userId: UUID): AdminUserResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        return AdminUserResponse.from(user)
+    }
+
+    @Transactional
+    override fun updateRole(userId: UUID, role: Role): AdminUserResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        user.role = role
+        return AdminUserResponse.from(user)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/user/presentation/controller/AdminUserController.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/controller/AdminUserController.kt
@@ -1,0 +1,53 @@
+package digdaserver.admin.user.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.user.application.service.AdminUserService
+import digdaserver.admin.user.presentation.dto.req.AdminUpdateUserRoleRequest
+import digdaserver.admin.user.presentation.dto.res.AdminUserResponse
+import digdaserver.domain.user.domain.entity.Role
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/admin/users")
+@Tag(name = "Admin - User", description = "관리자 사용자 관리 API")
+class AdminUserController(
+    private val adminUserService: AdminUserService
+) {
+
+    @Operation(summary = "사용자 목록 조회", description = "페이징, 키워드(이름/이메일), 권한 필터를 지원합니다.")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(required = false) role: Role?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminUserResponse>> {
+        return ResponseEntity.ok(adminUserService.search(keyword, role, page, size))
+    }
+
+    @Operation(summary = "사용자 상세 조회")
+    @GetMapping("/{userId}")
+    fun getDetail(@PathVariable userId: UUID): ResponseEntity<AdminUserResponse> {
+        return ResponseEntity.ok(adminUserService.getDetail(userId))
+    }
+
+    @Operation(summary = "사용자 권한 변경")
+    @PatchMapping("/{userId}/role")
+    fun updateRole(
+        @PathVariable userId: UUID,
+        @Valid @RequestBody request: AdminUpdateUserRoleRequest
+    ): ResponseEntity<AdminUserResponse> {
+        return ResponseEntity.ok(adminUserService.updateRole(userId, request.role))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/user/presentation/dto/req/AdminUpdateUserRoleRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/dto/req/AdminUpdateUserRoleRequest.kt
@@ -1,0 +1,13 @@
+package digdaserver.admin.user.presentation.dto.req
+
+import digdaserver.domain.user.domain.entity.Role
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "사용자 권한 변경 요청")
+data class AdminUpdateUserRoleRequest(
+
+    @field:NotNull
+    @Schema(description = "변경할 권한", example = "ADMIN")
+    val role: Role
+)

--- a/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
@@ -1,0 +1,50 @@
+package digdaserver.admin.user.presentation.dto.res
+
+import digdaserver.domain.user.domain.entity.User
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 사용자 정보")
+data class AdminUserResponse(
+
+    @Schema(description = "사용자 ID(UUID)")
+    val userId: String,
+
+    @Schema(description = "이메일")
+    val email: String?,
+
+    @Schema(description = "이름")
+    val name: String,
+
+    @Schema(description = "상태 메시지")
+    val statusMessage: String?,
+
+    @Schema(description = "프로필 이미지 URL")
+    val profileImage: String?,
+
+    @Schema(description = "소셜 프로바이더")
+    val socialProvider: String,
+
+    @Schema(description = "권한(USER/ADMIN)")
+    val role: String,
+
+    @Schema(description = "가입일시")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정일시")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(user: User): AdminUserResponse = AdminUserResponse(
+            userId = user.id.toString(),
+            email = user.email,
+            name = user.name,
+            statusMessage = user.statusMessage,
+            profileImage = user.profileImage,
+            socialProvider = user.socialProvider.name,
+            role = user.role.name,
+            createdAt = user.createdAt,
+            updatedAt = user.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
@@ -18,4 +19,17 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
 
     @Query("SELECT DISTINCT d.date FROM Diary d WHERE d.groupRoom.id = :groupRoomId AND d.date BETWEEN :startDate AND :endDate")
     fun findDistinctDatesByGroupRoomIdAndMonth(groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): List<LocalDate>
+
+    @Query(
+        """
+        SELECT d FROM Diary d
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(d.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<Diary>
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/domain/repository/GroupRoomRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/domain/repository/GroupRoomRepository.kt
@@ -1,8 +1,11 @@
 package digdaserver.domain.group_room.domain.repository
 
 import digdaserver.domain.group_room.domain.entity.GroupRoom
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import java.util.UUID
@@ -14,4 +17,22 @@ interface GroupRoomRepository : JpaRepository<GroupRoom, Long> {
     fun findAllScheduledForDeletion(now: LocalDateTime): List<GroupRoom>
 
     fun existsByOwnerIdAndDeletedAtIsNull(ownerId: UUID): Boolean
+
+    fun countByDeletedAtIsNull(): Long
+
+    fun countByDeleteScheduledAtIsNotNullAndDeletedAtIsNull(): Long
+
+    @Query(
+        """
+        SELECT g FROM GroupRoom g
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(g.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+          AND (:includeDeleted = true OR g.deletedAt IS NULL)
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        @Param("includeDeleted") includeDeleted: Boolean,
+        pageable: Pageable
+    ): Page<GroupRoom>
 }

--- a/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
@@ -1,8 +1,11 @@
 package digdaserver.domain.schedule.domain.repository
 
 import digdaserver.domain.schedule.domain.entity.Schedule
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
@@ -11,4 +14,16 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s WHERE s.groupRoom.id = :groupRoomId AND s.startDate <= :endDate AND s.endDate >= :startDate ORDER BY s.startDate ASC")
     fun findAllByGroupRoomIdAndDateRange(groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): List<Schedule>
+
+    @Query(
+        """
+        SELECT s FROM Schedule s
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<Schedule>
 }

--- a/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
@@ -1,8 +1,13 @@
 package digdaserver.domain.user.domain.repository
 
 import digdaserver.domain.oauth2.domain.entity.SocialProvider
+import digdaserver.domain.user.domain.entity.Role
 import digdaserver.domain.user.domain.entity.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.Optional
 import java.util.UUID
@@ -11,4 +16,21 @@ import java.util.UUID
 interface UserRepository : JpaRepository<User, UUID> {
 
     fun findBySocialIdAndSocialProvider(socialId: String, socialProvider: SocialProvider): Optional<User>
+
+    fun countByRole(role: Role): Long
+
+    @Query(
+        """
+        SELECT u FROM User u
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(COALESCE(u.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%')))
+          AND (:role IS NULL OR u.role = :role)
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        @Param("role") role: Role?,
+        pageable: Pageable
+    ): Page<User>
 }

--- a/src/main/kotlin/digdaserver/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/digdaserver/global/config/SecurityConfig.kt
@@ -35,7 +35,7 @@ class SecurityConfig(
         "/api/oauth2/login/**",
         "/api/oauth2/callback/**",
         "/api/healthcheck",
-        "/api/admin/**",
+        "/api/admin/auth/login",
         "/api/test/**",
         "/actuator/**",
         "/api/callback/**",
@@ -80,7 +80,8 @@ class SecurityConfig(
                 .requestMatchers("/auth/login", "/auth/refresh").permitAll()
                 .requestMatchers("/api/oauth2/login/**").permitAll()
                 .requestMatchers("/api/oauth2/callback/**", "/api/test/**", "/api/callback/**").permitAll()
-                .requestMatchers("/api/admin/**").permitAll()
+                .requestMatchers("/api/admin/auth/login").permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 .requestMatchers("/favicon.ico", "/api/region").permitAll()
                 .requestMatchers("/api/app/reissue", "/api/web/reissue").permitAll()

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -95,5 +95,13 @@ enum class ErrorCode(
     IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", "존재하지 않는 이미지입니다.", 404),
 
     // ── Rate Limit ──
-    RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429);
+    RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),
+
+    // ── Admin ──
+    ADMIN_NOT_FOUND("ADMIN_NOT_FOUND", "존재하지 않는 관리자 계정입니다.", 404),
+    ADMIN_PASSWORD_MISMATCH("ADMIN_PASSWORD_MISMATCH", "비밀번호가 일치하지 않습니다.", 401),
+    NOT_ADMIN_USER("NOT_ADMIN_USER", "관리자 권한이 없는 사용자입니다.", 403),
+    ADMIN_TABLE_NOT_ALLOWED("ADMIN_TABLE_NOT_ALLOWED", "조회할 수 없는 테이블명입니다.", 400),
+    ADMIN_TABLE_NOT_FOUND("ADMIN_TABLE_NOT_FOUND", "존재하지 않는 테이블입니다.", 404),
+    ADMIN_COLUMN_NOT_ALLOWED("ADMIN_COLUMN_NOT_ALLOWED", "유효하지 않은 컬럼명입니다.", 400);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37

## 📝작업 내용

> Admin API 5개 영역(인증/대시보드/도메인 관리/DB 조회/로그)을 한 브랜치에서 기능별 커밋/푸시로 나눠 구현했습니다.

### Admin API (18개)
| # | 메서드 | 엔드포인트 | 설명 |
|---|--------|-----------|------|
| 1 | POST | `/api/admin/auth/login` | 관리자 이메일/비밀번호 로그인 (JWT 발급, ADMIN 역할만) |
| 2 | GET | `/api/admin/dashboard/summary` | 주요 통계(사용자/그룹방/일기/일정/댓글/할일/알림) |
| 3 | GET | `/api/admin/users` | 사용자 목록(페이징·키워드·role 필터) |
| 4 | GET | `/api/admin/users/{userId}` | 사용자 상세 |
| 5 | PATCH | `/api/admin/users/{userId}/role` | 사용자 권한 변경 |
| 6 | GET | `/api/admin/group-rooms` | 그룹방 목록(페이징·키워드·삭제포함 여부) |
| 7 | GET | `/api/admin/group-rooms/{id}` | 그룹방 상세 |
| 8 | PATCH | `/api/admin/group-rooms/{id}/status` | 그룹방 상태(RECOVER/SCHEDULE_DELETE/HARD_DELETE) |
| 9 | GET | `/api/admin/diaries` | 일기 목록(페이징·키워드) |
| 10 | GET | `/api/admin/diaries/{id}` | 일기 상세 |
| 11 | DELETE | `/api/admin/diaries/{id}` | 일기 삭제 |
| 12 | GET | `/api/admin/schedules` | 일정 목록(페이징·키워드) |
| 13 | GET | `/api/admin/schedules/{id}` | 일정 상세 |
| 14 | GET | `/api/admin/db/tables` | 전체 테이블 목록 |
| 15 | GET | `/api/admin/db/tables/{name}/columns` | 테이블 컬럼 정보 |
| 16 | GET | `/api/admin/db/tables/{name}/rows` | 테이블 데이터(페이징·컬럼 기반) |
| 17 | GET | `/api/admin/logs` | 관리자 행위/시스템 로그(최신순, 필터) |

### 주요 구현 사항
- **인증/인가**: `AdminCredential` 엔티티로 관리자 자격증명 분리, BCrypt 검증 + `User.role == ADMIN` 검증 후 JWT 발급. SecurityConfig에서 `/api/admin/auth/login`만 공개, 나머지 `/api/admin/**`는 `hasRole("ADMIN")`.
- **대시보드**: 각 도메인 Repository의 count 쿼리 조합. 그룹방은 전체/활성/삭제예약 구분.
- **도메인 관리**: Service 인터페이스/Impl 분리, 공용 `AdminPageResponse<T>`로 페이징 일관화, 도메인별 검색 쿼리(`searchForAdmin`) 추가.
- **DB 조회**: `INFORMATION_SCHEMA` + `JdbcTemplate` 기반. 테이블/컬럼명은 `^[A-Za-z_][A-Za-z0-9_]{0,63}$` 화이트리스트, 정렬 방향 ASC/DESC 화이트리스트로 SQL 인젝션 차단. size 상한 200.
- **로그**: `AdminActionLog` 엔티티 + 인덱스(created_at/action/actor). 로그인·역할변경·그룹방 상태변경·일기 삭제·DB 조회 시점에 자동 기록.
- **Swagger**: `@Tag(name = "Admin - ...")`로 섹션 분리.

### 커밋 순서(푸시 5회)
1. `[Feature] Admin 인증 API 구현 (관리자 로그인, JWT 발급, ADMIN 인가)`
2. `[Feature] Admin 대시보드 API 구현 (주요 통계 조회)`
3. `[Feature] Admin 도메인 관리 API 구현 (사용자/그룹방/일기/일정 CRUD)`
4. `[Feature] Admin DB 테이블 조회 API 구현`
5. `[Feature] Admin 로그 관리 API 구현 및 행위 로그 연동`
