### PR TITLE
[Fix] Admin 행위 로그 저장 시 read-only 트랜잭션 충돌 해결

### DIFF
--- a/src/main/kotlin/digdaserver/admin/log/application/service/impl/AdminActionLogServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/log/application/service/impl/AdminActionLogServiceImpl.kt
@@ -9,6 +9,7 @@ import digdaserver.admin.log.presentation.dto.res.AdminActionLogResponse
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.UUID
@@ -19,7 +20,7 @@ class AdminActionLogServiceImpl(
     private val adminActionLogRepository: AdminActionLogRepository
 ) : AdminActionLogService {
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun record(
         actorId: UUID?,
         action: AdminAction,


### PR DESCRIPTION
## Summary
- readOnly 트랜잭션 안에서 `AdminActionLogServiceImpl.record()`가 호출될 때 INSERT가 거부되던 문제 수정
- `@Transactional(propagation = REQUIRES_NEW)`로 변경해 새 트랜잭션에서 로그가 기록되도록 함

## 재현 에러
```
JpaSystemException: Connection is read-only. Queries leading to data modification are not allowed
[insert into admin_action_log ...]
  at AdminActionLogServiceImpl.record(AdminActionLogServiceImpl.kt:30)
  at AdminDbServiceImpl.readRows(AdminDbServiceImpl.kt:113)
  at AdminDbController.readRows(AdminDbController.kt:46)
```

## 원인
`AdminDbServiceImpl`은 클래스 단위로 `@Transactional(readOnly = true)`. `readRows()` 내부에서 `adminActionLogService.record()`를 호출하면, `record()`의 `@Transactional`은 기본 propagation(REQUIRED)이라 **부모의 read-only 트랜잭션에 합류**하게 되어 INSERT가 거부됨.

## 수정
`record()`를 `Propagation.REQUIRES_NEW`로 지정 — 부모 트랜잭션을 일시 중단하고 별도의 RW 트랜잭션에서 로그를 저장. 부모 트랜잭션이 롤백되어도 감사 로그는 보존되므로 관리자 행위 로그 성격에도 부합.

## Test plan
- [ ] 서버 재기동 후 `GET /api/admin/db/tables/{name}/rows` 호출 시 200 응답 + `admin_action_log` 테이블에 `VIEW_DB_TABLE` 레코드 insert 확인
- [ ] 기존 쓰기 경로(사용자 role 변경, 그룹방 상태 변경 등)에서도 정상적으로 로그 기록되는지 확인
- [ ] dev 프로파일에서 부팅 정상 (기본 관리자 생성 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)