### PR TITLE
[Fix] Admin 부트스트랩 자격증명 하드코딩 제거 및 env 이관

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ out/
 ### Application Config ###
 src/main/resources/application-*.yml
 !src/main/resources/application.yml
+
+### Environment / Secrets ###
+env/
+*.env
+!.env.example

--- a/src/main/kotlin/digdaserver/admin/auth/config/AdminBootstrap.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/config/AdminBootstrap.kt
@@ -7,6 +7,7 @@ import digdaserver.domain.user.domain.entity.Role
 import digdaserver.domain.user.domain.entity.User
 import digdaserver.domain.user.domain.repository.UserRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Profile
@@ -19,17 +20,16 @@ import org.springframework.transaction.annotation.Transactional
 class AdminBootstrap(
     private val userRepository: UserRepository,
     private val adminCredentialRepository: AdminCredentialRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    @Value("\${admin.bootstrap.email}") private val email: String,
+    @Value("\${admin.bootstrap.password}") private val rawPassword: String,
+    @Value("\${admin.bootstrap.name}") private val name: String
 ) : ApplicationListener<ApplicationReadyEvent> {
 
     private val log = LoggerFactory.getLogger(AdminBootstrap::class.java)
 
     @Transactional
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
-        val email = System.getenv("DEFAULT_ADMIN_EMAIL") ?: "admin@digda.com"
-        val rawPassword = System.getenv("DEFAULT_ADMIN_PASSWORD") ?: "qkek@@0312"
-        val name = System.getenv("DEFAULT_ADMIN_NAME") ?: "admin"
-
         if (adminCredentialRepository.findByEmail(email).isPresent) {
             log.info("[AdminBootstrap] 기존 관리자 존재 — 생성 스킵 (email={})", email)
             return

--- a/src/main/kotlin/digdaserver/admin/auth/presentation/dto/req/AdminLoginRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/presentation/dto/req/AdminLoginRequest.kt
@@ -13,6 +13,6 @@ data class AdminLoginRequest(
     val email: String,
 
     @field:NotBlank
-    @Schema(description = "관리자 비밀번호", example = "qkek@@0312")
+    @Schema(description = "관리자 비밀번호", example = "P@ssw0rd!")
     val password: String
 )


### PR DESCRIPTION
## Summary
- `AdminBootstrap`의 이메일/비밀번호/이름을 코드 내 하드코딩에서 제거하고 `@Value`를 통한 env 주입 방식으로 전환
- `AdminLoginRequest` Swagger example에 실제 운영 비밀번호가 노출돼 있던 문제 수정
- `env/`, `*.env` `.gitignore`에 추가 (DB 비번/JWT 시크릿/OAuth 시크릿/S3 키 등 시크릿 커밋 방지)

## 배경
기존 `AdminBootstrap`은 `System.getenv("DEFAULT_ADMIN_PASSWORD") ?: "실제비밀번호"` 형태로, 환경변수가 없을 때의 fallback으로 실제 비밀번호가 소스코드에 박혀 있었음. 또한 `System.getenv()`는 OS 환경변수만 읽기 때문에 `env/dev.env`로 관리하는 값이 주입되지 않았음.

## 변경
### AdminBootstrap
```kotlin
@Value("\${admin.bootstrap.email}") private val email: String,
@Value("\${admin.bootstrap.password}") private val rawPassword: String,
@Value("\${admin.bootstrap.name}") private val name: String
```
- 하드코딩 기본값 제거 → 환경변수 누락 시 부팅 실패(fail-fast)
- Spring `@Value` 경유라 `env/dev.env` → `application-dev.yml` → 주입 체인이 정상 작동

### application-dev.yml (로컬, 이미 gitignore)
```yaml
admin:
  bootstrap:
    email: \${ADMIN_BOOTSTRAP_EMAIL}
    password: \${ADMIN_BOOTSTRAP_PASSWORD}
    name: \${ADMIN_BOOTSTRAP_NAME}
```

### env/dev.env (로컬, 이번에 gitignore 추가)
```
ADMIN_BOOTSTRAP_EMAIL=...
ADMIN_BOOTSTRAP_PASSWORD=...
ADMIN_BOOTSTRAP_NAME=...
```

### AdminLoginRequest
- Swagger `example`에 박혀있던 실제 비밀번호를 일반 placeholder(`P@ssw0rd!`)로 복구

### .gitignore
- `env/`, `*.env` 추가 (단 `.env.example`은 허용)

## 기존 관리자 로그 현황 (참고)
| Action | 시점 |
|---|---|
| `LOGIN` | 관리자 로그인 성공 |
| `UPDATE_USER_ROLE` | 사용자 권한 변경 |
| `CHANGE_GROUP_ROOM_STATUS` | 그룹방 상태 변경 |
| `DELETE_DIARY` | 일기 삭제 |
| `VIEW_DB_TABLE` | DB 테이블 행 조회 |

## Test plan
- [ ] 로컬 `env/dev.env`에 `ADMIN_BOOTSTRAP_*` 세 값 설정 후 서버 부팅 → 기본 관리자 생성 성공
- [ ] 위 변수들 중 하나라도 제거 시 부팅 실패(fail-fast) 확인
- [ ] `/api/admin/auth/login` 정상 로그인 + Swagger UI example이 더 이상 실제 비번을 노출하지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)