### PR TITLE
[Feature] DB 테이블 행 추가/수정/삭제 API

### DIFF
--- a/src/main/kotlin/digdaserver/admin/db/application/service/AdminDbService.kt
+++ b/src/main/kotlin/digdaserver/admin/db/application/service/AdminDbService.kt
@@ -11,4 +11,10 @@ interface AdminDbService {
     fun listColumns(tableName: String): List<AdminColumnInfoResponse>
 
     fun readRows(tableName: String, page: Int, size: Int, orderBy: String?, direction: String?): AdminTableRowsResponse
+
+    fun insertRow(tableName: String, values: Map<String, String?>): Int
+
+    fun updateRow(tableName: String, pkValues: Map<String, String>, values: Map<String, String?>): Int
+
+    fun deleteRow(tableName: String, pkValues: Map<String, String>): Int
 }

--- a/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/db/application/service/impl/AdminDbServiceImpl.kt
@@ -9,6 +9,10 @@ import digdaserver.global.infra.exception.error.ErrorCode
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 @Service
 @Transactional(readOnly = true)
@@ -78,18 +82,8 @@ class AdminDbServiceImpl(
         val safeSize = size.coerceIn(1, MAX_PAGE_SIZE)
         val offset = safePage.toLong() * safeSize.toLong()
 
-        val columns = jdbcTemplate.query(
-            """
-            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
-            ORDER BY ORDINAL_POSITION
-            """.trimIndent(),
-            { rs, _ -> rs.getString("COLUMN_NAME") },
-            safeTable
-        )
-        if (columns.isEmpty()) {
-            throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
-        }
+        val columns = fetchColumnNames(safeTable)
+        if (columns.isEmpty()) throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
 
         val orderClause = buildOrderClause(columns, orderBy, direction)
 
@@ -116,10 +110,81 @@ class AdminDbServiceImpl(
         )
     }
 
+    @Transactional
+    override fun insertRow(tableName: String, values: Map<String, String?>): Int {
+        val safeTable = validateIdentifier(tableName, ErrorCode.ADMIN_TABLE_NOT_ALLOWED)
+        ensureTableExists(safeTable)
+
+        if (values.isEmpty()) throw DigdaException(ErrorCode.ADMIN_NO_FIELDS_TO_UPDATE)
+
+        val columnTypes = fetchColumnTypes(safeTable)
+        val safeValues = values.mapKeys { (k, _) -> requireKnownColumn(k, columnTypes) }
+
+        val cols = safeValues.keys.joinToString(", ") { "`$it`" }
+        val placeholders = safeValues.keys.joinToString(", ") { "?" }
+        val sql = "INSERT INTO `$safeTable` ($cols) VALUES ($placeholders)"
+
+        val params = safeValues.entries.map { (col, raw) -> convertValue(raw, columnTypes.getValue(col)) }
+        return jdbcTemplate.update(sql, *params.toTypedArray())
+    }
+
+    @Transactional
+    override fun updateRow(
+        tableName: String,
+        pkValues: Map<String, String>,
+        values: Map<String, String?>
+    ): Int {
+        val safeTable = validateIdentifier(tableName, ErrorCode.ADMIN_TABLE_NOT_ALLOWED)
+        ensureTableExists(safeTable)
+
+        val pkColumns = fetchPrimaryKeyColumns(safeTable)
+        if (pkColumns.isEmpty()) throw DigdaException(ErrorCode.ADMIN_PK_NOT_FOUND)
+
+        val columnTypes = fetchColumnTypes(safeTable)
+        validatePkValues(pkColumns, pkValues)
+
+        // PK 컬럼은 update 대상에서 제외 (안전)
+        val updateValues = values
+            .mapKeys { (k, _) -> requireKnownColumn(k, columnTypes) }
+            .filterKeys { it !in pkColumns }
+
+        if (updateValues.isEmpty()) throw DigdaException(ErrorCode.ADMIN_NO_FIELDS_TO_UPDATE)
+
+        val setClause = updateValues.keys.joinToString(", ") { "`$it` = ?" }
+        val whereClause = pkColumns.joinToString(" AND ") { "`$it` = ?" }
+        val sql = "UPDATE `$safeTable` SET $setClause WHERE $whereClause"
+
+        val setParams = updateValues.entries.map { (col, raw) -> convertValue(raw, columnTypes.getValue(col)) }
+        val whereParams = pkColumns.map { convertValue(pkValues.getValue(it), columnTypes.getValue(it)) }
+        val affected = jdbcTemplate.update(sql, *(setParams + whereParams).toTypedArray())
+
+        return verifySingleRow(affected)
+    }
+
+    @Transactional
+    override fun deleteRow(tableName: String, pkValues: Map<String, String>): Int {
+        val safeTable = validateIdentifier(tableName, ErrorCode.ADMIN_TABLE_NOT_ALLOWED)
+        ensureTableExists(safeTable)
+
+        val pkColumns = fetchPrimaryKeyColumns(safeTable)
+        if (pkColumns.isEmpty()) throw DigdaException(ErrorCode.ADMIN_PK_NOT_FOUND)
+
+        val columnTypes = fetchColumnTypes(safeTable)
+        validatePkValues(pkColumns, pkValues)
+
+        val whereClause = pkColumns.joinToString(" AND ") { "`$it` = ?" }
+        val sql = "DELETE FROM `$safeTable` WHERE $whereClause"
+
+        val params = pkColumns.map { convertValue(pkValues.getValue(it), columnTypes.getValue(it)) }
+        val affected = jdbcTemplate.update(sql, *params.toTypedArray())
+
+        return verifySingleRow(affected)
+    }
+
+    // ---- helpers ----
+
     private fun validateIdentifier(value: String, errorCode: ErrorCode): String {
-        if (!IDENTIFIER_REGEX.matches(value)) {
-            throw DigdaException(errorCode)
-        }
+        if (!IDENTIFIER_REGEX.matches(value)) throw DigdaException(errorCode)
         return value
     }
 
@@ -131,22 +196,109 @@ class AdminDbServiceImpl(
             """.trimIndent(),
             Int::class.java,
             tableName
+        ) ?: 0
+        if (exists == 0) throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
+    }
+
+    private fun fetchColumnNames(tableName: String): List<String> =
+        jdbcTemplate.query(
+            """
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            ORDER BY ORDINAL_POSITION
+            """.trimIndent(),
+            { rs, _ -> rs.getString("COLUMN_NAME") },
+            tableName
         )
-        if (exists == null || exists == 0) {
-            throw DigdaException(ErrorCode.ADMIN_TABLE_NOT_FOUND)
+
+    private fun fetchColumnTypes(tableName: String): Map<String, String> {
+        val rows = jdbcTemplate.query(
+            """
+            SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            """.trimIndent(),
+            { rs, _ -> rs.getString("COLUMN_NAME") to rs.getString("DATA_TYPE") },
+            tableName
+        )
+        return rows.toMap()
+    }
+
+    private fun fetchPrimaryKeyColumns(tableName: String): List<String> =
+        jdbcTemplate.query(
+            """
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = 'PRIMARY'
+            ORDER BY ORDINAL_POSITION
+            """.trimIndent(),
+            { rs, _ -> rs.getString("COLUMN_NAME") },
+            tableName
+        )
+
+    private fun requireKnownColumn(name: String, columnTypes: Map<String, String>): String {
+        val safe = validateIdentifier(name, ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
+        if (safe !in columnTypes) throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
+        return safe
+    }
+
+    private fun validatePkValues(pkColumns: List<String>, pkValues: Map<String, String>) {
+        for (col in pkColumns) {
+            if (pkValues[col].isNullOrBlank()) throw DigdaException(ErrorCode.ADMIN_PK_VALUE_MISSING)
         }
+    }
+
+    private fun verifySingleRow(affected: Int): Int {
+        when {
+            affected == 0 -> throw DigdaException(ErrorCode.ADMIN_ROW_NOT_FOUND)
+            affected > 1 -> throw DigdaException(ErrorCode.ADMIN_ROW_AFFECTED_INVALID)
+        }
+        return affected
     }
 
     private fun buildOrderClause(columns: List<String>, orderBy: String?, direction: String?): String {
         if (orderBy.isNullOrBlank()) return ""
         val column = validateIdentifier(orderBy, ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
-        if (column !in columns) {
-            throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
-        }
+        if (column !in columns) throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
         val dir = (direction ?: "ASC").uppercase()
-        if (dir !in ALLOWED_DIRECTIONS) {
-            throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
-        }
+        if (dir !in ALLOWED_DIRECTIONS) throw DigdaException(ErrorCode.ADMIN_COLUMN_NOT_ALLOWED)
         return " ORDER BY `$column` $dir"
+    }
+
+    private fun convertValue(raw: String?, dataType: String): Any? {
+        if (raw == null) return null
+        val trimmed = raw.trim()
+        return when (dataType.lowercase()) {
+            "tinyint", "smallint", "int", "integer", "mediumint" -> trimmed.toIntOrNull() ?: trimmed
+            "bigint" -> trimmed.toLongOrNull() ?: trimmed
+            "decimal", "numeric", "float", "double", "real" -> trimmed.toDoubleOrNull() ?: trimmed
+            "bit", "boolean", "bool" -> when (trimmed.lowercase()) {
+                "true", "1" -> true
+                "false", "0" -> false
+                else -> trimmed
+            }
+            "date" -> runCatching { LocalDate.parse(trimmed) }.getOrElse { trimmed }
+            "datetime", "timestamp" -> runCatching {
+                LocalDateTime.parse(trimmed, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            }.getOrElse { trimmed }
+            "binary" ->
+                if (trimmed.length == 32 || trimmed.length == 36) {
+                    runCatching { uuidToBytes(UUID.fromString(normalizeUuid(trimmed))) }
+                        .getOrElse { trimmed }
+                } else trimmed
+            else -> trimmed
+        }
+    }
+
+    private fun normalizeUuid(raw: String): String =
+        if (raw.length == 32 && '-' !in raw) {
+            "${raw.substring(0, 8)}-${raw.substring(8, 12)}-${raw.substring(12, 16)}-${raw.substring(16, 20)}-${raw.substring(20)}"
+        } else raw
+
+    private fun uuidToBytes(uuid: UUID): ByteArray {
+        val msb = uuid.mostSignificantBits
+        val lsb = uuid.leastSignificantBits
+        val bytes = ByteArray(16)
+        for (i in 0..7) bytes[i] = (msb shr ((7 - i) * 8)).toByte()
+        for (i in 8..15) bytes[i] = (lsb shr ((15 - i) * 8)).toByte()
+        return bytes
     }
 }

--- a/src/main/kotlin/digdaserver/admin/db/presentation/controller/AdminDbController.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/controller/AdminDbController.kt
@@ -1,40 +1,42 @@
 package digdaserver.admin.db.presentation.controller
 
 import digdaserver.admin.db.application.service.AdminDbService
+import digdaserver.admin.db.presentation.dto.req.AdminUpsertRowRequest
 import digdaserver.admin.db.presentation.dto.res.AdminColumnInfoResponse
 import digdaserver.admin.db.presentation.dto.res.AdminTableInfoResponse
 import digdaserver.admin.db.presentation.dto.res.AdminTableRowsResponse
+import digdaserver.admin.db.presentation.dto.res.AdminWriteResultResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/admin/db")
-@Tag(name = "Admin - DB", description = "관리자 DB 메타/데이터 조회 API")
+@Tag(name = "Admin - DB", description = "관리자 DB 메타/데이터 조회·수정 API")
 class AdminDbController(
     private val adminDbService: AdminDbService
 ) {
 
-    @Operation(summary = "전체 테이블 목록 조회", description = "현재 스키마의 BASE TABLE 목록을 반환합니다.")
+    @Operation(summary = "전체 테이블 목록 조회")
     @GetMapping("/tables")
-    fun listTables(): ResponseEntity<List<AdminTableInfoResponse>> {
-        return ResponseEntity.ok(adminDbService.listTables())
-    }
+    fun listTables(): ResponseEntity<List<AdminTableInfoResponse>> =
+        ResponseEntity.ok(adminDbService.listTables())
 
     @Operation(summary = "테이블 컬럼 정보 조회")
     @GetMapping("/tables/{name}/columns")
-    fun listColumns(
-        @PathVariable name: String
-    ): ResponseEntity<List<AdminColumnInfoResponse>> {
-        return ResponseEntity.ok(adminDbService.listColumns(name))
-    }
+    fun listColumns(@PathVariable name: String): ResponseEntity<List<AdminColumnInfoResponse>> =
+        ResponseEntity.ok(adminDbService.listColumns(name))
 
-    @Operation(summary = "테이블 데이터 조회", description = "페이징 및 컬럼 기반 데이터 반환. size는 최대 200.")
+    @Operation(summary = "테이블 데이터 조회", description = "페이징·정렬. size 최대 200.")
     @GetMapping("/tables/{name}/rows")
     fun readRows(
         @PathVariable name: String,
@@ -42,7 +44,43 @@ class AdminDbController(
         @RequestParam(defaultValue = "20") size: Int,
         @RequestParam(required = false) orderBy: String?,
         @RequestParam(required = false) direction: String?
-    ): ResponseEntity<AdminTableRowsResponse> {
-        return ResponseEntity.ok(adminDbService.readRows(name, page, size, orderBy, direction))
+    ): ResponseEntity<AdminTableRowsResponse> =
+        ResponseEntity.ok(adminDbService.readRows(name, page, size, orderBy, direction))
+
+    @Operation(summary = "행 추가", description = "values 맵의 컬럼만 INSERT.")
+    @PostMapping("/tables/{name}/rows")
+    fun insertRow(
+        @PathVariable name: String,
+        @RequestBody request: AdminUpsertRowRequest
+    ): ResponseEntity<AdminWriteResultResponse> {
+        val affected = adminDbService.insertRow(name, request.values)
+        return ResponseEntity.ok(AdminWriteResultResponse(affected = affected))
+    }
+
+    @Operation(
+        summary = "행 수정",
+        description = "PK로만 매칭. PK 컬럼은 변경 불가, values에 PK 포함되어도 무시됨. 1행 영향 강제."
+    )
+    @PatchMapping("/tables/{name}/rows")
+    fun updateRow(
+        @PathVariable name: String,
+        @RequestParam pk: Map<String, String>,
+        @RequestBody request: AdminUpsertRowRequest
+    ): ResponseEntity<AdminWriteResultResponse> {
+        val affected = adminDbService.updateRow(name, pk, request.values)
+        return ResponseEntity.ok(AdminWriteResultResponse(affected = affected))
+    }
+
+    @Operation(
+        summary = "행 삭제",
+        description = "PK로만 매칭. WHERE 없는 전체 삭제 불가. 1행 영향 강제."
+    )
+    @DeleteMapping("/tables/{name}/rows")
+    fun deleteRow(
+        @PathVariable name: String,
+        @RequestParam pk: Map<String, String>
+    ): ResponseEntity<AdminWriteResultResponse> {
+        val affected = adminDbService.deleteRow(name, pk)
+        return ResponseEntity.ok(AdminWriteResultResponse(affected = affected))
     }
 }

--- a/src/main/kotlin/digdaserver/admin/db/presentation/dto/req/AdminUpsertRowRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/dto/req/AdminUpsertRowRequest.kt
@@ -1,0 +1,13 @@
+package digdaserver.admin.db.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "테이블 행 생성/수정 요청")
+data class AdminUpsertRowRequest(
+
+    @Schema(
+        description = "컬럼명 → 값 (값은 문자열로 전달, 서버가 컬럼 타입에 맞게 변환). null 컬럼은 \"NULL\" 대신 JSON null 사용",
+        example = """{"name":"홍길동","age":"20"}"""
+    )
+    val values: Map<String, String?>
+)

--- a/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminWriteResultResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/db/presentation/dto/res/AdminWriteResultResponse.kt
@@ -1,0 +1,10 @@
+package digdaserver.admin.db.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "테이블 쓰기 작업 결과")
+data class AdminWriteResultResponse(
+
+    @Schema(description = "영향받은 행 수")
+    val affected: Int
+)

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -103,5 +103,10 @@ enum class ErrorCode(
     NOT_ADMIN_USER("NOT_ADMIN_USER", "관리자 권한이 없는 사용자입니다.", 403),
     ADMIN_TABLE_NOT_ALLOWED("ADMIN_TABLE_NOT_ALLOWED", "조회할 수 없는 테이블명입니다.", 400),
     ADMIN_TABLE_NOT_FOUND("ADMIN_TABLE_NOT_FOUND", "존재하지 않는 테이블입니다.", 404),
-    ADMIN_COLUMN_NOT_ALLOWED("ADMIN_COLUMN_NOT_ALLOWED", "유효하지 않은 컬럼명입니다.", 400);
+    ADMIN_COLUMN_NOT_ALLOWED("ADMIN_COLUMN_NOT_ALLOWED", "유효하지 않은 컬럼명입니다.", 400),
+    ADMIN_PK_NOT_FOUND("ADMIN_PK_NOT_FOUND", "테이블에 PK가 없어 단일 행 수정/삭제가 불가합니다.", 400),
+    ADMIN_PK_VALUE_MISSING("ADMIN_PK_VALUE_MISSING", "PK 값이 누락되었습니다.", 400),
+    ADMIN_ROW_NOT_FOUND("ADMIN_ROW_NOT_FOUND", "해당 PK의 행을 찾을 수 없습니다.", 404),
+    ADMIN_ROW_AFFECTED_INVALID("ADMIN_ROW_AFFECTED_INVALID", "행 수정/삭제에서 1행이 아닌 결과가 발생했습니다.", 500),
+    ADMIN_NO_FIELDS_TO_UPDATE("ADMIN_NO_FIELDS_TO_UPDATE", "수정할 컬럼이 없습니다.", 400);
 }


### PR DESCRIPTION
## Summary
어드민이 DB 도구 없이도 데이터를 직접 수정/삭제할 수 있도록 행 단위 mutation API 추가. PK 기반 단일행 조작만 허용하여 사고 방지.

## 추가 엔드포인트
- \`POST   /api/admin/db/tables/{name}/rows\` — body: \`{ values: { col: value } }\`
- \`PATCH  /api/admin/db/tables/{name}/rows?pk[col]=val\` — body: \`{ values: {...} }\`
- \`DELETE /api/admin/db/tables/{name}/rows?pk[col]=val\`

## 안전 가드
1. **식별자 화이트리스트**: 테이블/컬럼명은 정규식 + \`INFORMATION_SCHEMA\` 존재 검증 → SQL 주입 차단
2. **PK 자동 발견**: \`KEY_COLUMN_USAGE\`에서 PK 조회, 복합 PK 지원
3. **WHERE 없는 mutation 차단**: update/delete는 항상 PK 조건 강제
4. **1행 영향 강제**: update/delete가 0행이면 NOT_FOUND, 2+이면 INVALID(롤백)
5. **PK 변경 차단**: update의 values에 PK가 들어와도 자동 제외
6. **타입 변환**: \`DATA_TYPE\` 기준 int/bigint/decimal/date/datetime/binary(UUID) 자동 변환
7. **Bind parameter**: 모든 값은 \`JdbcTemplate\` placeholder로만 바인딩

## ErrorCode 신규
\`ADMIN_PK_NOT_FOUND\`, \`ADMIN_PK_VALUE_MISSING\`, \`ADMIN_ROW_NOT_FOUND\`, \`ADMIN_ROW_AFFECTED_INVALID\`, \`ADMIN_NO_FIELDS_TO_UPDATE\`

## Test plan
- [ ] 일반 테이블 INSERT 1행 → affected=1
- [ ] PK 기반 PATCH → 1행 수정
- [ ] 존재하지 않는 PK로 PATCH/DELETE → 404 ADMIN_ROW_NOT_FOUND
- [ ] PK 없는 테이블에 PATCH/DELETE → 400 ADMIN_PK_NOT_FOUND
- [ ] 잘못된 컬럼명 / 테이블명 → 400 ADMIN_TABLE/COLUMN_NOT_ALLOWED
- [ ] FK 위반 시 DB 예외 그대로 노출 (롤백)
- [ ] BINARY(16) UUID 컬럼에 36자 문자열 PK 전달 → 정상 매칭

🤖 Generated with [Claude Code](https://claude.com/claude-code)