### PR TITLE
[Feature] 관리자 공지 목록 조회 API + 발송 이력 영속화

### DIFF
--- a/docs/API_SPECIFICATION.md
+++ b/docs/API_SPECIFICATION.md
@@ -1,8 +1,8 @@
-# 📘 API 명세서 — DigDa (그룹 다이어리)
+# API 명세서 — DigDa (그룹 다이어리)
 
 ---
 
-## 📌 개요
+## 개요
 
 **프로젝트**: DigDa — 그룹 기반 공유 다이어리 앱
 **플랫폼**: Flutter (iOS/Android)
@@ -14,13 +14,13 @@
 
 | 앱 용어 | API 도메인명 | 리소스 경로 | 설명 |
 |---------|-------------|------------|------|
-| 그룹 (방) | **Group** | `/groups` | 다이어리 방 단위 |
-| 일기 (글) | **Diary** | `/groups/:id/diaries` | 개별 일기 글 |
-| 구성원 | **Membership** | `/groups/:id/memberships` | 그룹 내 구성원 관리 |
+| 그룹방 (방) | **GroupRoom** | `/group-rooms` | 다이어리 방 단위 |
+| 일기 (글) | **Diary** | `/group-rooms/:id/diaries` | 개별 일기 글 |
+| 구성원 | **Membership** | `/group-rooms/:id/memberships` | 그룹방 내 구성원 관리 |
 | 사용자 | **User** | `/users` | 로그인한 사용자 본인 |
 
 > **왜 Member가 아니라 Membership인가?**
-> `User`는 "나 자신"의 프로필/설정, `Membership`은 "특정 그룹 안에서의 소속 관계"를 의미합니다.
+> `User`는 "나 자신"의 프로필/설정, `Membership`은 "특정 그룹방 안에서의 소속 관계"를 의미합니다.
 > Member라고 하면 User와 혼동되므로, 관계(소속)를 나타내는 Membership으로 명명합니다.
 
 ### API 설계 기준
@@ -32,41 +32,42 @@
 | 페이지네이션 | Offset 기반 (`?limit=20&offset=0`) |
 | 에러 응답 | `{ "error": { "code": "...", "message": "..." } }` |
 | 이미지 업로드 | Multipart form-data |
-| 삭제 전략 | 그룹: Soft Delete (7일 복구), 나머지: Hard Delete |
-| 권한 체크 | 그룹 구성원 여부 → 리소스 소유자/방장 여부 순서 |
+| 삭제 전략 | 그룹방: Soft Delete (7일 복구), 나머지: Hard Delete |
+| 권한 체크 | 그룹방 구성원 여부 → 리소스 소유자/방장 여부 순서 |
 | HTTP 메서드 | GET(조회), POST(생성), PUT(전체수정), PATCH(부분수정), DELETE(삭제) |
 
 ---
 
-## 📂 도메인 목록
+## 도메인 목록
 
 | # | 도메인 | 브랜치 | 엔드포인트 수 | 설명 |
 |---|--------|--------|:---:|------|
 | 1 | Auth | `feature/auth-api` | 6 | 소셜 로그인, 토큰 갱신, 약관 동의, 로그아웃, 회원 탈퇴 |
 | 2 | User | `feature/user-api` | 6 | 프로필 조회/수정, 알림 설정, 개인정보 설정 |
-| 3 | Group | `feature/group-api` | 6 | 그룹(방) 생성, 조회, 수정, 삭제, 복구 |
+| 3 | GroupRoom | `feature/group-room-api` | 6 | 그룹방 생성, 조회, 수정, 삭제, 복구 |
 | 4 | Invite | `feature/invite-api` | 3 | 초대 코드 생성, 검증, 참여 |
 | 5 | Membership | `feature/membership-api` | 4 | 구성원 목록, 내보내기, 역할 변경, 탈퇴 |
 | 6 | Schedule | `feature/schedule-api` | 5 | 일정 CRUD, 참여자 관리 |
 | 7 | Diary | `feature/diary-api` | 6 | 일기 CRUD, 이미지 첨부, 캘린더 조회 |
-| 8 | Comment | `feature/comment-api` | 4 | 일정·일기 댓글 작성/삭제 |
+| 8 | Comment | `feature/comment-api` | 4 | 일정/일기 댓글 작성/삭제 |
 | 9 | Todo | `feature/todo-api` | 4 | 할 일 CRUD, 완료 토글 |
 | 10 | Notification | `feature/notification-api` | 4 | 알림 목록, 읽음 처리, 삭제 |
 | 11 | Device | `feature/device-api` | 2 | 푸시 알림용 디바이스 토큰 등록/해제 |
-| 12 | Upload | `feature/upload-api` | 2 | 이미지 업로드 (단일/다중) |
-| | | **합계** | **52** | |
+| 12 | Upload | `feature/upload-api` | 1 | 이미지 업로드 (단일) |
+| 13 | Admin | `feature/admin-api` | 22 | 관리자 로그인, 대시보드, 도메인 관리, DB 조회/편집, 로그, 공지 발송/조회 |
+| | | **합계** | **73** | |
 
 ---
 
-## 📦 도메인별 상세
+## 도메인별 상세
 
 ---
 
-### 🔐 1. Auth (인증)
+### 1. Auth (인증)
 
 - **브랜치**: `feature/auth-api`
 - **설명**: 소셜 로그인, 온보딩(약관 동의), JWT 토큰 관리, 로그아웃, 회원 탈퇴
-- **인증 필요**: 로그인·약관조회 제외 전부
+- **인증 필요**: 로그인/약관조회/토큰갱신 제외 전부
 
 ---
 
@@ -81,8 +82,8 @@
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| provider | string | ✅ | `kakao` · `naver` · `apple` |
-| accessToken | string | ✅ | 소셜 프로바이더 액세스 토큰 |
+| provider | string | O | `kakao` / `naver` / `apple` |
+| accessToken | string | O | 소셜 프로바이더 액세스 토큰 |
 | idToken | string | 조건부 | Apple Sign In 시 필수 |
 
 **Response** `200 OK`
@@ -106,17 +107,13 @@
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| termsOfService | boolean | ✅ | 이용약관 동의 (필수) |
-| privacyPolicy | boolean | ✅ | 개인정보처리방침 동의 (필수) |
-| ageConfirmation | boolean | ✅ | 만 14세 이상 확인 (필수) |
-| marketingConsent | boolean | ❌ | 마케팅 수신 동의 (선택) |
-| pushConsent | boolean | ❌ | 푸시 알림 수신 동의 (선택) |
+| termsOfService | boolean | O | 이용약관 동의 (필수) |
+| privacyPolicy | boolean | O | 개인정보처리방침 동의 (필수) |
+| ageConfirmation | boolean | O | 만 14세 이상 확인 (필수) |
+| marketingConsent | boolean | - | 마케팅 수신 동의 (선택) |
+| pushConsent | boolean | - | 푸시 알림 수신 동의 (선택) |
 
 **Response** `200 OK`
-
-| 필드 | 타입 | 설명 |
-|------|------|------|
-| user | User | 약관 동의 완료된 사용자 정보 |
 
 **에러 케이스**
 
@@ -136,7 +133,7 @@
 
 | 파라미터 | 설명 |
 |----------|------|
-| type | `terms-of-service` · `privacy-policy` · `marketing` |
+| type | `terms-of-service` / `privacy-policy` / `marketing` |
 
 **Response** `200 OK`
 
@@ -157,7 +154,7 @@
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| refreshToken | string | ✅ | 기존 리프레시 토큰 |
+| refreshToken | string | O | 기존 리프레시 토큰 |
 
 **Response** `200 OK`
 
@@ -179,9 +176,9 @@
 
 **POST** `/auth/logout`
 
-서버 측 리프레시 토큰 무효화 + 디바이스 토큰 해제.
+서버 측 리프레시 토큰 무효화 + 소셜 토큰 삭제.
 
-**Response** `204 No Content`
+**Response** `200 OK`
 
 ---
 
@@ -189,22 +186,22 @@
 
 **DELETE** `/auth/account`
 
-계정 영구 삭제. 소유 중인 그룹이 있으면 먼저 양도 필요.
+계정 영구 삭제. 소유 중인 그룹방이 있으면 먼저 양도 필요.
 
-**Response** `204 No Content`
+**Response** `200 OK`
 
 **에러 케이스**
 
 | 코드 | HTTP | 상황 |
 |------|:---:|------|
-| `OWNS_ACTIVE_GROUP` | 409 | 소유 중인 그룹이 있어 탈퇴 불가. 방장 양도 후 재시도. |
+| `OWNS_ACTIVE_GROUP_ROOM` | 409 | 소유 중인 그룹방이 있어 탈퇴 불가. 방장 양도 후 재시도. |
 
 ---
 
-### 👤 2. User (사용자)
+### 2. User (사용자)
 
 - **브랜치**: `feature/user-api`
-- **설명**: 내 프로필 조회·수정, 알림 설정, 개인정보 설정
+- **설명**: 내 프로필 조회/수정, 알림 설정, 개인정보 설정
 - **인증 필요**: 전부
 
 ---
@@ -222,7 +219,7 @@
 | email | string? | 소셜 계정 이메일 (nullable — provider가 미제공 시 null) |
 | profileImage | string? | 프로필 이미지 URL (null이면 기본 아바타) |
 | statusMessage | string? | 상태 메시지 (최대 100자) |
-| provider | string | `kakao` · `naver` · `apple` · `admin` |
+| provider | string | `kakao` / `naver` / `apple` / `admin` |
 | createdAt | string | 가입일 |
 
 ---
@@ -235,9 +232,9 @@
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| name | string | ❌ | 닉네임 (2~20자) |
-| statusMessage | string? | ❌ | 상태 메시지 (빈 문자열 = 삭제, 최대 100자) |
-| profileImageId | string? | ❌ | Upload API로 받은 이미지 ID (null = 기본 아바타로 초기화) |
+| name | string | - | 닉네임 (2~20자) |
+| statusMessage | string? | - | 상태 메시지 (빈 문자열 = 삭제, 최대 100자) |
+| profileImageId | string? | - | Upload API로 받은 이미지 ID (null = 기본 아바타로 초기화) |
 
 **Response** `200 OK` — 수정된 User 객체
 
@@ -300,18 +297,18 @@
 
 ---
 
-### 🏠 3. Group (그룹)
+### 3. GroupRoom (그룹방)
 
-- **브랜치**: `feature/group-api`
-- **설명**: 다이어리 그룹(방) 생성, 목록 조회, 상세 조회, 수정, 삭제(Soft Delete 7일), 복구
+- **브랜치**: `feature/group-room-api`
+- **설명**: 그룹방 생성, 목록 조회, 상세 조회, 수정, 삭제(Soft Delete 7일), 복구
 - **인증 필요**: 전부
 - **권한**: 수정/삭제/복구는 방장(owner)만
 
 ---
 
-#### 3-1. 그룹 생성
+#### 3-1. 그룹방 생성
 
-**POST** `/groups`
+**POST** `/group-rooms`
 
 생성 시 초대 코드 자동 발급. 생성자가 방장(owner)이 됨.
 
@@ -319,65 +316,65 @@
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| name | string | ✅ | 그룹명 (2~20자) |
-| maxMembers | int | ✅ | 최대 인원 (2~99) |
-| thumbnailImageId | string | ❌ | Upload API로 받은 이미지 ID |
+| name | string | O | 그룹방명 (2~20자) |
+| maxMembers | int | O | 최대 인원 (2~99) |
+| thumbnailImageId | string | - | Upload API로 받은 이미지 ID |
 
 **Response** `201 Created`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| group | Group | 생성된 그룹 |
+| groupRoom | GroupRoom | 생성된 그룹방 |
 | inviteCode | string | 자동 발급된 6자리 초대 코드 |
 | inviteCodeExpiresAt | string | 초대 코드 만료 시각 (24시간 후) |
 
 ---
 
-#### 3-2. 내 그룹 목록
+#### 3-2. 내 그룹방 목록
 
-**GET** `/groups`
+**GET** `/group-rooms`
 
-내가 속한 모든 그룹. 최근 활동순 정렬.
+내가 속한 모든 그룹방. 최근 활동순 정렬.
 
 **Response** `200 OK`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| groups | GroupListItem[] | 그룹 배열 |
+| groupRooms | GroupRoomListItem[] | 그룹방 배열 |
 
-GroupListItem 객체:
+GroupRoomListItem 객체:
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| id | string | 그룹 ID |
-| name | string | 그룹명 |
+| id | string | 그룹방 ID |
+| name | string | 그룹방명 |
 | thumbnailImage | string? | 썸네일 이미지 URL |
 | memberCount | int | 현재 구성원 수 |
 | maxMembers | int | 최대 인원 |
-| myRole | string | 내 역할 (`owner` · `member`) |
+| myRole | string | 내 역할 (`owner` / `member`) |
 | lastActivityAt | string | 마지막 활동 시각 |
 | isDeleteScheduled | boolean | 삭제 예약 여부 |
 
 ---
 
-#### 3-3. 그룹 상세 조회
+#### 3-3. 그룹방 상세 조회
 
-**GET** `/groups/:groupId`
+**GET** `/group-rooms/:groupRoomId`
 
 **Response** `200 OK`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| group | Group | 그룹 정보 |
+| groupRoom | GroupRoom | 그룹방 정보 |
 | memberships | MembershipSummary[] | 구성원 목록 (간략) |
 | myRole | string | 내 역할 |
 | inviteCode | string? | 현재 유효한 초대 코드 (방장에게만 노출) |
 
 ---
 
-#### 3-4. 그룹 수정
+#### 3-4. 그룹방 수정
 
-**PUT** `/groups/:groupId`
+**PUT** `/group-rooms/:groupRoomId`
 
 방장만 가능.
 
@@ -385,11 +382,11 @@ GroupListItem 객체:
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| name | string | ❌ | 그룹명 (2~20자) |
-| maxMembers | int | ❌ | 최대 인원 (현재 구성원 수 이상이어야 함) |
-| thumbnailImageId | string? | ❌ | 새 썸네일 이미지 ID (null = 삭제) |
+| name | string | - | 그룹방명 (2~20자) |
+| maxMembers | int | - | 최대 인원 (현재 구성원 수 이상이어야 함) |
+| thumbnailImageId | string? | - | 새 썸네일 이미지 ID (null = 삭제) |
 
-**Response** `200 OK` — 수정된 Group 객체
+**Response** `200 OK` — 수정된 GroupRoom 객체
 
 **에러 케이스**
 
@@ -399,9 +396,9 @@ GroupListItem 객체:
 
 ---
 
-#### 3-5. 그룹 삭제 (Soft Delete)
+#### 3-5. 그룹방 삭제 (Soft Delete)
 
-**DELETE** `/groups/:groupId`
+**DELETE** `/group-rooms/:groupRoomId`
 
 방장만 가능. 즉시 삭제가 아닌 7일 후 영구 삭제 예약.
 
@@ -413,34 +410,34 @@ GroupListItem 객체:
 
 ---
 
-#### 3-6. 그룹 복구
+#### 3-6. 그룹방 복구
 
-**POST** `/groups/:groupId/recover`
+**POST** `/group-rooms/:groupRoomId/recover`
 
 방장만 가능. 삭제 예약 기간(7일) 내에만 복구 가능.
 
-**Response** `200 OK` — 복구된 Group 객체
+**Response** `200 OK` — 복구된 GroupRoom 객체
 
 **에러 케이스**
 
 | 코드 | HTTP | 상황 |
 |------|:---:|------|
-| `GROUP_NOT_SCHEDULED_FOR_DELETION` | 400 | 삭제 예약되지 않은 그룹 |
-| `GROUP_ALREADY_DELETED` | 410 | 이미 영구 삭제됨 |
+| `GROUP_ROOM_NOT_SCHEDULED_FOR_DELETION` | 400 | 삭제 예약되지 않은 그룹방 |
+| `GROUP_ROOM_ALREADY_DELETED` | 410 | 이미 영구 삭제됨 |
 
 ---
 
-### 🔗 4. Invite (초대)
+### 4. Invite (초대)
 
 - **브랜치**: `feature/invite-api`
-- **설명**: 초대 코드 생성·검증·참여
+- **설명**: 초대 코드 생성/검증/참여
 - **인증 필요**: 전부
 
 ---
 
 #### 4-1. 초대 코드 생성 (재발급)
 
-**POST** `/groups/:groupId/invites`
+**POST** `/group-rooms/:groupRoomId/invites`
 
 방장만 가능. 기존 코드 무효화 후 새 코드 발급. 유효기간 24시간.
 
@@ -457,19 +454,19 @@ GroupListItem 객체:
 
 **POST** `/invites/validate`
 
-코드 입력 시 그룹 미리보기. 참여 전 확인용.
+코드 입력 시 그룹방 미리보기. 참여 전 확인용.
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| code | string | ✅ | 6자리 초대 코드 |
+| code | string | O | 6자리 초대 코드 |
 
 **Response** `200 OK`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| groupName | string | 그룹명 |
+| groupRoomName | string | 그룹방명 |
 | thumbnailImage | string? | 썸네일 이미지 URL |
 | memberCount | int | 현재 구성원 수 |
 | maxMembers | int | 최대 인원 |
@@ -481,8 +478,8 @@ GroupListItem 객체:
 |------|:---:|------|
 | `INVITE_CODE_INVALID` | 404 | 존재하지 않는 코드 |
 | `INVITE_CODE_EXPIRED` | 410 | 만료된 코드 |
-| `GROUP_FULL` | 409 | 인원 초과 |
-| `ALREADY_JOINED` | 409 | 이미 참여 중인 그룹 |
+| `GROUP_ROOM_FULL` | 409 | 인원 초과 |
+| `ALREADY_JOINED` | 409 | 이미 참여 중인 그룹방 |
 
 ---
 
@@ -494,23 +491,23 @@ GroupListItem 객체:
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| code | string | ✅ | 6자리 초대 코드 |
+| code | string | O | 6자리 초대 코드 |
 
 **Response** `200 OK`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| group | Group | 참여한 그룹 정보 |
+| groupRoom | GroupRoom | 참여한 그룹방 정보 |
 | memberships | MembershipSummary[] | 전체 구성원 목록 |
 
 > 참여 성공 시 기존 구성원에게 `member_joined` 푸시 알림 발송
 
 ---
 
-### 👥 5. Membership (구성원 관리)
+### 5. Membership (구성원 관리)
 
 - **브랜치**: `feature/membership-api`
-- **설명**: 그룹 내 구성원 목록 조회, 내보내기(추방), 역할 변경(방장 양도), 자발적 탈퇴
+- **설명**: 그룹방 내 구성원 목록 조회, 내보내기(추방), 역할 변경(방장 양도), 자발적 탈퇴
 - **인증 필요**: 전부
 - **권한**: 내보내기/역할 변경은 방장만
 
@@ -518,7 +515,7 @@ GroupListItem 객체:
 
 #### 5-1. 구성원 목록
 
-**GET** `/groups/:groupId/memberships`
+**GET** `/group-rooms/:groupRoomId/memberships`
 
 **Response** `200 OK`
 
@@ -534,14 +531,14 @@ Membership 객체:
 | name | string | 닉네임 |
 | profileImage | string? | 프로필 이미지 URL |
 | color | string | 구성원 컬러 (hex, 캘린더 표시용) |
-| role | string | `owner` · `member` |
+| role | string | `owner` / `member` |
 | joinedAt | string | 참여일 |
 
 ---
 
 #### 5-2. 구성원 내보내기 (추방)
 
-**DELETE** `/groups/:groupId/memberships/:userId`
+**DELETE** `/group-rooms/:groupRoomId/memberships/:userId`
 
 방장만 가능. 클라이언트에서 2단계 확인 UI 처리.
 
@@ -554,13 +551,13 @@ Membership 객체:
 | 코드 | HTTP | 상황 |
 |------|:---:|------|
 | `CANNOT_REMOVE_OWNER` | 400 | 방장은 내보낼 수 없음 |
-| `USER_NOT_IN_GROUP` | 404 | 해당 그룹 구성원이 아님 |
+| `USER_NOT_IN_GROUP_ROOM` | 404 | 해당 그룹방 구성원이 아님 |
 
 ---
 
 #### 5-3. 역할 변경 (방장 양도)
 
-**PUT** `/groups/:groupId/memberships/:userId/role`
+**PUT** `/group-rooms/:groupRoomId/memberships/:userId/role`
 
 현재 방장만 가능. 지정한 구성원에게 방장을 양도하면 기존 방장은 일반 구성원이 됨.
 
@@ -568,7 +565,7 @@ Membership 객체:
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| role | string | ✅ | `owner` (양도 대상) |
+| role | string | O | `owner` (양도 대상) |
 
 **Response** `200 OK`
 
@@ -578,9 +575,9 @@ Membership 객체:
 
 ---
 
-#### 5-4. 그룹 탈퇴
+#### 5-4. 그룹방 탈퇴
 
-**POST** `/groups/:groupId/leave`
+**POST** `/group-rooms/:groupRoomId/leave`
 
 자발적 탈퇴. 방장은 양도 후에만 탈퇴 가능.
 
@@ -594,10 +591,10 @@ Membership 객체:
 
 ---
 
-### 📅 6. Schedule (일정)
+### 6. Schedule (일정)
 
 - **브랜치**: `feature/schedule-api`
-- **설명**: 그룹 일정 CRUD, 참여자 지정, 월별 조회
+- **설명**: 그룹방 일정 CRUD, 참여자 지정, 월별 조회
 - **인증 필요**: 전부
 - **권한**: 수정/삭제는 작성자 또는 방장
 
@@ -605,14 +602,14 @@ Membership 객체:
 
 #### 6-1. 일정 목록 (기간 조회)
 
-**GET** `/groups/:groupId/schedules`
+**GET** `/group-rooms/:groupRoomId/schedules`
 
 **Query Parameters**
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |----------|------|:---:|------|
-| startDate | string | ✅ | 조회 시작일 (`2026-03-01`) |
-| endDate | string | ✅ | 조회 종료일 (`2026-03-31`) |
+| startDate | string | O | 조회 시작일 (`2026-03-01`) |
+| endDate | string | O | 조회 종료일 (`2026-03-31`) |
 
 **Response** `200 OK`
 
@@ -637,13 +634,11 @@ Schedule 객체:
 | commentCount | int | 댓글 수 |
 | createdAt | string | 작성일시 |
 
-> **색상 옵션**: `#FF6B6B`(빨강), `#A78BFA`(보라), `#60A5FA`(파랑), `#34D399`(초록), `#FB923C`(주황)
-
 ---
 
 #### 6-2. 일정 상세
 
-**GET** `/groups/:groupId/schedules/:scheduleId`
+**GET** `/group-rooms/:groupRoomId/schedules/:scheduleId`
 
 **Response** `200 OK`
 
@@ -656,24 +651,24 @@ Schedule 객체:
 
 #### 6-3. 일정 생성
 
-**POST** `/groups/:groupId/schedules`
+**POST** `/group-rooms/:groupRoomId/schedules`
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| title | string | ✅ | 제목 (1~50자) |
-| color | string | ✅ | 색상 hex |
-| startDate | string | ✅ | 시작일 (`YYYY-MM-DD`) |
-| endDate | string | ✅ | 종료일 (`YYYY-MM-DD`, 시작일 이상) |
-| startTime | string | ❌ | 시작 시간 (`HH:mm`, allDay=false일 때) |
-| endTime | string | ❌ | 종료 시간 (`HH:mm`) |
-| allDay | boolean | ✅ | 종일 여부 |
-| participantIds | string[] | ❌ | 참여자 사용자 UUID 배열 |
+| title | string | O | 제목 (1~50자) |
+| color | string | O | 색상 hex |
+| startDate | string | O | 시작일 (`YYYY-MM-DD`) |
+| endDate | string | O | 종료일 (`YYYY-MM-DD`, 시작일 이상) |
+| startTime | string | - | 시작 시간 (`HH:mm`, allDay=false일 때) |
+| endTime | string | - | 종료 시간 (`HH:mm`) |
+| allDay | boolean | O | 종일 여부 |
+| participantIds | string[] | - | 참여자 사용자 UUID 배열 |
 
 **Response** `201 Created` — Schedule 객체
 
-> 그룹 구성원에게 `schedule_created` 푸시 알림 발송
+> 그룹방 구성원에게 `schedule_created` 푸시 알림 발송
 
 **에러 케이스**
 
@@ -681,13 +676,13 @@ Schedule 객체:
 |------|:---:|------|
 | `END_DATE_BEFORE_START` | 400 | 종료일이 시작일보다 이전 |
 | `END_TIME_BEFORE_START` | 400 | 같은 날인데 종료 시간이 시작 시간보다 이전 |
-| `INVALID_PARTICIPANT` | 400 | 참여자가 그룹 구성원이 아님 |
+| `INVALID_PARTICIPANT` | 400 | 참여자가 그룹방 구성원이 아님 |
 
 ---
 
 #### 6-4. 일정 수정
 
-**PUT** `/groups/:groupId/schedules/:scheduleId`
+**PUT** `/group-rooms/:groupRoomId/schedules/:scheduleId`
 
 작성자 또는 방장만 가능. Request Body는 생성과 동일 (변경할 필드만).
 
@@ -699,7 +694,7 @@ Schedule 객체:
 
 #### 6-5. 일정 삭제
 
-**DELETE** `/groups/:groupId/schedules/:scheduleId`
+**DELETE** `/group-rooms/:groupRoomId/schedules/:scheduleId`
 
 작성자 또는 방장만 가능.
 
@@ -707,10 +702,10 @@ Schedule 객체:
 
 ---
 
-### 📓 7. Diary (일기)
+### 7. Diary (일기)
 
 - **브랜치**: `feature/diary-api`
-- **설명**: 개별 일기 글 CRUD, 이미지 첨부, 날씨·기분 선택, 캘린더용 날짜 조회
+- **설명**: 개별 일기 글 CRUD, 이미지 첨부(1장), 날씨/기분 선택, 캘린더용 날짜 조회
 - **인증 필요**: 전부
 - **권한**: 수정/삭제는 작성자 또는 방장
 
@@ -718,15 +713,15 @@ Schedule 객체:
 
 #### 7-1. 일기 목록 (최신순)
 
-**GET** `/groups/:groupId/diaries`
+**GET** `/group-rooms/:groupRoomId/diaries`
 
 **Query Parameters**
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |----------|------|:---:|------|
-| month | string | ❌ | 월 필터 (`2026-03`) |
-| limit | int | ❌ | 페이지 크기 (기본 20, 최대 100) |
-| offset | int | ❌ | 오프셋 (기본 0) |
+| month | string | - | 월 필터 (`2026-03`) |
+| limit | int | - | 페이지 크기 (기본 20, 최대 100) |
+| offset | int | - | 오프셋 (기본 0) |
 
 **Response** `200 OK`
 
@@ -744,7 +739,7 @@ DiarySummary 객체:
 | date | string | 날짜 |
 | weather | int | 날씨 (0=맑음, 1=흐림, 2=비, 3=눈) |
 | mood | int | 기분 (0=행복, 1=사랑, 2=웃음, 3=뿌듯) |
-| thumbnailImage | string? | 첫 번째 이미지 URL (썸네일용) |
+| imageUrl | string? | 이미지 URL (썸네일용) |
 | createdBy | UserSummary | 작성자 |
 | commentCount | int | 댓글 수 |
 | createdAt | string | 작성일시 |
@@ -753,7 +748,7 @@ DiarySummary 객체:
 
 #### 7-2. 일기 캘린더 (날짜별 존재 여부)
 
-**GET** `/groups/:groupId/diaries/calendar`
+**GET** `/group-rooms/:groupRoomId/diaries/calendar`
 
 캘린더에 dot marker를 표시하기 위한 경량 API.
 
@@ -761,7 +756,7 @@ DiarySummary 객체:
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |----------|------|:---:|------|
-| month | string | ✅ | 조회 월 (`2026-03`) |
+| month | string | O | 조회 월 (`2026-03`) |
 
 **Response** `200 OK`
 
@@ -773,7 +768,7 @@ DiarySummary 객체:
 
 #### 7-3. 일기 상세
 
-**GET** `/groups/:groupId/diaries/:diaryId`
+**GET** `/group-rooms/:groupRoomId/diaries/:diaryId`
 
 **Response** `200 OK`
 
@@ -792,7 +787,7 @@ Diary 객체:
 | date | string | 날짜 |
 | weather | int | 날씨 |
 | mood | int | 기분 |
-| images | string[] | 이미지 URL 배열 |
+| imageUrl | string? | 이미지 URL |
 | createdBy | UserSummary | 작성자 |
 | createdAt | string | 작성일시 |
 | updatedAt | string | 수정일시 |
@@ -801,22 +796,22 @@ Diary 객체:
 
 #### 7-4. 일기 작성
 
-**POST** `/groups/:groupId/diaries`
+**POST** `/group-rooms/:groupRoomId/diaries`
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| title | string | ✅ | 제목 (1~20자) |
-| content | string | ✅ | 본문 (1~300자) |
-| date | string | ✅ | 날짜 (`YYYY-MM-DD`, 오늘 이전만 가능) |
-| weather | int | ✅ | 0~3 |
-| mood | int | ✅ | 0~3 |
-| imageIds | string[] | ❌ | Upload API로 받은 이미지 ID 배열 (최대 5장) |
+| title | string | O | 제목 (1~20자) |
+| content | string | O | 본문 (1~300자) |
+| date | string | O | 날짜 (`YYYY-MM-DD`, 오늘 이전만 가능) |
+| weather | int | O | 0~3 |
+| mood | int | O | 0~3 |
+| imageId | string? | - | Upload API로 받은 이미지 ID (1장) |
 
 **Response** `201 Created` — Diary 객체
 
-> 그룹 구성원에게 `diary_written` 푸시 알림 발송
+> 그룹방 구성원에게 `diary_written` 푸시 알림 발송
 
 **에러 케이스**
 
@@ -825,13 +820,12 @@ Diary 객체:
 | `FUTURE_DATE_NOT_ALLOWED` | 400 | 미래 날짜에 일기 작성 시도 |
 | `INVALID_WEATHER_VALUE` | 400 | weather가 0~3 범위 밖 |
 | `INVALID_MOOD_VALUE` | 400 | mood가 0~3 범위 밖 |
-| `TOO_MANY_IMAGES` | 400 | 이미지 5장 초과 |
 
 ---
 
 #### 7-5. 일기 수정
 
-**PUT** `/groups/:groupId/diaries/:diaryId`
+**PUT** `/group-rooms/:groupRoomId/diaries/:diaryId`
 
 작성자 또는 방장만 가능. Request Body는 작성과 동일 (변경할 필드만).
 
@@ -841,7 +835,7 @@ Diary 객체:
 
 #### 7-6. 일기 삭제
 
-**DELETE** `/groups/:groupId/diaries/:diaryId`
+**DELETE** `/group-rooms/:groupRoomId/diaries/:diaryId`
 
 작성자 또는 방장만 가능.
 
@@ -849,10 +843,10 @@ Diary 객체:
 
 ---
 
-### 💬 8. Comment (댓글)
+### 8. Comment (댓글)
 
 - **브랜치**: `feature/comment-api`
-- **설명**: 일정·일기에 댓글 작성/삭제
+- **설명**: 일정/일기에 댓글 작성/삭제
 - **인증 필요**: 전부
 - **권한**: 삭제는 댓글 작성자 또는 방장
 
@@ -860,13 +854,13 @@ Diary 객체:
 
 #### 8-1. 일정 댓글 작성
 
-**POST** `/groups/:groupId/schedules/:scheduleId/comments`
+**POST** `/group-rooms/:groupRoomId/schedules/:scheduleId/comments`
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| text | string | ✅ | 댓글 내용 (1~200자) |
+| text | string | O | 댓글 내용 (1~200자) |
 
 **Response** `201 Created`
 
@@ -883,7 +877,7 @@ Diary 객체:
 
 #### 8-2. 일기 댓글 작성
 
-**POST** `/groups/:groupId/diaries/:diaryId/comments`
+**POST** `/group-rooms/:groupRoomId/diaries/:diaryId/comments`
 
 Request/Response는 일정 댓글과 동일.
 
@@ -893,7 +887,7 @@ Request/Response는 일정 댓글과 동일.
 
 #### 8-3. 일정 댓글 삭제
 
-**DELETE** `/groups/:groupId/schedules/:scheduleId/comments/:commentId`
+**DELETE** `/group-rooms/:groupRoomId/schedules/:scheduleId/comments/:commentId`
 
 **Response** `204 No Content`
 
@@ -901,16 +895,16 @@ Request/Response는 일정 댓글과 동일.
 
 #### 8-4. 일기 댓글 삭제
 
-**DELETE** `/groups/:groupId/diaries/:diaryId/comments/:commentId`
+**DELETE** `/group-rooms/:groupRoomId/diaries/:diaryId/comments/:commentId`
 
 **Response** `204 No Content`
 
 ---
 
-### ✅ 9. Todo (할 일)
+### 9. Todo (할 일)
 
 - **브랜치**: `feature/todo-api`
-- **설명**: 그룹 공유 할 일 목록 — 생성, 완료 토글, 삭제
+- **설명**: 그룹방 공유 할 일 목록 — 생성, 완료 토글, 삭제
 - **인증 필요**: 전부
 - **권한**: 삭제는 작성자 또는 방장, 토글은 모든 구성원
 
@@ -918,7 +912,7 @@ Request/Response는 일정 댓글과 동일.
 
 #### 9-1. 할 일 목록
 
-**GET** `/groups/:groupId/todos`
+**GET** `/group-rooms/:groupRoomId/todos`
 
 미완료 → 완료 순서, 각각 생성일 기준 정렬.
 
@@ -953,13 +947,13 @@ Progress 객체:
 
 #### 9-2. 할 일 생성
 
-**POST** `/groups/:groupId/todos`
+**POST** `/group-rooms/:groupRoomId/todos`
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| text | string | ✅ | 내용 (1~100자) |
+| text | string | O | 내용 (1~100자) |
 
 **Response** `201 Created` — Todo 객체
 
@@ -967,13 +961,13 @@ Progress 객체:
 
 #### 9-3. 할 일 완료 토글
 
-**PATCH** `/groups/:groupId/todos/:todoId`
+**PATCH** `/group-rooms/:groupRoomId/todos/:todoId`
 
 **Request Body**
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| completed | boolean | ✅ | 완료 여부 |
+| completed | boolean | O | 완료 여부 |
 
 **Response** `200 OK` — 수정된 Todo 객체
 
@@ -981,13 +975,13 @@ Progress 객체:
 
 #### 9-4. 할 일 삭제
 
-**DELETE** `/groups/:groupId/todos/:todoId`
+**DELETE** `/group-rooms/:groupRoomId/todos/:todoId`
 
 **Response** `204 No Content`
 
 ---
 
-### 🔔 10. Notification (알림)
+### 10. Notification (알림)
 
 - **브랜치**: `feature/notification-api`
 - **설명**: 인앱 알림 목록 조회, 읽음 처리, 전체 읽음, 삭제
@@ -1003,8 +997,8 @@ Progress 객체:
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |----------|------|:---:|------|
-| limit | int | ❌ | 페이지 크기 (기본 20, 최대 100) |
-| offset | int | ❌ | 오프셋 (기본 0) |
+| limit | int | - | 페이지 크기 (기본 20, 최대 100) |
+| offset | int | - | 오프셋 (기본 0) |
 
 **Response** `200 OK`
 
@@ -1022,10 +1016,10 @@ Notification 객체:
 | type | string | 알림 유형 |
 | title | string | 알림 제목 |
 | message | string | 알림 메시지 |
-| groupId | string | 관련 그룹 ID |
-| groupName | string | 그룹명 |
+| groupRoomId | string | 관련 그룹방 ID |
+| groupRoomName | string | 그룹방명 |
 | relatedId | string? | 관련 리소스 ID (일정/일기) |
-| relatedType | string? | 관련 리소스 타입 (`schedule` · `diary` · `comment`) |
+| relatedType | string? | 관련 리소스 타입 (`schedule` / `diary` / `comment`) |
 | isRead | boolean | 읽음 여부 |
 | createdAt | string | 생성 시각 |
 
@@ -1033,14 +1027,14 @@ Notification 객체:
 
 | type | 트리거 시점 | 수신 대상 | 푸시 발송 |
 |------|-----------|----------|:---:|
-| `schedule_created` | 일정 생성 | 그룹 전체 구성원 (작성자 제외) | ✅ |
-| `schedule_updated` | 일정 수정 | 해당 일정 참여자 (수정자 제외) | ✅ |
-| `diary_written` | 일기 작성 | 그룹 전체 구성원 (작성자 제외) | ✅ |
-| `comment_on_schedule` | 일정에 댓글 | 일정 작성자 + 기존 댓글 작성자 (본인 제외) | ✅ |
-| `comment_on_diary` | 일기에 댓글 | 일기 작성자 + 기존 댓글 작성자 (본인 제외) | ✅ |
-| `member_joined` | 새 구성원 참여 | 기존 구성원 전체 | ✅ |
-| `member_removed` | 구성원 내보내기 | 내보내진 사용자 | ✅ |
-| `group_delete_scheduled` | 그룹 삭제 예약 | 전체 구성원 | ✅ |
+| `schedule_created` | 일정 생성 | 그룹방 전체 구성원 (작성자 제외) | O |
+| `schedule_updated` | 일정 수정 | 해당 일정 참여자 (수정자 제외) | O |
+| `diary_written` | 일기 작성 | 그룹방 전체 구성원 (작성자 제외) | O |
+| `comment_on_schedule` | 일정에 댓글 | 일정 작성자 + 기존 댓글 작성자 (본인 제외) | O |
+| `comment_on_diary` | 일기에 댓글 | 일기 작성자 + 기존 댓글 작성자 (본인 제외) | O |
+| `member_joined` | 새 구성원 참여 | 기존 구성원 전체 | O |
+| `member_removed` | 구성원 내보내기 | 내보내진 사용자 | O |
+| `group_delete_scheduled` | 그룹방 삭제 예약 | 전체 구성원 | O |
 
 ---
 
@@ -1052,7 +1046,7 @@ Notification 객체:
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| isRead | boolean | ✅ | `true` |
+| isRead | boolean | O | `true` |
 
 **Response** `204 No Content`
 
@@ -1074,10 +1068,10 @@ Notification 객체:
 
 ---
 
-### 📱 11. Device (디바이스)
+### 11. Device (디바이스)
 
 - **브랜치**: `feature/device-api`
-- **설명**: 푸시 알림 발송을 위한 디바이스 토큰(FCM) 등록·해제
+- **설명**: 푸시 알림 발송을 위한 디바이스 토큰(FCM) 등록/해제
 - **인증 필요**: 전부
 
 ---
@@ -1092,8 +1086,8 @@ Notification 객체:
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| token | string | ✅ | FCM 디바이스 토큰 |
-| platform | string | ✅ | `ios` · `android` |
+| token | string | O | FCM 디바이스 토큰 |
+| platform | string | O | `ios` / `android` |
 
 **Response** `201 Created`
 
@@ -1113,15 +1107,15 @@ Notification 객체:
 
 ---
 
-### 📤 12. Upload (업로드)
+### 12. Upload (업로드)
 
 - **브랜치**: `feature/upload-api`
-- **설명**: 이미지 업로드 (프로필, 그룹 썸네일, 일기 사진)
+- **설명**: 이미지 업로드 (프로필, 그룹방 썸네일, 일기 사진)
 - **인증 필요**: 전부
 
 ---
 
-#### 12-1. 이미지 업로드 (단일)
+#### 12-1. 이미지 업로드
 
 **POST** `/uploads/images`
 
@@ -1131,8 +1125,8 @@ Multipart form-data 방식.
 
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|:---:|------|
-| file | binary | ✅ | 이미지 파일 (PNG/JPEG, 최대 5MB) |
-| purpose | string | ✅ | `profile` · `group_thumbnail` · `diary` |
+| file | binary | O | 이미지 파일 (PNG/JPEG, 최대 5MB) |
+| purpose | string | O | `profile` / `group_thumbnail` / `diary` |
 
 **Response** `201 Created`
 
@@ -1152,23 +1146,633 @@ Multipart form-data 방식.
 
 ---
 
-#### 12-2. 이미지 업로드 (다중)
+### 13. Admin (관리자)
 
-**POST** `/uploads/images/batch`
+- **브랜치**: `feature/admin-api`
+- **설명**: 관리자(ADMIN) 전용 API. 관리자 로그인, 대시보드 요약, 사용자/그룹방/일기/일정 관리, DB 메타·데이터 조회 및 행 편집, 유저 행동 로그 조회, 공지 발송/이력 조회
+- **인증 필요**: 로그인(`/api/admin/auth/login`) 제외 전부. 모든 엔드포인트는 `ROLE_ADMIN` 권한을 요구하며 일반 사용자 토큰으로는 접근 불가
+- **공통 페이지네이션 응답 형식**
 
-일기 사진 여러 장 동시 업로드. Multipart form-data.
-
-**Request** — 최대 5개 파일 (`files[]`)
-
-**Response** `201 Created`
-
-| 필드 | 타입 | 설명 |
-|------|------|------|
-| images | UploadResult[] | 업로드된 이미지 배열 (각각 id, url, width, height) |
+  ```json
+  {
+    "page": 0,
+    "size": 20,
+    "totalElements": 123,
+    "totalPages": 7,
+    "content": [ ... ]
+  }
+  ```
 
 ---
 
-## 🔒 공통 사항
+#### 13-1. 관리자 로그인
+
+**POST** `/api/admin/auth/login`
+
+이메일/비밀번호 기반 관리자 로그인. `admin_credential` 테이블에서 이메일로 조회 후 BCrypt로 비밀번호 검증하고, 연결된 `user.role == ADMIN`일 때만 JWT 토큰을 발급한다. 인증 불필요.
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| email | string | O | 관리자 이메일 |
+| password | string | O | 관리자 비밀번호 |
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| adminId | string | 관리자 사용자 ID(UUID) |
+| email | string | 관리자 이메일 |
+| name | string | 관리자 이름 |
+| accessToken | string | JWT Access Token |
+| refreshToken | string | JWT Refresh Token |
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `ADMIN_NOT_FOUND` | 404 | 해당 이메일의 관리자 계정 없음 |
+| `ADMIN_PASSWORD_MISMATCH` | 401 | 비밀번호 불일치 |
+| `NOT_ADMIN_USER` | 403 | 연결된 유저가 ADMIN 권한이 아님 |
+
+---
+
+#### 13-2. 대시보드 요약 통계
+
+**GET** `/api/admin/dashboard/summary`
+
+총 사용자/그룹방/일기/일정/댓글/할 일/알림 등 핵심 지표를 한 번에 반환.
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| totalUsers | long | 총 사용자 수 |
+| adminUsers | long | 관리자(ADMIN) 수 |
+| totalGroupRooms | long | 총 그룹방 수 |
+| activeGroupRooms | long | 활성 그룹방 수 (삭제되지 않음) |
+| deleteScheduledGroupRooms | long | 삭제 예약된 그룹방 수 |
+| totalDiaries | long | 총 일기 수 |
+| totalSchedules | long | 총 일정 수 |
+| totalComments | long | 총 댓글 수 |
+| totalTodos | long | 총 할 일 수 |
+| totalNotifications | long | 총 알림 수 |
+
+---
+
+#### 13-3. 사용자 목록 조회
+
+**GET** `/api/admin/users`
+
+페이징·키워드(이름/이메일)·권한 필터. `createdAt DESC` 정렬.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| keyword | string | - | - | 이름/이메일 부분일치 검색 |
+| role | string | - | - | `USER` / `ADMIN` |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminUserResponse>` 참조.
+
+`AdminUserResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| userId | string(UUID) | 사용자 ID |
+| email | string | 이메일 (소셜 로그인 시 null 가능) |
+| name | string | 이름 |
+| statusMessage | string | 상태 메시지 |
+| profileImage | string | 프로필 이미지 URL |
+| socialProvider | string | `KAKAO` / `NAVER` / `APPLE` |
+| role | string | `USER` / `ADMIN` |
+| createdAt | string(datetime) | 가입일시 |
+| updatedAt | string(datetime) | 수정일시 |
+
+---
+
+#### 13-4. 사용자 상세 조회
+
+**GET** `/api/admin/users/:userId`
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| userId | string(UUID) | 사용자 ID |
+
+**Response** `200 OK` — `AdminUserResponse` (13-3 참조)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `USER_NOT_FOUND` | 404 | 사용자 없음 |
+
+---
+
+#### 13-5. 사용자 권한 변경
+
+**PATCH** `/api/admin/users/:userId/role`
+
+관리자가 특정 사용자의 권한을 변경한다.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| userId | string(UUID) | 사용자 ID |
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| role | string | O | `USER` / `ADMIN` |
+
+**Response** `200 OK` — `AdminUserResponse` (변경 후 상태)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `USER_NOT_FOUND` | 404 | 사용자 없음 |
+
+---
+
+#### 13-6. 그룹방 목록 조회
+
+**GET** `/api/admin/group-rooms`
+
+페이징·키워드(그룹방 이름)·삭제 포함 여부. `createdAt DESC` 정렬.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| keyword | string | - | - | 그룹방 이름 부분일치 |
+| includeDeleted | boolean | - | true | 삭제/예약 삭제된 그룹방 포함 여부 |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminGroupRoomResponse>`
+
+`AdminGroupRoomResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| groupRoomId | long | 그룹방 ID |
+| name | string | 그룹방 이름 |
+| thumbnailImage | string | 썸네일 이미지 URL |
+| maxMembers | int | 최대 인원 |
+| ownerId | string(UUID) | 방장 ID |
+| ownerName | string | 방장 이름 |
+| lastActivityAt | string(datetime) | 마지막 활동 시각 |
+| deleteScheduledAt | string(datetime) | 삭제 예약 시각 (null이면 미예약) |
+| deletedAt | string(datetime) | 삭제 시각 (null이면 미삭제) |
+| createdAt | string(datetime) | 생성 시각 |
+| updatedAt | string(datetime) | 수정 시각 |
+
+---
+
+#### 13-7. 그룹방 상세 조회
+
+**GET** `/api/admin/group-rooms/:groupRoomId`
+
+**Response** `200 OK` — `AdminGroupRoomResponse` (13-6 참조)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `GROUP_ROOM_NOT_FOUND` | 404 | 그룹방 없음 |
+
+---
+
+#### 13-8. 그룹방 상태 변경
+
+**PATCH** `/api/admin/group-rooms/:groupRoomId/status`
+
+관리자가 그룹방을 복구/삭제 예약/즉시 삭제 처리한다.
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| action | string | O | `RECOVER`(복구) / `SCHEDULE_DELETE`(삭제 예약) / `HARD_DELETE`(즉시 삭제) |
+
+**Response** `200 OK` — `AdminGroupRoomResponse` (변경 후 상태)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `GROUP_ROOM_NOT_FOUND` | 404 | 그룹방 없음 |
+
+---
+
+#### 13-9. 일기 목록 조회
+
+**GET** `/api/admin/diaries`
+
+페이징·키워드(제목/내용). `createdAt DESC` 정렬.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| keyword | string | - | - | 제목/내용 부분일치 |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminDiaryResponse>`
+
+`AdminDiaryResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| diaryId | long | 일기 ID |
+| groupRoomId | long | 그룹방 ID |
+| groupRoomName | string | 그룹방 이름 |
+| createdBy | string(UUID) | 작성자 ID |
+| authorName | string | 작성자 이름 |
+| title | string | 제목 |
+| content | string | 내용 |
+| date | string(date) | 일기 날짜 |
+| weather | int | 날씨 (0~3) |
+| mood | int | 기분 (0~3) |
+| imageUrl | string | 이미지 URL |
+| createdAt | string(datetime) | 생성 시각 |
+| updatedAt | string(datetime) | 수정 시각 |
+
+---
+
+#### 13-10. 일기 상세 조회
+
+**GET** `/api/admin/diaries/:diaryId`
+
+**Response** `200 OK` — `AdminDiaryResponse` (13-9 참조)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `DIARY_NOT_FOUND` | 404 | 일기 없음 |
+
+---
+
+#### 13-11. 일기 삭제
+
+**DELETE** `/api/admin/diaries/:diaryId`
+
+관리자 권한으로 일기를 영구 삭제한다.
+
+**Response** `204 No Content`
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `DIARY_NOT_FOUND` | 404 | 일기 없음 |
+
+---
+
+#### 13-12. 일정 목록 조회
+
+**GET** `/api/admin/schedules`
+
+페이징·키워드(제목). `createdAt DESC` 정렬.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| keyword | string | - | - | 제목 부분일치 |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminScheduleResponse>`
+
+`AdminScheduleResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| scheduleId | long | 일정 ID |
+| groupRoomId | long | 그룹방 ID |
+| groupRoomName | string | 그룹방 이름 |
+| createdBy | string(UUID) | 작성자 ID |
+| authorName | string | 작성자 이름 |
+| title | string | 제목 |
+| color | string | 색상 (#RRGGBB) |
+| startDate | string(date) | 시작 일자 |
+| endDate | string(date) | 종료 일자 |
+| startTime | string(time) | 시작 시간 (allDay 시 null) |
+| endTime | string(time) | 종료 시간 (allDay 시 null) |
+| allDay | boolean | 종일 여부 |
+| participantCount | int | 참여자 수 |
+| createdAt | string(datetime) | 생성 시각 |
+| updatedAt | string(datetime) | 수정 시각 |
+
+---
+
+#### 13-13. 일정 상세 조회
+
+**GET** `/api/admin/schedules/:scheduleId`
+
+**Response** `200 OK` — `AdminScheduleResponse` (13-12 참조)
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `SCHEDULE_NOT_FOUND` | 404 | 일정 없음 |
+
+---
+
+#### 13-14. DB 테이블 목록 조회
+
+**GET** `/api/admin/db/tables`
+
+`INFORMATION_SCHEMA.TABLES`를 조회하여 현재 스키마의 `BASE TABLE` 전체 목록을 반환한다.
+
+**Response** `200 OK` — `List<AdminTableInfoResponse>`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| tableName | string | 테이블명 |
+| tableComment | string | 테이블 주석 (없으면 null) |
+| approxRowCount | long | 통계 기반 근사 행 수 (MySQL `TABLE_ROWS`) |
+
+---
+
+#### 13-15. DB 테이블 컬럼 정보 조회
+
+**GET** `/api/admin/db/tables/:name/columns`
+
+`INFORMATION_SCHEMA.COLUMNS`를 조회해 특정 테이블의 컬럼 메타데이터를 반환한다. 테이블명은 식별자 화이트리스트(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)로 검증 후 존재 여부를 확인한다.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| name | string | 테이블명 |
+
+**Response** `200 OK` — `List<AdminColumnInfoResponse>` (`ORDINAL_POSITION` 오름차순)
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| columnName | string | 컬럼명 |
+| dataType | string | 데이터 타입 (varchar, bigint 등) |
+| columnType | string | 컬럼 전체 타입 (varchar(255) 등) |
+| nullable | boolean | NULL 허용 여부 |
+| defaultValue | string | 기본값 |
+| columnKey | string | 키 종류 (PRI/UNI/MUL) |
+| comment | string | 컬럼 주석 |
+| ordinalPosition | int | 정렬 순서 |
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `ADMIN_TABLE_NOT_ALLOWED` | 400 | 테이블명이 화이트리스트 정규식에 맞지 않음 |
+| `ADMIN_TABLE_NOT_FOUND` | 404 | 현재 스키마에 해당 테이블 없음 |
+
+---
+
+#### 13-16. DB 테이블 데이터 조회
+
+**GET** `/api/admin/db/tables/:name/rows`
+
+테이블 데이터를 컬럼 기반 페이지 응답으로 반환한다. 테이블/컬럼명은 정규식 화이트리스트로 검증 후 백틱으로 이스케이프하며, `size`는 최대 200으로 제한된다. 정렬은 실제 컬럼 존재 여부 및 방향(ASC/DESC) 검증 후 `ORDER BY \`col\` DIR`로 구성한다.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| name | string | 테이블명 |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 (최대 200) |
+| orderBy | string | - | - | 정렬 기준 컬럼명 |
+| direction | string | - | ASC | `ASC` / `DESC` |
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| tableName | string | 테이블명 |
+| columns | string[] | 컬럼 순서 (rows 객체의 키 순서) |
+| page | int | 현재 페이지 |
+| size | int | 페이지 크기 |
+| totalElements | long | 총 행 수 |
+| totalPages | int | 총 페이지 수 |
+| rows | object[] | 각 행은 `{ 컬럼명: 값 }` Map |
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `ADMIN_TABLE_NOT_ALLOWED` | 400 | 테이블명이 화이트리스트 정규식에 맞지 않음 |
+| `ADMIN_TABLE_NOT_FOUND` | 404 | 현재 스키마에 해당 테이블 없음 |
+| `ADMIN_COLUMN_NOT_ALLOWED` | 400 | `orderBy` 컬럼명/형식 또는 `direction` 값이 허용되지 않음 |
+
+---
+
+#### 13-17. 유저 행동 로그 조회
+
+**GET** `/api/admin/logs`
+
+`user_action_log` 테이블을 `createdAt DESC`로 페이징 조회. 행위자/액션/기간/키워드 필터 지원. 키워드는 `detail`, `targetId`에 대한 부분일치 검색이다. (관리자 전용 행위 로그가 아닌, 모든 사용자 행동 로그를 통합 조회한다.)
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| actorId | string(UUID) | - | - | 행위자 ID (null은 시스템 로그) |
+| action | string | - | - | `LOGIN` / `SIGNUP` / `LOGOUT` / `CREATE_DIARY` / `DELETE_DIARY` / `CREATE_SCHEDULE` / `DELETE_SCHEDULE` / `CREATE_COMMENT` / `CREATE_GROUP_ROOM` / `JOIN_GROUP_ROOM` / `LEAVE_GROUP_ROOM` / `TRANSFER_OWNER` / `CREATE_TODO` / `OTHER` |
+| from | string(datetime) | - | - | 조회 시작 (ISO-8601) |
+| to | string(datetime) | - | - | 조회 종료 (ISO-8601) |
+| keyword | string | - | - | `detail`/`targetId` 부분일치 |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminUserLogResponse>`
+
+`AdminUserLogResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| logId | long | 로그 ID |
+| actorId | string(UUID) | 행위자 ID (시스템 로그는 null) |
+| action | string | 액션 타입 |
+| targetType | string | 대상 타입 (USER/GROUP_ROOM/DIARY/SCHEDULE/COMMENT/TODO 등) |
+| targetId | string | 대상 ID |
+| detail | string | 상세 메시지 |
+| createdAt | string(datetime) | 생성 시각 |
+
+---
+
+#### 13-18. DB 테이블 행 추가
+
+**POST** `/api/admin/db/tables/:name/rows`
+
+`values` 맵의 컬럼만 `INSERT`. 테이블/컬럼명은 정규식 화이트리스트로 검증 후 백틱 이스케이프된다. 값은 문자열로 전달하며 서버가 컬럼 타입에 맞게 변환한다. NULL은 JSON `null`로 전달.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| name | string | 테이블명 |
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| values | object | O | `{ 컬럼명: 값(string \| null) }` |
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| affected | int | 영향받은 행 수 |
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `ADMIN_TABLE_NOT_ALLOWED` | 400 | 테이블명 화이트리스트 위반 |
+| `ADMIN_TABLE_NOT_FOUND` | 404 | 테이블 없음 |
+| `ADMIN_COLUMN_NOT_ALLOWED` | 400 | 컬럼명/형식 위반 |
+| `INVALID_PARAMETER` | 400 | values 비어있거나 값 변환 실패 |
+
+---
+
+#### 13-19. DB 테이블 행 수정
+
+**PATCH** `/api/admin/db/tables/:name/rows`
+
+PK로만 매칭하여 1행 수정. PK 컬럼은 변경 불가하며 `values`에 PK가 포함되어도 무시된다. 영향받는 행이 정확히 1행이 아니면 롤백된다.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| name | string | 테이블명 |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `pk[컬럼명]` | string | 매칭할 PK 컬럼명/값 (다중 PK 가능) |
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| values | object | O | 변경할 컬럼 → 값 |
+
+**Response** `200 OK` — `{ affected: int }`
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `ADMIN_TABLE_NOT_ALLOWED` | 400 | 테이블명 화이트리스트 위반 |
+| `ADMIN_TABLE_NOT_FOUND` | 404 | 테이블 없음 |
+| `ADMIN_COLUMN_NOT_ALLOWED` | 400 | 컬럼명/형식 위반 |
+| `INVALID_PARAMETER` | 400 | PK 누락, 영향 행 수 ≠ 1 |
+
+---
+
+#### 13-20. DB 테이블 행 삭제
+
+**DELETE** `/api/admin/db/tables/:name/rows`
+
+PK로만 매칭하여 1행 삭제. WHERE 없는 전체 삭제는 불가. 영향받는 행이 정확히 1행이 아니면 롤백된다.
+
+**Path Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| name | string | 테이블명 |
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `pk[컬럼명]` | string | 매칭할 PK 컬럼명/값 (다중 PK 가능) |
+
+**Response** `200 OK` — `{ affected: int }`
+
+**에러 케이스** — 13-19와 동일.
+
+---
+
+#### 13-21. 공지 발송
+
+**POST** `/api/admin/announcements`
+
+전체 사용자 또는 지정 유저들에게 공지를 발송한다. `notification` 레코드 생성 + FCM 푸시 멀티캐스트 발송이 동시에 일어나며, 발송 이력은 `announcement` 테이블에 1행 저장된다.
+
+**Request Body**
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:---:|------|
+| title | string | O | 공지 제목 (최대 100자) |
+| body | string | O | 공지 본문 (최대 1000자) |
+| target | string | O | `ALL` / `USER_IDS` (기본값 `ALL`) |
+| userIds | string(UUID)[] | △ | `target=USER_IDS`일 때 필수, 비어있을 수 없음 |
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| recipientCount | int | 실제 발송된 수신자 수 |
+
+**에러 케이스**
+
+| 코드 | HTTP | 상황 |
+|------|:---:|------|
+| `INVALID_PARAMETER` | 400 | `target` 값 위반 또는 `USER_IDS`인데 `userIds`가 비어있음 |
+
+---
+
+#### 13-22. 공지 목록 조회
+
+**GET** `/api/admin/announcements`
+
+지금까지 발송된 공지 이력을 `createdAt DESC`로 페이징 조회한다. 제목/본문 키워드 검색을 지원한다.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|:------:|------|
+| keyword | string | - | - | 제목/본문 부분일치 |
+| page | int | - | 0 | 0-base 페이지 |
+| size | int | - | 20 | 페이지 크기 |
+
+**Response** `200 OK` — `AdminPageResponse<AdminAnnouncementResponse>`
+
+`AdminAnnouncementResponse` 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| announcementId | long | 공지 ID |
+| title | string | 제목 |
+| body | string | 본문 |
+| targetType | string | `ALL` / `USER_IDS` |
+| recipientCount | int | 발송 당시 수신자 수 |
+| createdAt | string(datetime) | 발송 시각 |
+
+---
+
+## 공통 사항
 
 ### 인증 헤더
 
@@ -1248,7 +1852,7 @@ X-RateLimit-Reset: 1679234567
 
 ---
 
-## 🌿 브랜치 전략
+## 브랜치 전략
 
 ### 브랜치 구조
 
@@ -1258,7 +1862,7 @@ main
       ├── feature/auth-api          ← 1순위
       ├── feature/user-api          ← 2순위
       ├── feature/upload-api        ← 3순위
-      ├── feature/group-api         ← 4순위
+      ├── feature/group-room-api    ← 4순위
       ├── feature/invite-api        ← 5순위
       ├── feature/membership-api    ← 6순위
       ├── feature/device-api        ← 7순위 (독립)
@@ -1266,7 +1870,8 @@ main
       ├── feature/diary-api         ← 9순위
       ├── feature/comment-api       ← 10순위
       ├── feature/todo-api          ← 11순위 (독립)
-      └── feature/notification-api  ← 12순위
+      ├── feature/notification-api  ← 12순위
+      └── feature/admin-api         ← 13순위
 ```
 
 ### 개발 순서 (의존성 기반)
@@ -1274,17 +1879,18 @@ main
 | 순서 | 브랜치 | 의존 대상 | 이유 |
 |:---:|--------|----------|------|
 | 1 | `feature/auth-api` | — | 모든 API의 인증 기반, JWT 발급 |
-| 2 | `feature/user-api` | Auth | 프로필·설정, 인증된 사용자 필요 |
+| 2 | `feature/user-api` | Auth | 프로필/설정, 인증된 사용자 필요 |
 | 3 | `feature/upload-api` | Auth | 이미지 업로드, 이후 도메인에서 참조 |
-| 4 | `feature/group-api` | Auth, Upload | 그룹 CRUD, 썸네일 이미지 |
-| 5 | `feature/invite-api` | Group | 초대 코드는 그룹에 종속 |
-| 6 | `feature/membership-api` | Group | 구성원 관리는 그룹에 종속 |
+| 4 | `feature/group-room-api` | Auth, Upload | 그룹방 CRUD, 썸네일 이미지 |
+| 5 | `feature/invite-api` | GroupRoom | 초대 코드는 그룹방에 종속 |
+| 6 | `feature/membership-api` | GroupRoom | 구성원 관리는 그룹방에 종속 |
 | 7 | `feature/device-api` | Auth | FCM 토큰 등록, Auth만 의존 (병렬 가능) |
-| 8 | `feature/schedule-api` | Group, Membership | 일정은 그룹+구성원 필요 |
-| 9 | `feature/diary-api` | Group, Upload | 일기는 그룹+이미지 필요 |
+| 8 | `feature/schedule-api` | GroupRoom, Membership | 일정은 그룹방+구성원 필요 |
+| 9 | `feature/diary-api` | GroupRoom, Upload | 일기는 그룹방+이미지 필요 |
 | 10 | `feature/comment-api` | Schedule, Diary | 댓글은 일정/일기에 종속 |
-| 11 | `feature/todo-api` | Group | 할 일은 그룹에만 종속 (병렬 가능) |
+| 11 | `feature/todo-api` | GroupRoom | 할 일은 그룹방에만 종속 (병렬 가능) |
 | 12 | `feature/notification-api` | 전체 | 모든 도메인 이벤트를 수신하여 알림+푸시 생성 |
+| 13 | `feature/admin-api` | 전체 | 관리자 기능. 각 도메인 Repository 재사용 |
 
 > 7번(Device)과 11번(Todo)은 의존성이 적어 다른 도메인과 병렬 개발 가능
 
@@ -1298,30 +1904,32 @@ main
 
 ---
 
-## 📊 데이터베이스 ERD 요약
+## 데이터베이스 ERD 요약
 
 | 테이블 | 주요 관계 | 비고 |
 |--------|-----------|------|
-| users | — | 소셜 로그인 정보 포함 |
-| user_terms | users 1:1 | 약관 동의 내역 |
-| user_notification_settings | users 1:1 | 알림 설정 |
-| user_privacy_settings | users 1:1 | 개인정보 설정 |
-| groups | users N:1 (owner) | Soft Delete 지원 |
-| group_memberships | users N:M groups | 조인 테이블, role·color 포함 |
-| invite_codes | groups 1:N | 24시간 만료 |
-| schedules | groups 1:N | 색상, 종일 여부 포함 |
-| schedule_participants | users N:M schedules | 일정 참여자 |
-| diaries | groups 1:N | 날씨, 기분 포함 |
-| diary_images | diaries 1:N | 이미지 URL, 순서 |
-| comments | schedules/diaries 다형성 1:N | parentType으로 구분 |
-| todos | groups 1:N | 완료 여부, 완료자 |
-| notifications | users 1:N | type, relatedId로 연결 |
-| devices | users 1:N | FCM 토큰, 플랫폼 |
-| uploaded_images | users 1:N | purpose별 분류 |
+| user | — | 소셜 로그인 정보 포함 |
+| user_terms | user 1:1 | 약관 동의 내역 |
+| user_notification_setting | user 1:1 | 알림 설정 |
+| user_privacy_setting | user 1:1 | 개인정보 설정 |
+| group_room | user N:1 (owner) | Soft Delete 지원 |
+| membership | user N:M group_room | 조인 테이블, role/color 포함 |
+| invite_code | group_room 1:N | 24시간 만료 |
+| schedule | group_room 1:N | 색상, 종일 여부 포함 |
+| schedule_participant | user N:M schedule | 일정 참여자 |
+| diary | group_room 1:N | 날씨, 기분, 이미지 URL 포함 |
+| comment | schedule/diary 다형성 1:N | targetType으로 구분 |
+| todo | group_room 1:N | 완료 여부, 완료자 |
+| notification | user 1:N | type, relatedId로 연결 |
+| device | user 1:N | FCM 토큰, 플랫폼 |
+| uploaded_image | user 1:N | purpose별 분류 |
+| admin_credential | user 1:1 | 관리자 이메일/비밀번호 (BCrypt) |
+| user_action_log | user N:1 (actor, nullable) | 유저 행동 감사 로그 |
+| announcement | (독립) | 관리자 공지 발송 이력 |
 
 ---
 
-## 📋 엔드포인트 전체 목록 (52개)
+## 엔드포인트 전체 목록 (68개)
 
 | # | 메서드 | 엔드포인트 | 도메인 | 설명 |
 |:---:|:---:|------|------|------|
@@ -1337,67 +1945,92 @@ main
 | 10 | PUT | `/users/me/notification-settings` | User | 알림 설정 수정 |
 | 11 | GET | `/users/me/privacy-settings` | User | 개인정보 설정 조회 |
 | 12 | PUT | `/users/me/privacy-settings` | User | 개인정보 설정 수정 |
-| 13 | POST | `/groups` | Group | 그룹 생성 |
-| 14 | GET | `/groups` | Group | 내 그룹 목록 |
-| 15 | GET | `/groups/:groupId` | Group | 그룹 상세 |
-| 16 | PUT | `/groups/:groupId` | Group | 그룹 수정 |
-| 17 | DELETE | `/groups/:groupId` | Group | 그룹 삭제 |
-| 18 | POST | `/groups/:groupId/recover` | Group | 그룹 복구 |
-| 19 | POST | `/groups/:groupId/invites` | Invite | 초대 코드 생성 |
+| 13 | POST | `/group-rooms` | GroupRoom | 그룹방 생성 |
+| 14 | GET | `/group-rooms` | GroupRoom | 내 그룹방 목록 |
+| 15 | GET | `/group-rooms/:groupRoomId` | GroupRoom | 그룹방 상세 |
+| 16 | PUT | `/group-rooms/:groupRoomId` | GroupRoom | 그룹방 수정 |
+| 17 | DELETE | `/group-rooms/:groupRoomId` | GroupRoom | 그룹방 삭제 |
+| 18 | POST | `/group-rooms/:groupRoomId/recover` | GroupRoom | 그룹방 복구 |
+| 19 | POST | `/group-rooms/:groupRoomId/invites` | Invite | 초대 코드 생성 |
 | 20 | POST | `/invites/validate` | Invite | 초대 코드 검증 |
 | 21 | POST | `/invites/join` | Invite | 초대 코드로 참여 |
-| 22 | GET | `/groups/:groupId/memberships` | Membership | 구성원 목록 |
-| 23 | DELETE | `/groups/:groupId/memberships/:userId` | Membership | 구성원 내보내기 |
-| 24 | PUT | `/groups/:groupId/memberships/:userId/role` | Membership | 역할 변경 |
-| 25 | POST | `/groups/:groupId/leave` | Membership | 그룹 탈퇴 |
-| 26 | GET | `/groups/:groupId/schedules` | Schedule | 일정 목록 |
-| 27 | GET | `/groups/:groupId/schedules/:scheduleId` | Schedule | 일정 상세 |
-| 28 | POST | `/groups/:groupId/schedules` | Schedule | 일정 생성 |
-| 29 | PUT | `/groups/:groupId/schedules/:scheduleId` | Schedule | 일정 수정 |
-| 30 | DELETE | `/groups/:groupId/schedules/:scheduleId` | Schedule | 일정 삭제 |
-| 31 | GET | `/groups/:groupId/diaries` | Diary | 일기 목록 |
-| 32 | GET | `/groups/:groupId/diaries/calendar` | Diary | 일기 캘린더 |
-| 33 | GET | `/groups/:groupId/diaries/:diaryId` | Diary | 일기 상세 |
-| 34 | POST | `/groups/:groupId/diaries` | Diary | 일기 작성 |
-| 35 | PUT | `/groups/:groupId/diaries/:diaryId` | Diary | 일기 수정 |
-| 36 | DELETE | `/groups/:groupId/diaries/:diaryId` | Diary | 일기 삭제 |
-| 37 | POST | `/groups/:groupId/schedules/:scheduleId/comments` | Comment | 일정 댓글 작성 |
-| 38 | DELETE | `/groups/:groupId/schedules/:scheduleId/comments/:commentId` | Comment | 일정 댓글 삭제 |
-| 39 | POST | `/groups/:groupId/diaries/:diaryId/comments` | Comment | 일기 댓글 작성 |
-| 40 | DELETE | `/groups/:groupId/diaries/:diaryId/comments/:commentId` | Comment | 일기 댓글 삭제 |
-| 41 | GET | `/groups/:groupId/todos` | Todo | 할 일 목록 |
-| 42 | POST | `/groups/:groupId/todos` | Todo | 할 일 생성 |
-| 43 | PATCH | `/groups/:groupId/todos/:todoId` | Todo | 할 일 토글 |
-| 44 | DELETE | `/groups/:groupId/todos/:todoId` | Todo | 할 일 삭제 |
+| 22 | GET | `/group-rooms/:groupRoomId/memberships` | Membership | 구성원 목록 |
+| 23 | DELETE | `/group-rooms/:groupRoomId/memberships/:userId` | Membership | 구성원 내보내기 |
+| 24 | PUT | `/group-rooms/:groupRoomId/memberships/:userId/role` | Membership | 역할 변경 |
+| 25 | POST | `/group-rooms/:groupRoomId/leave` | Membership | 그룹방 탈퇴 |
+| 26 | GET | `/group-rooms/:groupRoomId/schedules` | Schedule | 일정 목록 |
+| 27 | GET | `/group-rooms/:groupRoomId/schedules/:scheduleId` | Schedule | 일정 상세 |
+| 28 | POST | `/group-rooms/:groupRoomId/schedules` | Schedule | 일정 생성 |
+| 29 | PUT | `/group-rooms/:groupRoomId/schedules/:scheduleId` | Schedule | 일정 수정 |
+| 30 | DELETE | `/group-rooms/:groupRoomId/schedules/:scheduleId` | Schedule | 일정 삭제 |
+| 31 | GET | `/group-rooms/:groupRoomId/diaries` | Diary | 일기 목록 |
+| 32 | GET | `/group-rooms/:groupRoomId/diaries/calendar` | Diary | 일기 캘린더 |
+| 33 | GET | `/group-rooms/:groupRoomId/diaries/:diaryId` | Diary | 일기 상세 |
+| 34 | POST | `/group-rooms/:groupRoomId/diaries` | Diary | 일기 작성 |
+| 35 | PUT | `/group-rooms/:groupRoomId/diaries/:diaryId` | Diary | 일기 수정 |
+| 36 | DELETE | `/group-rooms/:groupRoomId/diaries/:diaryId` | Diary | 일기 삭제 |
+| 37 | POST | `/group-rooms/:groupRoomId/schedules/:scheduleId/comments` | Comment | 일정 댓글 작성 |
+| 38 | DELETE | `/group-rooms/:groupRoomId/schedules/:scheduleId/comments/:commentId` | Comment | 일정 댓글 삭제 |
+| 39 | POST | `/group-rooms/:groupRoomId/diaries/:diaryId/comments` | Comment | 일기 댓글 작성 |
+| 40 | DELETE | `/group-rooms/:groupRoomId/diaries/:diaryId/comments/:commentId` | Comment | 일기 댓글 삭제 |
+| 41 | GET | `/group-rooms/:groupRoomId/todos` | Todo | 할 일 목록 |
+| 42 | POST | `/group-rooms/:groupRoomId/todos` | Todo | 할 일 생성 |
+| 43 | PATCH | `/group-rooms/:groupRoomId/todos/:todoId` | Todo | 할 일 토글 |
+| 44 | DELETE | `/group-rooms/:groupRoomId/todos/:todoId` | Todo | 할 일 삭제 |
 | 45 | GET | `/notifications` | Notification | 알림 목록 |
 | 46 | PATCH | `/notifications/:notificationId` | Notification | 알림 읽음 |
 | 47 | POST | `/notifications/read-all` | Notification | 전체 읽음 |
 | 48 | DELETE | `/notifications/:notificationId` | Notification | 알림 삭제 |
 | 49 | POST | `/devices` | Device | 디바이스 토큰 등록 |
 | 50 | DELETE | `/devices/:deviceId` | Device | 디바이스 토큰 해제 |
-| 51 | POST | `/uploads/images` | Upload | 이미지 업로드 (단일) |
-| 52 | POST | `/uploads/images/batch` | Upload | 이미지 업로드 (다중) |
+| 51 | POST | `/uploads/images` | Upload | 이미지 업로드 |
+| 52 | POST | `/api/admin/auth/login` | Admin | 관리자 로그인 (이메일/비밀번호) |
+| 53 | GET | `/api/admin/dashboard/summary` | Admin | 대시보드 주요 통계 |
+| 54 | GET | `/api/admin/users` | Admin | 사용자 목록 (페이징/키워드/role) |
+| 55 | GET | `/api/admin/users/:userId` | Admin | 사용자 상세 |
+| 56 | PATCH | `/api/admin/users/:userId/role` | Admin | 사용자 권한 변경 |
+| 57 | GET | `/api/admin/group-rooms` | Admin | 그룹방 목록 (페이징/키워드/삭제 포함) |
+| 58 | GET | `/api/admin/group-rooms/:groupRoomId` | Admin | 그룹방 상세 |
+| 59 | PATCH | `/api/admin/group-rooms/:groupRoomId/status` | Admin | 그룹방 상태 변경 |
+| 60 | GET | `/api/admin/diaries` | Admin | 일기 목록 (페이징/키워드) |
+| 61 | GET | `/api/admin/diaries/:diaryId` | Admin | 일기 상세 |
+| 62 | DELETE | `/api/admin/diaries/:diaryId` | Admin | 일기 삭제 |
+| 63 | GET | `/api/admin/schedules` | Admin | 일정 목록 (페이징/키워드) |
+| 64 | GET | `/api/admin/schedules/:scheduleId` | Admin | 일정 상세 |
+| 65 | GET | `/api/admin/db/tables` | Admin | DB 전체 테이블 목록 |
+| 66 | GET | `/api/admin/db/tables/:name/columns` | Admin | 테이블 컬럼 정보 |
+| 67 | GET | `/api/admin/db/tables/:name/rows` | Admin | 테이블 데이터(페이징) |
+| 68 | POST | `/api/admin/db/tables/:name/rows` | Admin | 테이블 행 추가 |
+| 69 | PATCH | `/api/admin/db/tables/:name/rows` | Admin | 테이블 행 수정 (PK 매칭) |
+| 70 | DELETE | `/api/admin/db/tables/:name/rows` | Admin | 테이블 행 삭제 (PK 매칭) |
+| 71 | GET | `/api/admin/logs` | Admin | 유저 행동 로그 조회 |
+| 72 | POST | `/api/admin/announcements` | Admin | 공지 발송 (ALL/USER_IDS) |
+| 73 | GET | `/api/admin/announcements` | Admin | 공지 발송 이력 조회 |
 
 ---
 
-## 🔑 권한 매트릭스
+## 권한 매트릭스
 
-| 행동 | 방장 (owner) | 구성원 (member) | 비구성원 |
-|------|:---:|:---:|:---:|
-| 그룹 조회 | ✅ | ✅ | ❌ |
-| 그룹 수정/삭제/복구 | ✅ | ❌ | ❌ |
-| 초대 코드 생성 | ✅ | ❌ | ❌ |
-| 구성원 내보내기 | ✅ | ❌ | ❌ |
-| 역할 변경 (방장 양도) | ✅ | ❌ | ❌ |
-| 일정 생성 | ✅ | ✅ | ❌ |
-| 일정 수정/삭제 (본인 것) | ✅ | ✅ | ❌ |
-| 일정 수정/삭제 (타인 것) | ✅ | ❌ | ❌ |
-| 일기 작성 | ✅ | ✅ | ❌ |
-| 일기 수정/삭제 (본인 것) | ✅ | ✅ | ❌ |
-| 일기 수정/삭제 (타인 것) | ✅ | ❌ | ❌ |
-| 댓글 작성 | ✅ | ✅ | ❌ |
-| 댓글 삭제 (본인 것) | ✅ | ✅ | ❌ |
-| 댓글 삭제 (타인 것) | ✅ | ❌ | ❌ |
-| 할 일 생성/토글 | ✅ | ✅ | ❌ |
-| 할 일 삭제 (본인 것) | ✅ | ✅ | ❌ |
-| 할 일 삭제 (타인 것) | ✅ | ❌ | ❌ |
+그룹방 관련 행위는 `방장`/`구성원`/`비구성원` 기준이며, 별도로 **ADMIN**(시스템 관리자 — `user.role == ADMIN`)은 아래 모든 행위 권한과 무관하게 `/api/admin/**` 엔드포인트를 통해 사용자/그룹방/일기/일정/DB/로그 전반을 관리할 수 있다.
+
+| 행동 | 방장 (owner) | 구성원 (member) | 비구성원 | 관리자 (ADMIN) |
+|------|:---:|:---:|:---:|:---:|
+| 그룹방 조회 | O | O | X | O (admin API) |
+| 그룹방 수정/삭제/복구 | O | X | X | O (상태 변경 API) |
+| 초대 코드 생성 | O | X | X | - |
+| 구성원 내보내기 | O | X | X | - |
+| 역할 변경 (방장 양도) | O | X | X | - |
+| 일정 생성 | O | O | X | - |
+| 일정 수정/삭제 (본인 것) | O | O | X | - |
+| 일정 수정/삭제 (타인 것) | O | X | X | - |
+| 일기 작성 | O | O | X | - |
+| 일기 수정/삭제 (본인 것) | O | O | X | - |
+| 일기 수정/삭제 (타인 것) | O | X | X | O (강제 삭제) |
+| 댓글 작성 | O | O | X | - |
+| 댓글 삭제 (본인 것) | O | O | X | - |
+| 댓글 삭제 (타인 것) | O | X | X | - |
+| 할 일 생성/토글 | O | O | X | - |
+| 할 일 삭제 (본인 것) | O | O | X | - |
+| 할 일 삭제 (타인 것) | O | X | X | - |
+| 사용자 권한 변경 | X | X | X | O |
+| DB 테이블/로그 열람 | X | X | X | O |

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,7 +1,7 @@
 # DigDa ERD (Entity Relationship Diagram)
 
-> 총 **14개 MySQL 테이블** + **2개 Redis 엔티티**
-> `users`를 중심으로 그룹 → 일정/일기/할일 구조
+> 총 **18개 MySQL 테이블** + **2개 Redis 엔티티**
+> `user`를 중심으로 그룹방 → 일정/일기/할일 구조 + 어드민(`admin_credential`) / 감사 로그(`user_action_log`) / 공지(`announcement`)
 
 ---
 
@@ -9,7 +9,7 @@
 
 ```mermaid
 erDiagram
-    users["users (사용자)"] {
+    user["user (사용자)"] {
         binary_16 user_id PK "사용자 UUID"
         varchar social_id "소셜 고유 ID (nullable — 관리자는 null)"
         enum social_provider "제공자 (KAKAO/NAVER/APPLE/ADMIN)"
@@ -18,8 +18,8 @@ erDiagram
         varchar profile_image "프로필 이미지 URL"
         varchar status_message "상태 메시지 (최대 100자)"
         enum role "역할 (USER/ADMIN)"
-        datetime createdAt "가입일"
-        datetime updatedAt "수정일"
+        datetime created_at "가입일"
+        datetime updated_at "수정일"
     }
 
     user_terms["user_terms (약관 동의)"] {
@@ -33,7 +33,7 @@ erDiagram
         datetime agreed_at "동의 일시"
     }
 
-    user_notification_settings["user_notification_settings (알림 설정)"] {
+    user_notification_setting["user_notification_setting (알림 설정)"] {
         bigint id PK "알림 설정 ID"
         binary_16 user_id FK "사용자 UUID"
         boolean push_enabled "푸시 알림 전체 ON/OFF"
@@ -43,46 +43,46 @@ erDiagram
         boolean marketing_consent "마케팅 수신 동의"
     }
 
-    user_privacy_settings["user_privacy_settings (개인정보 설정)"] {
+    user_privacy_setting["user_privacy_setting (개인정보 설정)"] {
         bigint id PK "개인정보 설정 ID"
         binary_16 user_id FK "사용자 UUID"
         boolean profile_public "프로필 공개 여부"
         boolean activity_visible "활동 표시 여부"
     }
 
-    groups["groups (그룹/다이어리 방)"] {
-        bigint group_id PK "그룹 ID"
-        varchar name "그룹명 (2~20자)"
+    group_room["group_room (그룹방)"] {
+        bigint group_room_id PK "그룹방 ID"
+        varchar name "그룹방명 (2~20자)"
         varchar thumbnail_image "썸네일 이미지 URL"
         int max_members "최대 인원"
         binary_16 owner_id FK "방장 사용자 UUID"
         datetime last_activity_at "마지막 활동 일시"
         datetime delete_scheduled_at "삭제 예약 일시"
         datetime deleted_at "삭제 일시 (Soft Delete)"
-        datetime createdAt "생성일"
-        datetime updatedAt "수정일"
+        datetime created_at "생성일"
+        datetime updated_at "수정일"
     }
 
-    memberships["memberships (그룹 소속)"] {
+    membership["membership (그룹방 소속)"] {
         bigint membership_id PK "소속 ID"
         binary_16 user_id FK "사용자 UUID"
-        bigint group_id FK "그룹 ID"
-        enum role "그룹 역할 (OWNER/MEMBER)"
+        bigint group_room_id FK "그룹방 ID"
+        enum role "그룹방 역할 (OWNER/MEMBER)"
         varchar color "사용자 색상 (#FFFFFF)"
         datetime joined_at "가입 일시"
     }
 
-    invite_codes["invite_codes (초대 코드)"] {
+    invite_code["invite_code (초대 코드)"] {
         bigint invite_code_id PK "초대 코드 ID"
-        bigint group_id FK "그룹 ID"
+        bigint group_room_id FK "그룹방 ID"
         varchar code UK "초대 코드 (6자리)"
         datetime expires_at "만료 일시"
         datetime created_at "생성 일시"
     }
 
-    schedules["schedules (일정)"] {
+    schedule["schedule (일정)"] {
         bigint schedule_id PK "일정 ID"
-        bigint group_id FK "그룹 ID"
+        bigint group_room_id FK "그룹방 ID"
         varchar title "일정 제목 (최대 50자)"
         varchar color "일정 색상 (#FFFFFF)"
         date start_date "시작일"
@@ -91,37 +91,31 @@ erDiagram
         time end_time "종료 시간 (종일이면 null)"
         boolean all_day "종일 여부"
         binary_16 created_by FK "작성자 UUID"
-        datetime createdAt "생성일"
-        datetime updatedAt "수정일"
+        datetime created_at "생성일"
+        datetime updated_at "수정일"
     }
 
-    schedule_participants["schedule_participants (일정 참여자)"] {
+    schedule_participant["schedule_participant (일정 참여자)"] {
         bigint id PK "참여자 ID"
         bigint schedule_id FK "일정 ID"
         binary_16 user_id FK "사용자 UUID"
     }
 
-    diaries["diaries (일기)"] {
+    diary["diary (일기)"] {
         bigint diary_id PK "일기 ID"
-        bigint group_id FK "그룹 ID"
+        bigint group_room_id FK "그룹방 ID"
         varchar title "일기 제목 (최대 20자)"
         varchar content "일기 내용 (최대 300자)"
         date date "일기 날짜"
         int weather "날씨 (0~3)"
         int mood "기분 (0~3)"
+        varchar image_url "이미지 URL (nullable)"
         binary_16 created_by FK "작성자 UUID"
-        datetime createdAt "생성일"
-        datetime updatedAt "수정일"
+        datetime created_at "생성일"
+        datetime updated_at "수정일"
     }
 
-    diary_images["diary_images (일기 이미지)"] {
-        bigint diary_image_id PK "이미지 ID"
-        bigint diary_id FK "일기 ID"
-        varchar image_url "이미지 URL"
-        int sort_order "정렬 순서"
-    }
-
-    comments["comments (댓글)"] {
+    comment["comment (댓글)"] {
         bigint comment_id PK "댓글 ID"
         enum target_type "대상 유형 (SCHEDULE/DIARY)"
         bigint target_id "대상 ID"
@@ -130,9 +124,9 @@ erDiagram
         datetime created_at "작성 일시"
     }
 
-    todos["todos (할 일)"] {
+    todo["todo (할 일)"] {
         bigint todo_id PK "할 일 ID"
-        bigint group_id FK "그룹 ID"
+        bigint group_room_id FK "그룹방 ID"
         varchar text "할 일 내용 (최대 100자)"
         boolean completed "완료 여부"
         datetime completed_at "완료 일시"
@@ -141,30 +135,30 @@ erDiagram
         datetime created_at "작성 일시"
     }
 
-    notifications["notifications (알림)"] {
+    notification["notification (알림)"] {
         bigint notification_id PK "알림 ID"
         binary_16 user_id FK "수신자 UUID"
         enum type "알림 유형"
         varchar title "알림 제목"
         varchar message "알림 메시지"
-        bigint group_id "관련 그룹 ID"
-        varchar group_name "관련 그룹명"
+        bigint group_room_id "관련 그룹방 ID"
+        varchar group_room_name "관련 그룹방명"
         bigint related_id "관련 리소스 ID"
         varchar related_type "관련 리소스 유형"
         boolean is_read "읽음 여부"
         datetime created_at "생성 일시"
     }
 
-    devices["devices (디바이스)"] {
+    device["device (디바이스)"] {
         bigint device_id PK "디바이스 ID"
         binary_16 user_id FK "사용자 UUID"
         varchar token UK "FCM 토큰 (고유)"
         enum platform "플랫폼 (IOS/ANDROID)"
-        datetime createdAt "등록일"
-        datetime updatedAt "수정일"
+        datetime created_at "등록일"
+        datetime updated_at "수정일"
     }
 
-    uploaded_images["uploaded_images (업로드 이미지)"] {
+    uploaded_image["uploaded_image (업로드 이미지)"] {
         bigint uploaded_image_id PK "이미지 ID"
         binary_16 user_id FK "업로더 UUID"
         varchar url "이미지 URL"
@@ -174,34 +168,65 @@ erDiagram
         datetime created_at "업로드 일시"
     }
 
+    admin_credential["admin_credential (관리자 자격증명)"] {
+        bigint admin_credential_id PK "자격증명 ID"
+        binary_16 user_id FK "사용자 UUID (1:1, role=ADMIN)"
+        varchar email UK "관리자 이메일"
+        varchar password "BCrypt 해시"
+        datetime created_at "생성일"
+        datetime updated_at "수정일"
+    }
+
+    user_action_log["user_action_log (유저 행동 로그)"] {
+        bigint user_action_log_id PK "로그 ID"
+        binary_16 actor_id "행위자 UUID (시스템 로그는 nullable)"
+        enum action "액션 타입 (LOGIN/SIGNUP/LOGOUT/CREATE_DIARY/...)"
+        varchar target_type "대상 타입 (USER/GROUP_ROOM/DIARY/SCHEDULE/COMMENT/TODO 등)"
+        varchar target_id "대상 ID"
+        varchar detail "상세 메시지 (최대 500자)"
+        datetime created_at "기록 일시"
+    }
+
+    announcement["announcement (공지 발송 이력)"] {
+        bigint announcement_id PK "공지 ID"
+        varchar title "공지 제목 (최대 100자)"
+        varchar body "공지 본문 (최대 1000자)"
+        enum target_type "발송 대상 (ALL/USER_IDS)"
+        int recipient_count "실제 발송 수신자 수"
+        datetime created_at "발송 일시"
+        datetime updated_at "수정 일시"
+    }
+
     %% ── 관계 (Relationships) ──
 
-    users ||--o| user_terms : "약관 동의"
-    users ||--o| user_notification_settings : "알림 설정"
-    users ||--o| user_privacy_settings : "개인정보 설정"
+    user ||--o| user_terms : "약관 동의"
+    user ||--o| user_notification_setting : "알림 설정"
+    user ||--o| user_privacy_setting : "개인정보 설정"
 
-    users ||--o{ memberships : "그룹 소속"
-    users ||--o{ devices : "디바이스 등록"
-    users ||--o{ notifications : "알림 수신"
-    users ||--o{ uploaded_images : "이미지 업로드"
-    users ||--o{ comments : "댓글 작성"
+    user ||--o{ membership : "그룹방 소속"
+    user ||--o{ device : "디바이스 등록"
+    user ||--o{ notification : "알림 수신"
+    user ||--o{ uploaded_image : "이미지 업로드"
+    user ||--o{ comment : "댓글 작성"
 
-    groups ||--o{ memberships : "구성원"
-    groups ||--o{ invite_codes : "초대 코드"
-    groups ||--o{ schedules : "일정"
-    groups ||--o{ diaries : "일기"
-    groups ||--o{ todos : "할 일"
-    groups }o--|| users : "방장"
+    group_room ||--o{ membership : "구성원"
+    group_room ||--o{ invite_code : "초대 코드"
+    group_room ||--o{ schedule : "일정"
+    group_room ||--o{ diary : "일기"
+    group_room ||--o{ todo : "할 일"
+    group_room }o--|| user : "방장"
 
-    schedules }o--|| users : "작성자"
-    schedules ||--o{ schedule_participants : "참여자"
-    schedule_participants }o--|| users : "참여 사용자"
+    schedule }o--|| user : "작성자"
+    schedule ||--o{ schedule_participant : "참여자"
+    schedule_participant }o--|| user : "참여 사용자"
 
-    diaries }o--|| users : "작성자"
-    diaries ||--o{ diary_images : "첨부 이미지"
+    diary }o--|| user : "작성자"
 
-    todos }o--|| users : "작성자"
-    todos }o--o| users : "완료자"
+    todo }o--|| user : "작성자"
+    todo }o--o| user : "완료자"
+
+    user ||--o| admin_credential : "관리자 계정"
+    user ||--o{ user_action_log : "행동 기록(actor)"
 ```
 
 ---
@@ -214,14 +239,14 @@ erDiagram
 erDiagram
     JsonWebToken_Redis["JsonWebToken (JWT 토큰 — TTL 14일)"] {
         string refreshToken PK "리프레시 토큰 (키)"
-        string providerId "사용자 UUID (users.user_id 참조)"
+        string providerId "사용자 UUID (user.user_id 참조)"
         string email "사용자 이메일 (nullable)"
         enum role "역할 (USER/ADMIN)"
     }
 
     SocialToken_Redis["SocialToken (소셜 토큰)"] {
         string id PK "키 (userId:provider 형식)"
-        string userId "사용자 UUID (users.user_id 참조)"
+        string userId "사용자 UUID (user.user_id 참조)"
         enum provider "소셜 제공자 (KAKAO/NAVER/APPLE)"
         string accessToken "소셜 액세스 토큰"
         string refreshToken "소셜 리프레시 토큰"
@@ -235,31 +260,35 @@ erDiagram
 
 | # | 테이블 | 설명 | 주요 관계 |
 |---|--------|------|-----------|
-| 1 | `users` | 사용자 (중심 엔티티, PK=UUID, UK=social_id+social_provider) | — |
-| 2 | `user_terms` | 약관 동의 | users 1:1 |
-| 3 | `user_notification_settings` | 알림 설정 | users 1:1 |
-| 4 | `user_privacy_settings` | 개인정보 설정 | users 1:1 |
-| 5 | `groups` | 그룹 (다이어리 방) | users N:1 (방장) |
-| 6 | `memberships` | 그룹 소속 관계 | users N:1, groups N:1 |
-| 7 | `invite_codes` | 초대 코드 (6자리, 만료) | groups N:1 |
-| 8 | `schedules` | 일정 | groups N:1, users N:1 |
-| 9 | `schedule_participants` | 일정 참여자 | schedules N:1, users N:1 |
-| 10 | `diaries` | 일기 | groups N:1, users N:1 |
-| 11 | `diary_images` | 일기 첨부 이미지 (최대 5장) | diaries N:1 |
-| 12 | `comments` | 댓글 (일정/일기 공용) | users N:1 |
-| 13 | `todos` | 할 일 | groups N:1, users N:1 |
-| 14 | `notifications` | 알림 | users N:1 |
-| 15 | `devices` | 디바이스 (FCM 푸시용) | users N:1 |
-| 16 | `uploaded_images` | 업로드 이미지 (S3) | users N:1 |
+| 1 | `user` | 사용자 (중심 엔티티, PK=UUID, UK=social_id+social_provider) | — |
+| 2 | `user_terms` | 약관 동의 | user 1:1 |
+| 3 | `user_notification_setting` | 알림 설정 | user 1:1 |
+| 4 | `user_privacy_setting` | 개인정보 설정 | user 1:1 |
+| 5 | `group_room` | 그룹방 (다이어리 방) | user N:1 (방장) |
+| 6 | `membership` | 그룹방 소속 관계 | user N:1, group_room N:1 |
+| 7 | `invite_code` | 초대 코드 (6자리, 만료) | group_room N:1 |
+| 8 | `schedule` | 일정 | group_room N:1, user N:1 |
+| 9 | `schedule_participant` | 일정 참여자 | schedule N:1, user N:1 |
+| 10 | `diary` | 일기 (이미지 URL 직접 포함) | group_room N:1, user N:1 |
+| 11 | `comment` | 댓글 (일정/일기 공용) | user N:1 |
+| 12 | `todo` | 할 일 | group_room N:1, user N:1 |
+| 13 | `notification` | 알림 | user N:1 |
+| 14 | `device` | 디바이스 (FCM 푸시용) | user N:1 |
+| 15 | `uploaded_image` | 업로드 이미지 (S3) | user N:1 |
+| 16 | `admin_credential` | 관리자 자격증명 (BCrypt) | user 1:1 |
+| 17 | `user_action_log` | 유저 행동 감사 로그 | user N:1 (actor, nullable) |
+| 18 | `announcement` | 관리자 공지 발송 이력 | (독립) |
 
 ### Enum 목록
 
 | Enum | 값 | 사용처 |
 |------|----|--------|
-| `SocialProvider` | KAKAO, NAVER, APPLE, ADMIN | users.social_provider |
-| `Role` | USER, ADMIN | users.role |
-| `GroupRole` | OWNER, MEMBER | memberships.role |
-| `Platform` | IOS, ANDROID | devices.platform |
-| `CommentTargetType` | SCHEDULE, DIARY | comments.target_type |
-| `ImagePurpose` | PROFILE, GROUP_THUMBNAIL, DIARY | uploaded_images.purpose |
-| `NotificationType` | SCHEDULE_CREATED, SCHEDULE_UPDATED, DIARY_WRITTEN, COMMENT_ON_SCHEDULE, COMMENT_ON_DIARY, MEMBER_JOINED, MEMBER_REMOVED, GROUP_DELETE_SCHEDULED | notifications.type |
+| `SocialProvider` | KAKAO, NAVER, APPLE, ADMIN | user.social_provider |
+| `Role` | USER, ADMIN | user.role |
+| `GroupRoomRole` | OWNER, MEMBER | membership.role |
+| `Platform` | IOS, ANDROID | device.platform |
+| `CommentTargetType` | SCHEDULE, DIARY | comment.target_type |
+| `ImagePurpose` | PROFILE, GROUP_THUMBNAIL, DIARY | uploaded_image.purpose |
+| `NotificationType` | SCHEDULE_CREATED, SCHEDULE_UPDATED, DIARY_WRITTEN, COMMENT_ON_SCHEDULE, COMMENT_ON_DIARY, MEMBER_JOINED, MEMBER_LEFT, MEMBER_REMOVED, OWNERSHIP_TRANSFERRED, GROUP_DELETE_SCHEDULED, ANNOUNCEMENT | notification.type |
+| `UserAction` | LOGIN, SIGNUP, LOGOUT, CREATE_DIARY, DELETE_DIARY, CREATE_SCHEDULE, DELETE_SCHEDULE, CREATE_COMMENT, CREATE_GROUP_ROOM, JOIN_GROUP_ROOM, LEAVE_GROUP_ROOM, TRANSFER_OWNER, CREATE_TODO, OTHER | user_action_log.action |
+| `AnnouncementTarget` | ALL, USER_IDS | announcement.target_type |

--- a/src/main/kotlin/digdaserver/admin/announcement/presentation/controller/AdminAnnouncementController.kt
+++ b/src/main/kotlin/digdaserver/admin/announcement/presentation/controller/AdminAnnouncementController.kt
@@ -1,24 +1,29 @@
 package digdaserver.admin.announcement.presentation.controller
 
 import digdaserver.admin.announcement.presentation.dto.req.SendAnnouncementRequest
+import digdaserver.admin.announcement.presentation.dto.res.AdminAnnouncementResponse
 import digdaserver.admin.announcement.presentation.dto.res.SendAnnouncementResponse
-import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.domain.announcement.application.service.AnnouncementService
+import digdaserver.domain.announcement.domain.entity.AnnouncementTarget
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/admin/announcements")
-@Tag(name = "Admin - Announcement", description = "관리자 공지 발송 API")
+@Tag(name = "Admin - Announcement", description = "관리자 공지 발송/조회 API")
 class AdminAnnouncementController(
-    private val notificationService: NotificationService
+    private val announcementService: AnnouncementService
 ) {
 
     @Operation(
@@ -27,14 +32,35 @@ class AdminAnnouncementController(
     )
     @PostMapping
     fun send(@Valid @RequestBody request: SendAnnouncementRequest): ResponseEntity<SendAnnouncementResponse> {
-        val targetUserIds = when (request.target.uppercase()) {
-            "ALL" -> null
-            "USER_IDS" -> request.userIds?.takeIf { it.isNotEmpty() }
+        val target = parseTarget(request.target)
+        val targetUserIds = when (target) {
+            AnnouncementTarget.ALL -> null
+            AnnouncementTarget.USER_IDS -> request.userIds?.takeIf { it.isNotEmpty() }
                 ?: throw DigdaException(ErrorCode.INVALID_PARAMETER, "USER_IDS 발송 시 userIds가 비어있을 수 없습니다")
-            else -> throw DigdaException(ErrorCode.INVALID_PARAMETER, "target은 ALL 또는 USER_IDS 만 허용됩니다")
         }
 
-        val count = notificationService.sendAnnouncement(targetUserIds, request.title, request.body)
-        return ResponseEntity.ok(SendAnnouncementResponse(recipientCount = count))
+        val saved = announcementService.send(target, targetUserIds, request.title, request.body)
+        return ResponseEntity.ok(SendAnnouncementResponse(recipientCount = saved.recipientCount))
     }
+
+    @Operation(
+        summary = "공지 목록 조회",
+        description = "최신순 정렬. 제목/본문 키워드 검색 지원."
+    )
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminAnnouncementResponse>> {
+        val result = announcementService.search(keyword, page, size)
+        return ResponseEntity.ok(AdminPageResponse.of(result, AdminAnnouncementResponse::from))
+    }
+
+    private fun parseTarget(raw: String): AnnouncementTarget =
+        when (raw.uppercase()) {
+            "ALL" -> AnnouncementTarget.ALL
+            "USER_IDS" -> AnnouncementTarget.USER_IDS
+            else -> throw DigdaException(ErrorCode.INVALID_PARAMETER, "target은 ALL 또는 USER_IDS 만 허용됩니다")
+        }
 }

--- a/src/main/kotlin/digdaserver/admin/announcement/presentation/dto/res/AdminAnnouncementResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/announcement/presentation/dto/res/AdminAnnouncementResponse.kt
@@ -1,0 +1,38 @@
+package digdaserver.admin.announcement.presentation.dto.res
+
+import digdaserver.domain.announcement.domain.entity.Announcement
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "관리자 공지 항목")
+data class AdminAnnouncementResponse(
+
+    @Schema(description = "공지 ID")
+    val announcementId: Long,
+
+    @Schema(description = "공지 제목")
+    val title: String,
+
+    @Schema(description = "공지 본문")
+    val body: String,
+
+    @Schema(description = "발송 대상 (ALL / USER_IDS)")
+    val targetType: String,
+
+    @Schema(description = "실제 발송된 수신자 수")
+    val recipientCount: Int,
+
+    @Schema(description = "발송 시각")
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(entity: Announcement): AdminAnnouncementResponse = AdminAnnouncementResponse(
+            announcementId = entity.id,
+            title = entity.title,
+            body = entity.body,
+            targetType = entity.targetType.name,
+            recipientCount = entity.recipientCount,
+            createdAt = entity.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/announcement/application/service/AnnouncementService.kt
+++ b/src/main/kotlin/digdaserver/domain/announcement/application/service/AnnouncementService.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.announcement.application.service
+
+import digdaserver.domain.announcement.domain.entity.Announcement
+import digdaserver.domain.announcement.domain.entity.AnnouncementTarget
+import org.springframework.data.domain.Page
+import java.util.UUID
+
+interface AnnouncementService {
+
+    fun send(
+        target: AnnouncementTarget,
+        targetUserIds: List<UUID>?,
+        title: String,
+        body: String
+    ): Announcement
+
+    fun search(keyword: String?, page: Int, size: Int): Page<Announcement>
+}

--- a/src/main/kotlin/digdaserver/domain/announcement/application/service/impl/AnnouncementServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/announcement/application/service/impl/AnnouncementServiceImpl.kt
@@ -1,0 +1,46 @@
+package digdaserver.domain.announcement.application.service.impl
+
+import digdaserver.domain.announcement.application.service.AnnouncementService
+import digdaserver.domain.announcement.domain.entity.Announcement
+import digdaserver.domain.announcement.domain.entity.AnnouncementTarget
+import digdaserver.domain.announcement.domain.repository.AnnouncementRepository
+import digdaserver.domain.notification.application.service.NotificationService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class AnnouncementServiceImpl(
+    private val announcementRepository: AnnouncementRepository,
+    private val notificationService: NotificationService
+) : AnnouncementService {
+
+    @Transactional
+    override fun send(
+        target: AnnouncementTarget,
+        targetUserIds: List<UUID>?,
+        title: String,
+        body: String
+    ): Announcement {
+        val resolvedUserIds = if (target == AnnouncementTarget.ALL) null else targetUserIds
+        val recipientCount = notificationService.sendAnnouncement(resolvedUserIds, title, body)
+
+        return announcementRepository.save(
+            Announcement(
+                title = title,
+                body = body,
+                targetType = target,
+                recipientCount = recipientCount
+            )
+        )
+    }
+
+    override fun search(keyword: String?, page: Int, size: Int): Page<Announcement> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        return announcementRepository.searchForAdmin(keyword?.takeIf { it.isNotBlank() }, pageable)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/announcement/domain/entity/Announcement.kt
+++ b/src/main/kotlin/digdaserver/domain/announcement/domain/entity/Announcement.kt
@@ -1,0 +1,41 @@
+package digdaserver.domain.announcement.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+
+@Entity
+@Table(
+    name = "announcement",
+    indexes = [
+        Index(name = "idx_announcement_created_at", columnList = "created_at")
+    ]
+)
+class Announcement(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "announcement_id")
+    val id: Long = 0L,
+
+    @Column(nullable = false, length = 100)
+    val title: String,
+
+    @Column(nullable = false, length = 1000)
+    val body: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 20)
+    val targetType: AnnouncementTarget,
+
+    @Column(name = "recipient_count", nullable = false)
+    val recipientCount: Int
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/digdaserver/domain/announcement/domain/entity/AnnouncementTarget.kt
+++ b/src/main/kotlin/digdaserver/domain/announcement/domain/entity/AnnouncementTarget.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.announcement.domain.entity
+
+enum class AnnouncementTarget {
+    ALL,
+    USER_IDS
+}

--- a/src/main/kotlin/digdaserver/domain/announcement/domain/repository/AnnouncementRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/announcement/domain/repository/AnnouncementRepository.kt
@@ -1,0 +1,21 @@
+package digdaserver.domain.announcement.domain.repository
+
+import digdaserver.domain.announcement.domain.entity.Announcement
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AnnouncementRepository : JpaRepository<Announcement, Long> {
+
+    @Query(
+        """
+        SELECT a FROM Announcement a
+        WHERE (:keyword IS NULL OR a.title LIKE %:keyword% OR a.body LIKE %:keyword%)
+        """
+    )
+    fun searchForAdmin(@Param("keyword") keyword: String?, pageable: Pageable): Page<Announcement>
+}


### PR DESCRIPTION
## Summary
- \`Announcement\` 엔티티 + 리포지토리 신설 (title/body/targetType/recipientCount + BaseTimeEntity)
- \`AnnouncementService\` 추가: 발송 시 \`NotificationService.sendAnnouncement\` 위임 + \`announcement\` 1행 저장
- GET \`/api/admin/announcements\` (page/size/keyword) 추가 → \`AdminPageResponse<AdminAnnouncementResponse>\`
- 기존 POST 컨트롤러도 새 서비스를 경유하도록 변경 (이제 발송하면 자동으로 이력 저장됨)
- API 명세서/ERD 동기화: §13-21·13-22 추가, \`announcement\` 테이블 + \`AnnouncementTarget\` enum 반영

## Test plan
- [ ] POST \`/api/admin/announcements\` ALL/USER_IDS 두 케이스 모두 성공 후 \`announcement\` 테이블에 1행 INSERT 확인
- [ ] GET \`/api/admin/announcements?page=0&size=20\` 응답이 createdAt DESC 정렬, recipientCount 정확
- [ ] keyword 검색이 title/body LIKE 부분일치로 동작
- [ ] 기존 발송 동작(notification + FCM 멀티캐스트) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)