### PR TITLE
[Fix] 파일 업로드 크기 제한 50MB 상향 및 404 로그 정리

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -22,6 +23,14 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(e.httpStatusCode)
             .body(ErrorResponse.of(e))
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFound(e: NoResourceFoundException): ResponseEntity<ErrorResponse> {
+        log.warn("404 Not Found: {}", e.message)
+        return ResponseEntity
+            .status(404)
+            .body(ErrorResponse.of(ErrorCode.SERVER_ERROR))
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,8 +35,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 50MB
+      max-request-size: 50MB
 
   task:
     scheduling:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,8 +35,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 50MB
+      max-request-size: 50MB
 
   task:
     scheduling:


### PR DESCRIPTION
## Summary
- multipart 파일 업로드 크기 제한 20MB → 50MB (dev/prod 동일 적용)
- `NoResourceFoundException` (404) 발생 시 스택트레이스 없이 WARN 한 줄로 처리

## Test plan
- [ ] 50MB 이하 이미지 업로드 정상 동작 확인
- [ ] 없는 경로 요청 시 로그가 한 줄 WARN으로만 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)