### PR TITLE
fix: 일정 수정 참여자 duplicate key 오류 수정 및 파일 업로드 크기 8MB 상향

### DIFF
--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
@@ -178,10 +178,20 @@ class ScheduleServiceImpl(
         )
 
         val addedParticipantIds = request.participantIds?.let { newIds ->
-            val oldIds = schedule.participants.map { it.user.id }.toSet()
-            schedule.clearParticipants()
-            addParticipants(schedule, groupRoomId, newIds)
-            newIds.filter { it !in oldIds }
+            val oldIdSet = schedule.participants.map { it.user.id }.toSet()
+            val newIdSet = newIds.toSet()
+
+            // 제거: 새 목록에 없는 기존 참여자만 삭제 (orphanRemoval 트리거)
+            val iterator = schedule.participants.iterator()
+            while (iterator.hasNext()) {
+                if (iterator.next().user.id !in newIdSet) iterator.remove()
+            }
+
+            // 추가: 기존에 없는 참여자만 INSERT — clear/re-insert 패턴 제거로 duplicate key 방지
+            val toAdd = newIds.filter { it !in oldIdSet }
+            addParticipants(schedule, groupRoomId, toAdd)
+
+            toAdd
         } ?: emptyList()
 
         groupRoom.updateLastActivity()

--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -27,7 +27,7 @@ class UploadServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val MAX_SIZE_BYTES = 5L * 1024 * 1024
+        private const val MAX_SIZE_BYTES = 8L * 1024 * 1024
         private val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/jpg")
     }
 

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -90,7 +90,7 @@ enum class ErrorCode(
     DEVICE_NOT_FOUND("DEVICE_NOT_FOUND", "존재하지 않는 디바이스입니다.", 404),
 
     // ── Upload ──
-    FILE_TOO_LARGE("FILE_TOO_LARGE", "파일 크기가 5MB를 초과합니다.", 413),
+    FILE_TOO_LARGE("FILE_TOO_LARGE", "파일 크기가 8MB를 초과합니다.", 413),
     INVALID_FILE_TYPE("INVALID_FILE_TYPE", "PNG 또는 JPEG 파일만 업로드할 수 있습니다.", 400),
     IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", "존재하지 않는 이미지입니다.", 404),
 


### PR DESCRIPTION
## Summary

- **일정 수정 참여자 duplicate key 버그 수정**
  - 증상: `PUT /schedules/:id` 호출 시 `Duplicate entry for key 'schedule_participant.UKlncr8gcy4ntjcvrrqh51j9f1n'` 에러
  - 원인: 기존 `clearParticipants()` → `addParticipants()` 패턴에서 JPA auto-flush 시 DELETE보다 INSERT가 먼저 실행됨 (기존 참여자를 재추가할 때 unique constraint 위반)
  - 수정: diff 방식으로 변경 — 제거 대상만 삭제, 신규 대상만 INSERT, 유지 항목은 DB 변경 없음
- **파일 업로드 최대 크기 5MB → 8MB 상향**
  - `UploadServiceImpl.MAX_SIZE_BYTES`: `5L * 1024 * 1024` → `8L * 1024 * 1024`
  - `ErrorCode.FILE_TOO_LARGE` 에러 메시지 동기화

## Test plan

- [ ] 일정 수정 시 기존 참여자 유지 + 새 참여자 추가 → 500 없이 정상 응답
- [ ] 일정 수정 시 기존 참여자 일부 제거 → 정상 제거 확인
- [ ] 8MB 이하 이미지 업로드 → 성공
- [ ] 8MB 초과 이미지 업로드 → `FILE_TOO_LARGE` 에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)