### PR TITLE
fix: 썸네일 업로드ID→URL 변환 + 주요 액션 사용자 로그 추가

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -20,9 +20,11 @@ import digdaserver.domain.log.domain.entity.UserAction
 import digdaserver.domain.membership.domain.entity.Membership
 import digdaserver.domain.membership.domain.repository.MembershipRepository
 import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.domain.upload.domain.repository.UploadedImageRepository
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -36,22 +38,46 @@ class GroupRoomServiceImpl(
     private val membershipRepository: MembershipRepository,
     private val inviteCodeRepository: InviteCodeRepository,
     private val notificationService: NotificationService,
-    private val userActionLogService: UserActionLogService
+    private val userActionLogService: UserActionLogService,
+    private val uploadedImageRepository: UploadedImageRepository
 ) : GroupRoomService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 클라이언트가 보내는 thumbnailImageId(=UploadedImage 의 PK 문자열) 를 실제 S3 URL 로 변환.
+     * 입력이 null/blank/숫자가 아니면 null 을 반환해 호출 측에서 변경 없음으로 처리한다.
+     */
+    private fun resolveImageUrl(imageId: String?): String? {
+        if (imageId.isNullOrBlank()) return null
+        val id = imageId.toLongOrNull() ?: run {
+            log.warn("imageId 가 Long 이 아님: imageId={}", imageId)
+            return null
+        }
+        val image = uploadedImageRepository.findById(id).orElse(null)
+        if (image == null) {
+            log.warn("imageId 에 해당하는 업로드 레코드 없음: imageId={}", id)
+            return null
+        }
+        return image.url
+    }
 
     @Transactional
     override fun createGroupRoom(userId: UUID, request: CreateGroupRoomRequest): CreateGroupRoomResponse {
+        log.info("userId={}, action=그룹 생성 요청, name={}", userId, request.name)
         validateGroupRoomName(request.name)
 
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val thumbnailUrl = resolveImageUrl(request.thumbnailImageId)
 
         val groupRoom = groupRoomRepository.save(
             GroupRoom(
                 name = request.name,
                 maxMembers = request.maxMembers,
                 owner = user,
-                thumbnailImage = request.thumbnailImageId
+                thumbnailImage = thumbnailUrl
             )
         )
 
@@ -80,6 +106,9 @@ class GroupRoomServiceImpl(
             detail = "name=${groupRoom.name}"
         )
 
+        log.info("userId={}, action=그룹 생성 완료, groupRoomId={}, thumbnail={}",
+            userId, groupRoom.id, groupRoom.thumbnailImage)
+
         return CreateGroupRoomResponse(
             groupRoom = GroupRoomResponse.from(groupRoom, 1),
             inviteCode = inviteCode.code,
@@ -88,6 +117,7 @@ class GroupRoomServiceImpl(
     }
 
     override fun getMyGroupRooms(userId: UUID): GroupRoomListResponse {
+        log.info("userId={}, action=내 그룹방 목록 조회", userId)
         val memberships = membershipRepository.findAllByUserIdWithGroupRoom(userId)
 
         val groupRoomItems = memberships.map { membership ->
@@ -107,6 +137,7 @@ class GroupRoomServiceImpl(
     }
 
     override fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse {
+        log.info("userId={}, action=그룹 상세 조회, groupRoomId={}", userId, groupRoomId)
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
 
@@ -127,6 +158,9 @@ class GroupRoomServiceImpl(
 
     @Transactional
     override fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse {
+        log.info("userId={}, action=그룹 수정 요청, groupRoomId={}, fields=[name={}, maxMembers={}, thumbnailImageId={}]",
+            userId, groupRoomId, request.name, request.maxMembers, request.thumbnailImageId)
+
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
 
@@ -150,14 +184,25 @@ class GroupRoomServiceImpl(
             thumbnailImage = null
         )
 
-        // thumbnailImageId: null(미전송)=변경없음, Optional.empty=삭제, Optional(값)=변경
+        // thumbnailImageId: null(미전송)=변경없음, Optional.empty=삭제, Optional(값)=변경.
+        // 값이 전달되면 UploadedImage 의 PK 문자열이므로 실제 S3 URL 로 변환해 저장한다.
+        // (기존엔 PK 문자열을 그대로 저장하여 클라이언트 리스트 썸네일이 깨졌음)
         request.thumbnailImageId?.let { optional ->
             if (optional.isPresent) {
-                groupRoom.thumbnailImage = optional.get()
+                val resolvedUrl = resolveImageUrl(optional.get())
+                if (resolvedUrl != null) {
+                    groupRoom.thumbnailImage = resolvedUrl
+                } else {
+                    log.warn("userId={}, action=그룹 썸네일 변경 무시(업로드 lookup 실패), groupRoomId={}, imageId={}",
+                        userId, groupRoomId, optional.get())
+                }
             } else {
                 groupRoom.removeThumbnail()
             }
         }
+
+        log.info("userId={}, action=그룹 수정 완료, groupRoomId={}, thumbnail={}",
+            userId, groupRoomId, groupRoom.thumbnailImage)
 
         val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
         return GroupRoomResponse.from(groupRoom, memberCount)
@@ -165,6 +210,8 @@ class GroupRoomServiceImpl(
 
     @Transactional
     override fun deleteGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomDeleteResponse {
+        log.info("userId={}, action=그룹 삭제 요청, groupRoomId={}", userId, groupRoomId)
+
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
 
@@ -179,6 +226,9 @@ class GroupRoomServiceImpl(
 
         notificationService.notifyGroupRoomDeleteScheduled(groupRoomId, userId)
 
+        log.info("userId={}, action=그룹 삭제 예약 완료, groupRoomId={}, deleteScheduledAt={}",
+            userId, groupRoomId, groupRoom.deleteScheduledAt)
+
         return GroupRoomDeleteResponse(
             deleteScheduledAt = groupRoom.deleteScheduledAt!!
         )
@@ -186,6 +236,8 @@ class GroupRoomServiceImpl(
 
     @Transactional
     override fun recoverGroupRoom(userId: UUID, groupRoomId: Long): GroupRoomResponse {
+        log.info("userId={}, action=그룹 복구 요청, groupRoomId={}", userId, groupRoomId)
+
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
 
@@ -199,6 +251,8 @@ class GroupRoomServiceImpl(
         if (!membership.isOwner) throw DigdaException(ErrorCode.NOT_GROUP_ROOM_OWNER)
 
         groupRoom.recover()
+
+        log.info("userId={}, action=그룹 복구 완료, groupRoomId={}", userId, groupRoomId)
 
         val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
         return GroupRoomResponse.from(groupRoom, memberCount)

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -16,6 +16,7 @@ import digdaserver.global.common.page.OffsetBasedPageRequest
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import digdaserver.global.infra.fcm.presentation.application.NotificationPushDispatcher
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,7 +32,10 @@ class NotificationServiceImpl(
     private val pushDispatcher: NotificationPushDispatcher
 ) : NotificationService {
 
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun getNotifications(userId: UUID, limit: Int, offset: Int): NotificationListResponse {
+        log.info("userId={}, action=알림 목록 조회, limit={}, offset={}", userId, limit, offset)
         val safeLimit = limit.coerceIn(1, 100)
         val safeOffset = offset.coerceAtLeast(0)
         val pageable = OffsetBasedPageRequest.of(
@@ -55,17 +59,21 @@ class NotificationServiceImpl(
 
     @Transactional
     override fun markAsRead(userId: UUID, notificationId: Long, isRead: Boolean) {
+        log.info("userId={}, action=알림 읽음 처리, notificationId={}, isRead={}",
+            userId, notificationId, isRead)
         val notification = requireOwnedNotification(userId, notificationId)
         if (isRead) notification.markAsRead()
     }
 
     @Transactional
     override fun markAllAsRead(userId: UUID) {
+        log.info("userId={}, action=전체 알림 읽음 처리", userId)
         notificationRepository.markAllAsReadByUserId(userId)
     }
 
     @Transactional
     override fun deleteNotification(userId: UUID, notificationId: Long) {
+        log.info("userId={}, action=알림 삭제, notificationId={}", userId, notificationId)
         val notification = requireOwnedNotification(userId, notificationId)
         notificationRepository.delete(notification)
     }

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
@@ -27,6 +27,8 @@ class AccountServiceImpl(
     private val log = LoggerFactory.getLogger(AccountServiceImpl::class.java)
 
     override fun deleteAccount(userId: UUID) {
+        log.info("userId={}, action=회원 탈퇴 요청", userId)
+
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
@@ -83,6 +83,11 @@ class SocialLoginServiceImpl(
             detail = "provider=$provider, email=${user.email}"
         )
 
+        log.info("userId={}, action={}, provider={}",
+            user.id,
+            if (isNewUser) "회원 가입" else "로그인",
+            provider)
+
         return LoginResponse(
             accessToken = loginToken.accessToken,
             refreshToken = loginToken.refreshToken,

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
@@ -1,11 +1,13 @@
 package digdaserver.domain.user.application.service.impl
 
+import digdaserver.domain.upload.domain.repository.UploadedImageRepository
 import digdaserver.domain.user.application.service.UserProfileService
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.domain.user.presentation.dto.req.UpdateProfileRequest
 import digdaserver.domain.user.presentation.dto.res.MyProfileResponse
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -13,10 +15,29 @@ import java.util.UUID
 @Service
 @Transactional(readOnly = true)
 class UserProfileServiceImpl(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val uploadedImageRepository: UploadedImageRepository
 ) : UserProfileService {
 
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /** 업로드 PK 문자열 → 실제 S3 URL 로 변환. 그룹방 썸네일과 동일 로직. */
+    private fun resolveImageUrl(imageId: String?): String? {
+        if (imageId.isNullOrBlank()) return null
+        val id = imageId.toLongOrNull() ?: run {
+            log.warn("imageId 가 Long 이 아님: imageId={}", imageId)
+            return null
+        }
+        val image = uploadedImageRepository.findById(id).orElse(null)
+        if (image == null) {
+            log.warn("imageId 에 해당하는 업로드 레코드 없음: imageId={}", id)
+            return null
+        }
+        return image.url
+    }
+
     override fun getMyProfile(userId: UUID): MyProfileResponse {
+        log.info("userId={}, action=내 프로필 조회", userId)
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
@@ -25,6 +46,9 @@ class UserProfileServiceImpl(
 
     @Transactional
     override fun updateProfile(userId: UUID, request: UpdateProfileRequest): MyProfileResponse {
+        log.info("userId={}, action=프로필 수정 요청, fields=[name={}, statusMessage={}, profileImageId={}]",
+            userId, request.name, request.statusMessage, request.profileImageId)
+
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
@@ -43,14 +67,23 @@ class UserProfileServiceImpl(
             }
         }
 
+        // profileImageId: null(미전송)=변경없음, Optional.empty=초기화, Optional(값)=변경.
+        // 값이 들어오면 UploadedImage 의 PK 문자열이므로 S3 URL 로 변환해 저장한다.
         request.profileImageId?.let { optional ->
             if (optional.isPresent) {
-                user.profileImage = optional.get()
+                val resolvedUrl = resolveImageUrl(optional.get())
+                if (resolvedUrl != null) {
+                    user.profileImage = resolvedUrl
+                } else {
+                    log.warn("userId={}, action=프로필 이미지 변경 무시(업로드 lookup 실패), imageId={}",
+                        userId, optional.get())
+                }
             } else {
                 user.resetProfileImage()
             }
         }
 
+        log.info("userId={}, action=프로필 수정 완료, profileImage={}", userId, user.profileImage)
         return MyProfileResponse.from(user)
     }
 }


### PR DESCRIPTION
## Summary

### 1. 그룹/프로필 썸네일 표시 안되는 버그 수정
클라이언트 측에서 \`thumbnailImageId\` / \`profileImageId\` 는 \`UploadedImage\` 의 PK 문자열을 전송합니다. 기존 서비스 구현은 그 값을 그대로 \`thumbnail_image\` / \`profile_image\` URL 컬럼에 저장하고 있어, 앱 리스트에서 \`Image.network\` 가 정상 URL 이 아닌 PK 문자열을 로드 시도 → 그룹 리스트 썸네일이 항상 비어 보이는 문제가 있었습니다.

- \`GroupRoomServiceImpl\`: \`UploadedImageRepository\` 주입, \`resolveImageUrl(imageId)\` 헬퍼로 PK→URL 변환 후 entity 에 저장. \`createGroupRoom\` / \`updateGroupRoom\` 모두 적용. lookup 실패 시 warn 로그.
- \`UserProfileServiceImpl\`: 동일 패턴으로 프로필 이미지도 실제 URL 로 저장.

### 2. 주요 액션 사용자 로그 추가 (요청 사항)
디버깅 가시성 향상을 위해 주요 진입점에 \`log.info(\"userId={}, action=...\", userId, ...)\` 형식 로그 추가.

대상:
- \`SocialLoginServiceImpl#login\`: 로그인/회원가입 성공 시 \`userId + provider\` 로그
- \`AccountServiceImpl#deleteAccount\`: 진입 시점
- \`GroupRoomServiceImpl\`: 생성 / 내 목록 / 상세 / 수정 / 삭제 / 복구 모두
- \`UserProfileServiceImpl\`: 조회 / 수정
- \`NotificationServiceImpl\`: 목록 / 단건 읽음 / 전체 읽음 / 삭제

## Test plan
- [ ] 그룹 생성 시 이미지 첨부 → 리스트 썸네일 즉시 노출 확인
- [ ] 그룹 수정에서 이미지 교체/삭제 → 리스트 썸네일 갱신 확인
- [ ] 프로필 이미지 변경 → 마이페이지/멤버 리스트에서 정상 노출 확인
- [ ] 서버 로그에 \`userId=..., action=그룹 삭제\` 등 사용자 액션 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)