### PR TITLE
style: ktlint argument-list-wrapping 포맷팅 (CI hotfix)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -106,8 +106,12 @@ class GroupRoomServiceImpl(
             detail = "name=${groupRoom.name}"
         )
 
-        log.info("userId={}, action=그룹 생성 완료, groupRoomId={}, thumbnail={}",
-            userId, groupRoom.id, groupRoom.thumbnailImage)
+        log.info(
+            "userId={}, action=그룹 생성 완료, groupRoomId={}, thumbnail={}",
+            userId,
+            groupRoom.id,
+            groupRoom.thumbnailImage
+        )
 
         return CreateGroupRoomResponse(
             groupRoom = GroupRoomResponse.from(groupRoom, 1),
@@ -158,8 +162,14 @@ class GroupRoomServiceImpl(
 
     @Transactional
     override fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse {
-        log.info("userId={}, action=그룹 수정 요청, groupRoomId={}, fields=[name={}, maxMembers={}, thumbnailImageId={}]",
-            userId, groupRoomId, request.name, request.maxMembers, request.thumbnailImageId)
+        log.info(
+            "userId={}, action=그룹 수정 요청, groupRoomId={}, fields=[name={}, maxMembers={}, thumbnailImageId={}]",
+            userId,
+            groupRoomId,
+            request.name,
+            request.maxMembers,
+            request.thumbnailImageId
+        )
 
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
@@ -193,16 +203,24 @@ class GroupRoomServiceImpl(
                 if (resolvedUrl != null) {
                     groupRoom.thumbnailImage = resolvedUrl
                 } else {
-                    log.warn("userId={}, action=그룹 썸네일 변경 무시(업로드 lookup 실패), groupRoomId={}, imageId={}",
-                        userId, groupRoomId, optional.get())
+                    log.warn(
+                        "userId={}, action=그룹 썸네일 변경 무시(업로드 lookup 실패), groupRoomId={}, imageId={}",
+                        userId,
+                        groupRoomId,
+                        optional.get()
+                    )
                 }
             } else {
                 groupRoom.removeThumbnail()
             }
         }
 
-        log.info("userId={}, action=그룹 수정 완료, groupRoomId={}, thumbnail={}",
-            userId, groupRoomId, groupRoom.thumbnailImage)
+        log.info(
+            "userId={}, action=그룹 수정 완료, groupRoomId={}, thumbnail={}",
+            userId,
+            groupRoomId,
+            groupRoom.thumbnailImage
+        )
 
         val memberCount = membershipRepository.countByGroupRoomId(groupRoomId)
         return GroupRoomResponse.from(groupRoom, memberCount)
@@ -226,8 +244,12 @@ class GroupRoomServiceImpl(
 
         notificationService.notifyGroupRoomDeleteScheduled(groupRoomId, userId)
 
-        log.info("userId={}, action=그룹 삭제 예약 완료, groupRoomId={}, deleteScheduledAt={}",
-            userId, groupRoomId, groupRoom.deleteScheduledAt)
+        log.info(
+            "userId={}, action=그룹 삭제 예약 완료, groupRoomId={}, deleteScheduledAt={}",
+            userId,
+            groupRoomId,
+            groupRoom.deleteScheduledAt
+        )
 
         return GroupRoomDeleteResponse(
             deleteScheduledAt = groupRoom.deleteScheduledAt!!

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -59,8 +59,12 @@ class NotificationServiceImpl(
 
     @Transactional
     override fun markAsRead(userId: UUID, notificationId: Long, isRead: Boolean) {
-        log.info("userId={}, action=알림 읽음 처리, notificationId={}, isRead={}",
-            userId, notificationId, isRead)
+        log.info(
+            "userId={}, action=알림 읽음 처리, notificationId={}, isRead={}",
+            userId,
+            notificationId,
+            isRead
+        )
         val notification = requireOwnedNotification(userId, notificationId)
         if (isRead) notification.markAsRead()
     }

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
@@ -83,10 +83,12 @@ class SocialLoginServiceImpl(
             detail = "provider=$provider, email=${user.email}"
         )
 
-        log.info("userId={}, action={}, provider={}",
+        log.info(
+            "userId={}, action={}, provider={}",
             user.id,
             if (isNewUser) "회원 가입" else "로그인",
-            provider)
+            provider
+        )
 
         return LoginResponse(
             accessToken = loginToken.accessToken,

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
@@ -46,8 +46,13 @@ class UserProfileServiceImpl(
 
     @Transactional
     override fun updateProfile(userId: UUID, request: UpdateProfileRequest): MyProfileResponse {
-        log.info("userId={}, action=프로필 수정 요청, fields=[name={}, statusMessage={}, profileImageId={}]",
-            userId, request.name, request.statusMessage, request.profileImageId)
+        log.info(
+            "userId={}, action=프로필 수정 요청, fields=[name={}, statusMessage={}, profileImageId={}]",
+            userId,
+            request.name,
+            request.statusMessage,
+            request.profileImageId
+        )
 
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
@@ -75,8 +80,11 @@ class UserProfileServiceImpl(
                 if (resolvedUrl != null) {
                     user.profileImage = resolvedUrl
                 } else {
-                    log.warn("userId={}, action=프로필 이미지 변경 무시(업로드 lookup 실패), imageId={}",
-                        userId, optional.get())
+                    log.warn(
+                        "userId={}, action=프로필 이미지 변경 무시(업로드 lookup 실패), imageId={}",
+                        userId,
+                        optional.get()
+                    )
                 }
             } else {
                 user.resetProfileImage()


### PR DESCRIPTION
## Summary
직전 PR #48 의 multi-line \`log.info(...)\` 호출이 ktlint 의 \`standard:argument-list-wrapping\` 룰을 위반해 CI 가 실패함. \`./gradlew ktlintFormat\` 으로 자동 정렬.

기능 변경 없음 — 포맷 only.

## 영향 파일
- GroupRoomServiceImpl, NotificationServiceImpl, SocialLoginServiceImpl, UserProfileServiceImpl

## 검증
- \`./gradlew ktlintCheck\` ✅
- \`./gradlew compileKotlin\` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)