### PR TITLE
feat: 그룹방 자동 정리 스케줄러 + 초대코드 숫자화

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/scheduler/GroupRoomCleanupScheduler.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/scheduler/GroupRoomCleanupScheduler.kt
@@ -1,0 +1,87 @@
+package digdaserver.domain.group_room.application.scheduler
+
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * delete_scheduled_at 이 만료된 그룹방을 영구 삭제하는 잡.
+ *
+ * - 매 5분마다 실행 (fixedDelay = 300_000ms).
+ * - row 단위 격리: 한 그룹방 삭제가 실패해도 나머지는 계속 처리한다. 이를 위해
+ *   실제 삭제 로직은 [GroupRoomPurgeExecutor.purge] 에 위임 — 별도 빈으로 호출해야
+ *   Spring 의 @Transactional 프록시가 정상 동작한다 (self-invocation 회피).
+ * - JPA cascade(ALL) + orphanRemoval 로 membership/invite/schedule/diary/todo 가
+ *   함께 정리된다.
+ */
+@Component
+class GroupRoomCleanupScheduler(
+    private val groupRoomRepository: GroupRoomRepository,
+    private val purgeExecutor: GroupRoomPurgeExecutor
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = FIXED_DELAY_MS, initialDelay = INITIAL_DELAY_MS)
+    fun purgeScheduledGroupRooms() {
+        val now = LocalDateTime.now()
+        val targets = groupRoomRepository.findAllScheduledForDeletion(now)
+        if (targets.isEmpty()) return
+
+        log.info("action=그룹방 자동 정리 시작, count={}, now={}", targets.size, now)
+        var success = 0
+        var failed = 0
+        targets.forEach { room ->
+            val id = room.id
+            try {
+                purgeExecutor.purge(id)
+                success++
+            } catch (e: Exception) {
+                failed++
+                log.error(
+                    "action=그룹방 자동 정리 실패, groupRoomId={}, error={}",
+                    id,
+                    e.message,
+                    e
+                )
+            }
+        }
+        log.info("action=그룹방 자동 정리 완료, success={}, failed={}", success, failed)
+    }
+
+    companion object {
+        private const val FIXED_DELAY_MS = 5L * 60 * 1000
+        private const val INITIAL_DELAY_MS = 60L * 1000
+    }
+}
+
+@Component
+class GroupRoomPurgeExecutor(
+    private val groupRoomRepository: GroupRoomRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun purge(groupRoomId: Long) {
+        val room = groupRoomRepository.findById(groupRoomId).orElse(null) ?: return
+        if (room.deleteScheduledAt == null || room.deleteScheduledAt!!.isAfter(LocalDateTime.now())) {
+            log.info(
+                "action=그룹방 영구 삭제 건너뜀(만료 전 또는 복구됨), groupRoomId={}, deleteScheduledAt={}",
+                groupRoomId,
+                room.deleteScheduledAt
+            )
+            return
+        }
+        log.info(
+            "action=그룹방 영구 삭제, groupRoomId={}, name={}, deleteScheduledAt={}",
+            groupRoomId,
+            room.name,
+            room.deleteScheduledAt
+        )
+        groupRoomRepository.delete(room)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -286,7 +286,7 @@ class GroupRoomServiceImpl(
     }
 
     private fun generateInviteCode(): String {
-        val chars = ('A'..'Z') + ('0'..'9')
+        val chars = ('0'..'9').toList()
         return (1..6).map { chars.random() }.joinToString("")
     }
 

--- a/src/main/kotlin/digdaserver/domain/group_room/domain/entity/GroupRoom.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/domain/entity/GroupRoom.kt
@@ -82,7 +82,7 @@ class GroupRoom(
     }
 
     fun scheduleDelete() {
-        this.deleteScheduledAt = LocalDateTime.now().plusDays(7)
+        this.deleteScheduledAt = LocalDateTime.now().plusHours(24)
     }
 
     fun recover() {

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -70,7 +70,7 @@ class GroupRoomController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(summary = "그룹방 삭제", description = "그룹방을 삭제 예약합니다. 7일 후 영구 삭제됩니다. 방장만 가능합니다.")
+    @Operation(summary = "그룹방 삭제", description = "그룹방을 삭제 예약합니다. 24시간 후 영구 삭제됩니다. 방장만 가능합니다.")
     @DeleteMapping("/{groupRoomId}")
     fun deleteGroupRoom(
         @AuthenticationPrincipal userId: String,
@@ -80,7 +80,7 @@ class GroupRoomController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(summary = "그룹방 복구", description = "삭제 예약된 그룹방을 복구합니다. 삭제 예약 기간(7일) 내에만 가능하며 방장만 가능합니다.")
+    @Operation(summary = "그룹방 복구", description = "삭제 예약된 그룹방을 복구합니다. 삭제 예약 기간(24시간) 내에만 가능하며 방장만 가능합니다.")
     @PostMapping("/{groupRoomId}/recover")
     fun recoverGroupRoom(
         @AuthenticationPrincipal userId: String,

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupRoomListItem.kt
@@ -13,6 +13,7 @@ data class GroupRoomListItem(
     val myRole: String,
     val lastActivityAt: LocalDateTime,
     val isDeleteScheduled: Boolean,
+    val deleteScheduledAt: LocalDateTime?,
     val inviteCode: String? = null
 ) {
     companion object {
@@ -25,6 +26,7 @@ data class GroupRoomListItem(
             myRole = myRole.name.lowercase(),
             lastActivityAt = groupRoom.lastActivityAt,
             isDeleteScheduled = groupRoom.isDeleteScheduled,
+            deleteScheduledAt = groupRoom.deleteScheduledAt,
             inviteCode = inviteCode
         )
     }

--- a/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
@@ -142,7 +142,7 @@ class InviteServiceImpl(
     }
 
     private fun generateInviteCode(): String {
-        val chars = ('A'..'Z') + ('0'..'9')
+        val chars = ('0'..'9').toList()
         return (1..6).map { chars.random() }.joinToString("")
     }
 


### PR DESCRIPTION
## Summary
- 그룹방 삭제 예약 기간 **7일 → 24시간** 단축 (`GroupRoom.scheduleDelete()`).
- `GroupRoomCleanupScheduler` 신규 추가 — 매 5분마다 `findAllScheduledForDeletion(now)` 결과를 실제 `delete()` 처리. JPA cascade 로 membership/invite/schedule/diary/todo 동시 정리.
- row 단위 try/catch + 별도 `GroupRoomPurgeExecutor` (@Transactional) 로 self-invocation 회피, 한 row 실패가 전체에 전파되지 않게 격리.
- `GroupRoomListItem` 응답에 `deleteScheduledAt` 필드 추가 (앱 카운트다운용).
- 초대코드 생성에서 알파벳 제거하고 0–9 만 사용 — `GroupRoomServiceImpl#generateInviteCode`, `InviteServiceImpl#generateInviteCode`.

## Test plan
- [ ] 그룹방 삭제 후 `delete_scheduled_at` 이 `now + 24h` 로 박히는지
- [ ] 24시간 경과 후 5분 이내 cleanup 잡이 row + cascade 대상 모두 삭제하는지
- [ ] 잡 도중 1건이 실패해도 나머지가 계속 처리되는지 (log 의 success/failed count)
- [ ] 새 초대코드가 6자리 숫자만 생성되는지 (그룹 생성 / 코드 재발급 두 경로)
- [ ] 기존 알파벳 포함 코드가 DB 에 남아 있어도 입력으로 join 가능한지 (서버는 코드 문자열만 매칭하므로 영향 없음)