### PR TITLE
feat(notification): 댓글/강퇴 알림 발화 추가

### DIFF
--- a/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
@@ -10,6 +10,7 @@ import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.log.application.service.UserActionLogService
 import digdaserver.domain.log.domain.entity.UserAction
 import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.notification.application.service.NotificationService
 import digdaserver.domain.schedule.domain.repository.ScheduleRepository
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
@@ -27,7 +28,8 @@ class CommentServiceImpl(
     private val scheduleRepository: ScheduleRepository,
     private val diaryRepository: DiaryRepository,
     private val userRepository: UserRepository,
-    private val userActionLogService: UserActionLogService
+    private val userActionLogService: UserActionLogService,
+    private val notificationService: NotificationService
 ) : CommentService {
 
     @Transactional
@@ -35,7 +37,7 @@ class CommentServiceImpl(
         validateGroupRoomMember(groupRoomId, userId)
         validateCommentText(text)
 
-        scheduleRepository.findById(scheduleId)
+        val schedule = scheduleRepository.findById(scheduleId)
             .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
 
         val user = userRepository.findById(userId)
@@ -58,6 +60,13 @@ class CommentServiceImpl(
             detail = "groupRoomId=$groupRoomId, commentId=${comment.id}"
         )
 
+        notificationService.notifyCommentOnSchedule(
+            groupRoomId = groupRoomId,
+            scheduleId = scheduleId,
+            commenterUserId = userId,
+            scheduleTitle = schedule.title
+        )
+
         return CreateCommentResponse.from(comment)
     }
 
@@ -66,7 +75,7 @@ class CommentServiceImpl(
         validateGroupRoomMember(groupRoomId, userId)
         validateCommentText(text)
 
-        diaryRepository.findById(diaryId)
+        val diary = diaryRepository.findById(diaryId)
             .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
 
         val user = userRepository.findById(userId)
@@ -87,6 +96,13 @@ class CommentServiceImpl(
             targetType = "DIARY",
             targetId = diaryId.toString(),
             detail = "groupRoomId=$groupRoomId, commentId=${comment.id}"
+        )
+
+        notificationService.notifyCommentOnDiary(
+            groupRoomId = groupRoomId,
+            diaryId = diaryId,
+            commenterUserId = userId,
+            diaryTitle = diary.title
         )
 
         return CreateCommentResponse.from(comment)

--- a/src/main/kotlin/digdaserver/domain/log/domain/entity/UserAction.kt
+++ b/src/main/kotlin/digdaserver/domain/log/domain/entity/UserAction.kt
@@ -12,6 +12,7 @@ enum class UserAction {
     CREATE_GROUP_ROOM,
     JOIN_GROUP_ROOM,
     LEAVE_GROUP_ROOM,
+    REMOVE_MEMBER,
     TRANSFER_OWNER,
     CREATE_TODO,
     OTHER

--- a/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
@@ -58,6 +58,16 @@ class MembershipServiceImpl(
         if (targetMembership.isOwner) throw DigdaException(ErrorCode.CANNOT_REMOVE_OWNER)
 
         membershipRepository.delete(targetMembership)
+
+        notificationService.notifyMemberRemoved(groupRoomId, userId, targetUserId)
+
+        userActionLogService.record(
+            actorId = userId,
+            action = UserAction.REMOVE_MEMBER,
+            targetType = "GROUP_ROOM",
+            targetId = groupRoomId.toString(),
+            detail = "removedUserId=$targetUserId"
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
@@ -39,6 +39,22 @@ interface NotificationService {
         addedParticipantUserIds: List<UUID>
     )
 
+    fun notifyCommentOnSchedule(
+        groupRoomId: Long,
+        scheduleId: Long,
+        commenterUserId: UUID,
+        scheduleTitle: String
+    )
+
+    fun notifyCommentOnDiary(
+        groupRoomId: Long,
+        diaryId: Long,
+        commenterUserId: UUID,
+        diaryTitle: String
+    )
+
+    fun notifyMemberRemoved(groupRoomId: Long, actorUserId: UUID, removedUserId: UUID)
+
     fun sendAnnouncement(
         targetUserIds: List<UUID>?,
         title: String,

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -236,6 +236,92 @@ class NotificationServiceImpl(
     }
 
     @Transactional
+    override fun notifyCommentOnSchedule(
+        groupRoomId: Long,
+        scheduleId: Long,
+        commenterUserId: UUID,
+        scheduleTitle: String
+    ) {
+        val groupRoom = findGroupRoom(groupRoomId)
+        val commenter = findUser(commenterUserId)
+        // 일정 댓글은 그룹 멤버 전원에게 노출(작성자 본인 제외). 어떤 댓글이 달렸는지
+        // 모든 멤버가 알 수 있게 하는 디그팟 그룹 다이어리 특성에 맞춤.
+        val recipients = memberRecipientsExcept(groupRoomId, commenterUserId)
+
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.COMMENT_ON_SCHEDULE,
+                title = "새 댓글",
+                message = "${commenter.name}님이 '$scheduleTitle' 일정에 댓글을 남겼습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = scheduleId,
+                relatedType = "SCHEDULE"
+            )
+        )
+    }
+
+    @Transactional
+    override fun notifyCommentOnDiary(
+        groupRoomId: Long,
+        diaryId: Long,
+        commenterUserId: UUID,
+        diaryTitle: String
+    ) {
+        val groupRoom = findGroupRoom(groupRoomId)
+        val commenter = findUser(commenterUserId)
+        val recipients = memberRecipientsExcept(groupRoomId, commenterUserId)
+
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.COMMENT_ON_DIARY,
+                title = "새 댓글",
+                message = "${commenter.name}님이 '$diaryTitle' 일기에 댓글을 남겼습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name,
+                relatedId = diaryId,
+                relatedType = "DIARY"
+            )
+        )
+    }
+
+    @Transactional
+    override fun notifyMemberRemoved(groupRoomId: Long, actorUserId: UUID, removedUserId: UUID) {
+        val groupRoom = findGroupRoom(groupRoomId)
+        val removedUser = findUser(removedUserId)
+
+        // 강퇴 당사자에게는 본인이 내보내졌다는 알림을 별도 메시지로 발송.
+        notify(
+            listOf(removedUser),
+            NotificationPayload(
+                type = NotificationType.MEMBER_REMOVED,
+                title = "그룹방에서 내보내짐",
+                message = "'${groupRoom.name}' 그룹방에서 내보내졌습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name
+            )
+        )
+
+        // 나머지 멤버에게는 "OOO 님이 내보내졌다" 안내. 강퇴 액터(방장) + 당사자 제외.
+        val others = membershipRepository.findAllByGroupRoomId(groupRoomId)
+            .map { it.user }
+            .filter { it.id != actorUserId && it.id != removedUserId }
+
+        notify(
+            others,
+            NotificationPayload(
+                type = NotificationType.MEMBER_REMOVED,
+                title = "구성원 내보냄",
+                message = "${removedUser.name}님이 '${groupRoom.name}' 그룹방에서 내보내졌습니다.",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name
+            )
+        )
+    }
+
+    @Transactional
     override fun sendAnnouncement(
         targetUserIds: List<UUID>?,
         title: String,


### PR DESCRIPTION
## Summary
NotificationType enum 에는 있지만 실제 호출 지점이 없어 **데드코드였던 3종** 의 발화 경로를 살렸다.

| Type | 이전 | 변경 |
|---|---|---|
| `COMMENT_ON_SCHEDULE` | 호출 0 | `CommentServiceImpl.createScheduleComment` 에서 발화 |
| `COMMENT_ON_DIARY` | 호출 0 | `CommentServiceImpl.createDiaryComment` 에서 발화 |
| `MEMBER_REMOVED` | 호출 0 | `MembershipServiceImpl.removeMember` 에서 발화 |

수신자 규칙:
- **댓글 (일정/일기)** — 댓글 작성자 본인 제외 그룹 멤버 **전원**. `relatedType=SCHEDULE`/`DIARY`, `relatedId=scheduleId/diaryId` 로 채워 클라이언트 딥링크가 그대로 동작.
- **강퇴** — **강퇴 당사자**(개인) 에게 "내보내짐" 메시지, **나머지 멤버**(액터+당사자 제외) 에게 "OOO 님이 내보내졌다" 메시지로 분기. 같은 `MEMBER_REMOVED` 타입.

부수:
- `UserAction.REMOVE_MEMBER` enum 추가, 강퇴 액션 로그 기록.
- `PushDispatcher.isPushEligible` 의 when 분기는 이미 3종 모두 다루고 있어 FCM 발송도 동시에 활성화됨 (별도 변경 불필요).

## Test plan
- [ ] A가 일정 댓글 작성 → 같은 그룹의 B/C가 알림 수신, `comment_on_schedule` 타입
- [ ] A가 일기 댓글 작성 → B/C 알림 수신, `comment_on_diary` 타입
- [ ] 방장 A가 B를 강퇴 → B에게 "내보내졌다" 알림, C 에게 "B가 내보내졌다" 알림
- [ ] 댓글 알림 탭 시 해당 일정/일기 상세로 딥링크 이동