### PR TITLE
fix(notification): 멤버 내보내기 후 롤백 버그 수정

### DIFF
--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -358,6 +358,14 @@ class NotificationServiceImpl(
         val groupRoom = findGroupRoom(groupRoomId)
         val removedUser = findUser(removedUserId)
 
+        // recipients 를 먼저 조회해 auto-flush 로 pending DELETE 를 선행 실행한 뒤
+        // notify() 의 saveAll 이 뒤따르도록 순서를 고정한다.
+        // (notify() 이후에 findAllByGroupRoomId 를 호출하면 auto-flush 시
+        //  notification INSERT 와 membership DELETE 가 혼재해 제약 위반이 발생할 수 있음)
+        val others = membershipRepository.findAllByGroupRoomId(groupRoomId)
+            .map { it.user }
+            .filter { it.id != actorUserId && it.id != removedUserId }
+
         // 강퇴 당사자에게는 본인이 내보내졌다는 알림을 별도 메시지로 발송.
         notify(
             listOf(removedUser),
@@ -371,10 +379,6 @@ class NotificationServiceImpl(
         )
 
         // 나머지 멤버에게는 "OOO 님이 내보내졌다" 안내. 강퇴 액터(방장) + 당사자 제외.
-        val others = membershipRepository.findAllByGroupRoomId(groupRoomId)
-            .map { it.user }
-            .filter { it.id != actorUserId && it.id != removedUserId }
-
         notify(
             others,
             NotificationPayload(


### PR DESCRIPTION
## Summary
- `notifyMemberRemoved`에서 `notify()` 호출 이후 `findAllByGroupRoomId` 실행 시 Hibernate auto-flush가 notification INSERT와 membership DELETE를 혼재 처리해 예외가 발생하고 트랜잭션이 롤백되는 버그 수정
- recipient 목록 조회를 `notify()` 이전으로 이동해 auto-flush가 pending DELETE만 실행하도록 순서 고정
- 결과: FCM 알림은 발송되나 멤버가 실제 제거되지 않던 현상 해결

## Test plan
- [ ] 방장이 멤버 내보내기 실행 → 멤버 실제 제거 확인
- [ ] 강퇴 알림 수신 확인 (당사자 + 나머지 멤버)
- [ ] 서버 500 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)