### PR TITLE
fix(account): 그룹 데이터 보유 시 회원탈퇴 FK 제약 오류 수정

### DIFF
--- a/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
@@ -3,9 +3,11 @@ package digdaserver.domain.comment.domain.repository
 import digdaserver.domain.comment.domain.entity.Comment
 import digdaserver.domain.comment.domain.entity.CommentTargetType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 @Repository
 interface CommentRepository : JpaRepository<Comment, Long> {
@@ -29,4 +31,8 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         @Param("targetType") targetType: CommentTargetType,
         @Param("targetIds") targetIds: Collection<Long>
     ): List<Array<Any>>
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.createdBy.id = :userId")
+    fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -4,10 +4,12 @@ import digdaserver.domain.diary.domain.entity.Diary
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.util.UUID
 
 @Repository
 interface DiaryRepository : JpaRepository<Diary, Long> {
@@ -32,4 +34,8 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
         @Param("keyword") keyword: String?,
         pageable: Pageable
     ): Page<Diary>
+
+    @Modifying
+    @Query("DELETE FROM Diary d WHERE d.createdBy.id = :userId")
+    fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -23,4 +24,8 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.user.id = :userId AND n.isRead = false")
     fun markAllAsReadByUserId(userId: UUID): Int
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.user.id = :userId")
+    fun deleteAllByUserId(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
@@ -1,9 +1,17 @@
 package digdaserver.domain.oauth2.application.service.impl.auth
 
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.device.domain.repository.DeviceRepository
+import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.notification.domain.repository.NotificationRepository
 import digdaserver.domain.oauth2.application.service.AccountService
+import digdaserver.domain.schedule.domain.repository.ScheduleParticipantRepository
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.domain.todo.domain.repository.TodoRepository
+import digdaserver.domain.upload.domain.repository.UploadedImageRepository
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
@@ -21,7 +29,15 @@ class AccountServiceImpl(
     private val groupRoomRepository: GroupRoomRepository,
     private val membershipRepository: MembershipRepository,
     private val jsonWebTokenRepository: JsonWebTokenRepository,
-    private val socialTokenRepository: SocialTokenRepository
+    private val socialTokenRepository: SocialTokenRepository,
+    private val scheduleParticipantRepository: ScheduleParticipantRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val commentRepository: CommentRepository,
+    private val diaryRepository: DiaryRepository,
+    private val todoRepository: TodoRepository,
+    private val notificationRepository: NotificationRepository,
+    private val deviceRepository: DeviceRepository,
+    private val uploadedImageRepository: UploadedImageRepository
 ) : AccountService {
 
     private val log = LoggerFactory.getLogger(AccountServiceImpl::class.java)
@@ -42,6 +58,24 @@ class AccountServiceImpl(
         // 토큰 무효화
         jsonWebTokenRepository.deleteByProviderId(userId.toString())
         socialTokenRepository.deleteByUserId(userId.toString())
+
+        // 다른 사용자 todo 의 completedBy 참조 null 처리 (nullable FK)
+        todoRepository.clearCompletedByUserId(userId)
+
+        // 일정 참여 기록 제거 (다른 사람 일정 참여 + 내 일정의 다른 참여자)
+        scheduleParticipantRepository.deleteAllByUserId(userId)
+        scheduleParticipantRepository.deleteAllByScheduleCreatedById(userId)
+
+        // 내가 만든 컨텐츠 삭제
+        scheduleRepository.deleteAllByCreatedById(userId)
+        commentRepository.deleteAllByCreatedById(userId)
+        diaryRepository.deleteAllByCreatedById(userId)
+        todoRepository.deleteAllByCreatedById(userId)
+
+        // 알림·기기·이미지 삭제
+        notificationRepository.deleteAllByUserId(userId)
+        deviceRepository.deleteAllByUserId(userId)
+        uploadedImageRepository.deleteAllByUserId(userId)
 
         // 멤버십 삭제 및 빈 그룹 정리
         val groupRoomIds = memberships.map { it.groupRoom.id!! }

--- a/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleParticipantRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleParticipantRepository.kt
@@ -2,7 +2,11 @@ package digdaserver.domain.schedule.domain.repository
 
 import digdaserver.domain.schedule.domain.entity.ScheduleParticipant
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 @Repository
 interface ScheduleParticipantRepository : JpaRepository<ScheduleParticipant, Long> {
@@ -10,4 +14,12 @@ interface ScheduleParticipantRepository : JpaRepository<ScheduleParticipant, Lon
     fun findAllByScheduleId(scheduleId: Long): List<ScheduleParticipant>
 
     fun deleteAllByScheduleId(scheduleId: Long)
+
+    @Modifying
+    @Query("DELETE FROM ScheduleParticipant sp WHERE sp.user.id = :userId")
+    fun deleteAllByUserId(@Param("userId") userId: UUID)
+
+    @Modifying
+    @Query("DELETE FROM ScheduleParticipant sp WHERE sp.schedule.createdBy.id = :userId")
+    fun deleteAllByScheduleCreatedById(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
@@ -4,10 +4,12 @@ import digdaserver.domain.schedule.domain.entity.Schedule
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
+import java.util.UUID
 
 @Repository
 interface ScheduleRepository : JpaRepository<Schedule, Long> {
@@ -39,4 +41,8 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
         @Param("keyword") keyword: String?,
         pageable: Pageable
     ): Page<Schedule>
+
+    @Modifying
+    @Query("DELETE FROM Schedule s WHERE s.createdBy.id = :userId")
+    fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/todo/domain/repository/TodoRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/domain/repository/TodoRepository.kt
@@ -2,8 +2,11 @@ package digdaserver.domain.todo.domain.repository
 
 import digdaserver.domain.todo.domain.entity.Todo
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 @Repository
 interface TodoRepository : JpaRepository<Todo, Long> {
@@ -14,4 +17,12 @@ interface TodoRepository : JpaRepository<Todo, Long> {
     fun countByGroupRoomId(groupRoomId: Long): Int
 
     fun countByGroupRoomIdAndCompletedTrue(groupRoomId: Long): Int
+
+    @Modifying
+    @Query("UPDATE Todo t SET t.completedBy = null, t.completedAt = null, t.completed = false WHERE t.completedBy.id = :userId")
+    fun clearCompletedByUserId(@Param("userId") userId: UUID)
+
+    @Modifying
+    @Query("DELETE FROM Todo t WHERE t.createdBy.id = :userId")
+    fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 }

--- a/src/main/kotlin/digdaserver/domain/upload/domain/repository/UploadedImageRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/domain/repository/UploadedImageRepository.kt
@@ -2,7 +2,16 @@ package digdaserver.domain.upload.domain.repository
 
 import digdaserver.domain.upload.domain.entity.UploadedImage
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 @Repository
-interface UploadedImageRepository : JpaRepository<UploadedImage, Long>
+interface UploadedImageRepository : JpaRepository<UploadedImage, Long> {
+
+    @Modifying
+    @Query("DELETE FROM UploadedImage ui WHERE ui.user.id = :userId")
+    fun deleteAllByUserId(@Param("userId") userId: UUID)
+}


### PR DESCRIPTION
## Summary
- 회원 탈퇴(`deleteAccount`) 시 User FK를 참조하는 레코드가 남아 DB 제약 위반으로 500 오류 발생
- 방장이 아닌 멤버가 그림일기·일정 등 그룹 데이터를 가지고 있을 때 탈퇴 불가 현상 해결

## Root Cause
`AccountServiceImpl.deleteAccount()`에서 Membership만 삭제하고 아래 테이블의 FK 참조를 정리하지 않은 채 User를 삭제하려다 constraint violation 발생:
- `schedule_participant.user_id`, `schedule.created_by`
- `comment.created_by`, `diary.created_by`, `todo.created_by`
- `notification.user_id`, `device.user_id`, `uploaded_image.user_id`
- `todo.completed_by` (nullable, 미처리시 FK 오류 가능)

## Changes
- `AccountServiceImpl`: 삭제 순서 재정립 — 컨텐츠 → 알림/기기/이미지 → 멤버십 → 유저
- `ScheduleParticipantRepository`: `deleteAllByUserId`, `deleteAllByScheduleCreatedById` 추가
- `ScheduleRepository`, `CommentRepository`, `DiaryRepository`, `TodoRepository`: `deleteAllByCreatedById` 추가
- `TodoRepository`: `clearCompletedByUserId` 추가 (nullable FK null 처리)
- `NotificationRepository`, `UploadedImageRepository`: `deleteAllByUserId` 추가

## Test plan
- [ ] 그룹에 가입된 비방장 멤버로 회원탈퇴 → 성공 (기존 500 재현 후 수정 확인)
- [ ] 탈퇴한 유저의 일정·일기·댓글이 그룹에서 제거되었는지 확인
- [ ] 그룹 내 다른 멤버 데이터는 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)