### PR TITLE
fix(notify+ops): notification.type 자동 ALTER + API/예외 글로벌 로깅

### DIFF
--- a/src/main/kotlin/digdaserver/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/digdaserver/global/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package digdaserver.global.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import digdaserver.global.infra.exception.auth.DigdaAuthExceptionFilter
+import digdaserver.global.infra.filter.ApiAccessLogFilter
 import digdaserver.global.infra.filter.DigdaJWTFilter
 import digdaserver.global.jwt.util.JWTUtil
 import org.springframework.context.annotation.Bean
@@ -106,6 +107,13 @@ class SecurityConfig(
         http.addFilterAfter(
             DigdaJWTFilter(jwtUtil, excludedUrls),
             UsernamePasswordAuthenticationFilter::class.java
+        )
+
+        // JWT 인증이 끝난 직후에 진입 로그를 남겨 SecurityContext 의 userId 가
+        // 포함되게 한다. 컨트롤러별로 일일이 박지 않고 한 곳에서 보장.
+        http.addFilterAfter(
+            ApiAccessLogFilter(),
+            DigdaJWTFilter::class.java
         )
 
         return http.build()

--- a/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
@@ -3,9 +3,11 @@ package digdaserver.global.infra.exception
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import digdaserver.global.infra.exception.error.response.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -17,8 +19,29 @@ class GlobalExceptionHandler {
     private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
     @ExceptionHandler(DigdaException::class)
-    fun handleDigdaException(e: DigdaException): ResponseEntity<ErrorResponse> {
-        log.error("DigdaException - code: {}, message: {}", e.errorCode.code, e.message)
+    fun handleDigdaException(
+        e: DigdaException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
+        val ctx = requestContext(request)
+        // 4xx 비즈니스 에러는 warn, 5xx 만 error 로 분기해 운영 로그 노이즈 감소.
+        if (e.httpStatusCode >= 500) {
+            log.error(
+                "DigdaException(5xx) {}, code={}, message={}",
+                ctx,
+                e.errorCode.code,
+                e.message,
+                e
+            )
+        } else {
+            log.warn(
+                "DigdaException {}, status={}, code={}, message={}",
+                ctx,
+                e.httpStatusCode,
+                e.errorCode.code,
+                e.message
+            )
+        }
 
         return ResponseEntity
             .status(e.httpStatusCode)
@@ -26,16 +49,27 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(NoResourceFoundException::class)
-    fun handleNoResourceFound(e: NoResourceFoundException): ResponseEntity<ErrorResponse> {
-        log.warn("404 Not Found: {}", e.message)
+    fun handleNoResourceFound(
+        e: NoResourceFoundException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("404 Not Found {}, message={}", requestContext(request), e.message)
         return ResponseEntity
             .status(404)
             .body(ErrorResponse.of(ErrorCode.SERVER_ERROR))
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleUnexpectedException(e: Exception): ResponseEntity<ErrorResponse> {
-        log.error("Unexpected exception", e)
+    fun handleUnexpectedException(
+        e: Exception,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
+        log.error(
+            "Unexpected exception {}, message={}",
+            requestContext(request),
+            e.message,
+            e
+        )
 
         return ResponseEntity
             .status(500)
@@ -43,16 +77,31 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleJsonParseError(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+    fun handleJsonParseError(
+        e: HttpMessageNotReadableException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
         val root = e.rootCause
 
         return when (root) {
-            is DigdaException ->
+            is DigdaException -> {
+                log.warn(
+                    "JSON parse → DigdaException {}, code={}, message={}",
+                    requestContext(request),
+                    root.errorCode.code,
+                    root.message
+                )
                 ResponseEntity
                     .status(root.httpStatusCode)
                     .body(ErrorResponse.of(root))
+            }
 
-            else ->
+            else -> {
+                log.warn(
+                    "JSON parse 실패 {}, message={}",
+                    requestContext(request),
+                    root?.message ?: e.message
+                )
                 ResponseEntity
                     .status(400)
                     .body(
@@ -61,17 +110,39 @@ class GlobalExceptionHandler {
                             root?.message ?: "잘못된 요청입니다."
                         )
                     )
+            }
         }
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(ex: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+    fun handleValidationException(
+        ex: MethodArgumentNotValidException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
         val details = ex.bindingResult.fieldErrors.associate {
             it.field to (it.defaultMessage ?: "잘못된 값입니다.")
         }
+        log.warn(
+            "요청 검증 실패 {}, details={}",
+            requestContext(request),
+            details
+        )
 
         return ResponseEntity
             .badRequest()
             .body(ErrorResponse.of(ErrorCode.PARAMETER_VALIDATION_ERROR, details))
+    }
+
+    /**
+     * 모든 예외 로그에 공통으로 붙는 요청 컨텍스트. ApiAccessLogFilter 와 키 포맷을
+     * 맞춰 같은 한 트랜잭션을 grep 으로 묶을 수 있게 한다.
+     */
+    private fun requestContext(request: HttpServletRequest): String {
+        val userId = SecurityContextHolder.getContext().authentication?.principal
+            ?.toString()
+            ?.takeIf { it.isNotBlank() && it != "anonymousUser" }
+            ?: "-"
+        val query = request.queryString?.let { "?$it" } ?: ""
+        return "method=${request.method}, path=${request.requestURI}$query, userId=$userId"
     }
 }

--- a/src/main/kotlin/digdaserver/global/infra/filter/ApiAccessLogFilter.kt
+++ b/src/main/kotlin/digdaserver/global/infra/filter/ApiAccessLogFilter.kt
@@ -1,0 +1,70 @@
+package digdaserver.global.infra.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * 모든 API 요청 진입에 대해 한 줄로 표준 로그를 남긴다.
+ *
+ * - JWT 필터 뒤에 체이닝되어 SecurityContext 의 userId 를 함께 기록
+ * - 헬스체크/Swagger/static 등 노이즈 경로는 스킵
+ * - 응답 종료 시점에 method, path, userId, status, latency 한 줄 로그
+ *
+ * "내가 분명히 API 진입점마다 로그 박으라고 했지" 라는 운영 요구에 대한
+ * 컨트롤러별 일일이 추가하지 않는 글로벌 솔루션.
+ */
+class ApiAccessLogFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(ApiAccessLogFilter::class.java)
+
+    /** 로그에서 제외할 prefix — 헬스체크/문서/정적자원. */
+    private val skipPrefixes = listOf(
+        "/api/healthcheck",
+        "/actuator",
+        "/v3/api-docs",
+        "/swagger-ui",
+        "/favicon.ico"
+    )
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val uri = request.requestURI
+        if (skipPrefixes.any { uri.startsWith(it) }) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val start = System.currentTimeMillis()
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val latency = System.currentTimeMillis() - start
+            val userId = resolveUserId()
+            val query = request.queryString?.let { "?$it" } ?: ""
+            log.info(
+                "action=API 진입, method={}, path={}{}, userId={}, status={}, latency={}ms",
+                request.method,
+                uri,
+                query,
+                userId,
+                response.status,
+                latency
+            )
+        }
+    }
+
+    private fun resolveUserId(): String {
+        val auth = SecurityContextHolder.getContext().authentication ?: return "-"
+        val principal = auth.principal?.toString()?.takeIf { it.isNotBlank() }
+            ?: auth.name?.takeIf { it.isNotBlank() }
+            ?: return "-"
+        return if (principal == "anonymousUser") "-" else principal
+    }
+}

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -1,0 +1,157 @@
+package digdaserver.global.infra.migration
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.dao.DataAccessException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * prod 는 `ddl-auto: none` 이라 Hibernate 가 스키마를 갱신하지 않는다. Flyway/Liquibase 도
+ * 없는 상태에서 enum 값 추가 같은 변경이 누락되면 insert 가 "Data truncated for column"
+ * 으로 통째로 실패하고, 운영에서는 catch-up 로그를 깔기 전엔 알기도 어렵다.
+ *
+ * 그래서 알려진 schema drift 케이스를 startup 시 멱등하게 정정한다. 새 변경이 생길 때마다
+ * [requiredColumns] 에 정의만 추가하면 자동 ALTER 가 적용된다.
+ *
+ * - 컬럼 타입이 이미 기대값이면 ALTER 를 치지 않고 skip (멱등)
+ * - 한 컬럼 실패가 다른 컬럼 마이그레이션을 막지 않도록 row 단위 try/catch
+ * - 실패해도 애플리케이션 부팅은 막지 않는다 (운영에서 회복할 시간 확보)
+ */
+@Component
+class SchemaAutoMigration(
+    private val jdbcTemplate: JdbcTemplate
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 정정 대상 컬럼 목록.
+     *
+     * 현재 등록된 케이스:
+     *  - `notification.type`: 초기 MySQL ENUM(8) 으로 생성됐는데 이후 [NotificationType]
+     *    에 SCHEDULE_DAY_BEFORE / SCHEDULE_TODAY / MEMBER_LEFT / OWNERSHIP_TRANSFERRED /
+     *    ANNOUNCEMENT 5개 값이 추가되면서 새 값 insert 가 "Data truncated" 로 실패.
+     *    더 이상 enum 정의를 늘릴 때마다 SQL 을 손대지 않도록 VARCHAR(64) 로 일반화.
+     */
+    private val requiredColumns: List<RequiredColumn> = listOf(
+        RequiredColumn(
+            table = "notification",
+            column = "type",
+            expectedDataType = "varchar",
+            expectedMaxLength = 64,
+            nullable = false,
+            alterSql = "ALTER TABLE notification MODIFY COLUMN type VARCHAR(64) NOT NULL"
+        )
+    )
+
+    override fun run(args: ApplicationArguments?) {
+        log.info("action=startup schema auto-migration 시작, 대상={}건", requiredColumns.size)
+        for (rc in requiredColumns) {
+            try {
+                migrateOne(rc)
+            } catch (e: Exception) {
+                // 한 컬럼 실패가 다른 컬럼·앱 부팅을 막지 않게.
+                log.error(
+                    "action=startup schema auto-migration 실패, table={}, column={}, error={}",
+                    rc.table,
+                    rc.column,
+                    e.message,
+                    e
+                )
+            }
+        }
+        log.info("action=startup schema auto-migration 완료")
+    }
+
+    private fun migrateOne(rc: RequiredColumn) {
+        val info = readColumnInfo(rc.table, rc.column)
+        if (info == null) {
+            log.warn(
+                "action=startup schema auto-migration 스킵(컬럼 없음), table={}, column={}",
+                rc.table,
+                rc.column
+            )
+            return
+        }
+        if (rc.matches(info)) {
+            log.info(
+                "action=startup schema auto-migration 스킵(이미 OK), table={}, column={}, current={}",
+                rc.table,
+                rc.column,
+                info
+            )
+            return
+        }
+        log.warn(
+            "action=startup schema auto-migration ALTER 실행, table={}, column={}, before={}, sql={}",
+            rc.table,
+            rc.column,
+            info,
+            rc.alterSql
+        )
+        jdbcTemplate.execute(rc.alterSql)
+        val after = readColumnInfo(rc.table, rc.column)
+        log.info(
+            "action=startup schema auto-migration ALTER 완료, table={}, column={}, after={}",
+            rc.table,
+            rc.column,
+            after
+        )
+    }
+
+    private fun readColumnInfo(table: String, column: String): ColumnInfo? {
+        return try {
+            jdbcTemplate.query(
+                """
+                SELECT DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, IS_NULLABLE
+                FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = ?
+                  AND COLUMN_NAME = ?
+                """.trimIndent(),
+                { rs, _ ->
+                    ColumnInfo(
+                        dataType = rs.getString("DATA_TYPE").lowercase(),
+                        maxLength = rs.getObject("CHARACTER_MAXIMUM_LENGTH") as? Number,
+                        nullable = rs.getString("IS_NULLABLE").equals("YES", ignoreCase = true)
+                    )
+                },
+                table,
+                column
+            ).firstOrNull()
+        } catch (e: DataAccessException) {
+            log.warn(
+                "action=startup schema auto-migration 컬럼 메타 조회 실패, table={}, column={}, error={}",
+                table,
+                column,
+                e.message
+            )
+            null
+        }
+    }
+
+    private data class ColumnInfo(
+        val dataType: String,
+        val maxLength: Number?,
+        val nullable: Boolean
+    )
+
+    private data class RequiredColumn(
+        val table: String,
+        val column: String,
+        val expectedDataType: String,
+        val expectedMaxLength: Int,
+        val nullable: Boolean,
+        val alterSql: String
+    ) {
+        fun matches(info: ColumnInfo): Boolean {
+            if (info.dataType != expectedDataType.lowercase()) return false
+            val len = info.maxLength?.toInt() ?: return false
+            if (len < expectedMaxLength) return false
+            if (info.nullable != nullable) return false
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## 9시 알림이 안 가던 직접 원인 발견

서버 로그(이전 PR 의 catch-up 진입 로그 덕분에 발견):
\`\`\`
action=일정 리마인더 발송 실패, type=당일, scheduleId=5, 
error=could not execute statement [Data truncated for column 'type' at row 1]
\`\`\`

prod MySQL 의 \`notification.type\` 컬럼이 초기 ENUM(8) 으로 만들어졌는데 그 후 \`NotificationType\` 에 5개 enum 값이 추가됨:
- SCHEDULE_DAY_BEFORE
- SCHEDULE_TODAY
- MEMBER_LEFT
- OWNERSHIP_TRANSFERRED
- ANNOUNCEMENT

→ 새 값 insert 가 통째로 실패. **이게 9시 일정 리마인더가 안 가던 진짜 원인.** 다른 멤버 자발탈퇴·방장 양도·공지 알림도 다 같은 이유로 묻혀 있었음.

prod 는 \`ddl-auto: none\` + Flyway 미적용 → 자동 갱신 불가.

## 변경

### 1. \`SchemaAutoMigration\` (ApplicationRunner)
- startup 시 \`information_schema\` 로 컬럼 메타 조회 → 기대 타입과 다르면 멱등 ALTER 실행
- 첫 정정 대상: \`notification.type → VARCHAR(64) NOT NULL\`. 앞으로 enum 값 늘려도 ALTER 필요 없음.
- 한 컬럼 실패가 부팅을 막지 않게 row 단위 try/catch
- 향후 다른 컬럼 schema drift 도 \`requiredColumns\` 리스트 추가만으로 해결

### 2. \`ApiAccessLogFilter\` (OncePerRequestFilter)
사용자 요구: 모든 API 요청 진입을 SLF4J 로 항상 봐야 함. 컨트롤러마다 박지 않는 글로벌 솔루션.

- JWT 필터 뒤에 체이닝되어 SecurityContext userId 포함
- 한 줄 로그: \`method=X, path=Y, userId=Z, status=N, latency=Mms\`
- 헬스체크·Swagger·static prefix 는 스킵

### 3. \`GlobalExceptionHandler\` 로깅 강화
- 모든 예외 로그에 method/path/userId 공통 컨텍스트 동봉 → ApiAccessLogFilter 와 grep 으로 묶임
- 4xx 비즈니스 에러 → warn, 5xx → error 로 분기 (운영 노이즈 감소)
- HttpMessageNotReadableException, MethodArgumentNotValidException 도 path 함께 기록

## Test plan
- [ ] 로컬 부팅 → \"SchemaAutoMigration ALTER 실행\" 또는 \"이미 OK 스킵\" 로그 확인
- [ ] 어떤 API 든 호출 → \"action=API 진입, method=..., path=..., userId=..., status=..., latency=...ms\" 한 줄
- [ ] 잘못된 JSON 으로 요청 → JSON parse 실패 warn + path 포함
- [ ] 인증 토큰 없이 보호 API → 401 + 진입 로그
- [ ] 다음 9:00 KST → 일정 리마인더가 실제로 발송되고 인앱 알림 + 푸시 모두 도착하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)