### PR TITLE
fix(diary): imageId 를 실제 S3 URL 로 변환해 저장

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -18,9 +18,11 @@ import digdaserver.domain.log.application.service.UserActionLogService
 import digdaserver.domain.log.domain.entity.UserAction
 import digdaserver.domain.membership.domain.repository.MembershipRepository
 import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.domain.upload.domain.repository.UploadedImageRepository
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -38,8 +40,30 @@ class DiaryServiceImpl(
     private val commentRepository: CommentRepository,
     private val userRepository: UserRepository,
     private val notificationService: NotificationService,
-    private val userActionLogService: UserActionLogService
+    private val userActionLogService: UserActionLogService,
+    private val uploadedImageRepository: UploadedImageRepository
 ) : DiaryService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 클라이언트가 보내는 imageId(=UploadedImage 의 PK 문자열) 를 실제 S3 URL 로 변환.
+     * 입력이 null/blank/숫자가 아니거나 lookup 실패 시 null 을 반환한다.
+     * (기존엔 PK 문자열을 그대로 image_url 컬럼에 저장하여 클라이언트에서 이미지 로딩 실패)
+     */
+    private fun resolveImageUrl(imageId: String?): String? {
+        if (imageId.isNullOrBlank()) return null
+        val id = imageId.toLongOrNull() ?: run {
+            log.warn("imageId 가 Long 이 아님: imageId={}", imageId)
+            return null
+        }
+        val image = uploadedImageRepository.findById(id).orElse(null)
+        if (image == null) {
+            log.warn("imageId 에 해당하는 업로드 레코드 없음: imageId={}", id)
+            return null
+        }
+        return image.url
+    }
 
     override fun getDiaries(userId: UUID, groupRoomId: Long, month: YearMonth?, limit: Int, offset: Int): DiaryListResponse {
         val groupRoom = groupRoomRepository.findById(groupRoomId)
@@ -138,7 +162,7 @@ class DiaryServiceImpl(
                 date = request.date,
                 weather = request.weather,
                 mood = request.mood,
-                imageUrl = request.imageId,
+                imageUrl = resolveImageUrl(request.imageId),
                 createdBy = user
             )
         )
@@ -187,7 +211,7 @@ class DiaryServiceImpl(
             date = request.date,
             weather = request.weather,
             mood = request.mood,
-            imageUrl = request.imageId
+            imageUrl = resolveImageUrl(request.imageId)
         )
 
         groupRoom.updateLastActivity()


### PR DESCRIPTION
## Summary
- DiaryServiceImpl 에 `resolveImageUrl` 헬퍼 추가 (그룹 썸네일과 동일 패턴)
- create/update 모두 `request.imageId`(업로드 PK 문자열)를 그대로 `image_url` 컬럼에 저장하던 버그 수정
- 이제 일기 상세에서 사진이 정상 표시됨

## 배경
클라이언트는 `/uploads/images` 응답의 `id` 를 `imageId` 로 전송하는데, 서버는 그걸 그대로 `image_url` 에 넣고 있어 `Image.network("42")` 같은 형태로 깨짐. 그룹 썸네일은 이미 동일한 패턴으로 해결되어 있어 그 구조를 그대로 차용.

## Test plan
- [ ] 일기 작성 시 이미지 첨부 → 상세에서 사진 정상 노출
- [ ] 일기 수정 시 이미지 변경 → 상세에서 사진 정상 갱신
- [ ] 이미지 없이 작성 → `image_url` null 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)