### PR TITLE
feat(diary): 일기 도메인 리뉴얼 — 다중이미지/장소/좋아요/리액션, 기분 5종

### DIFF
--- a/src/main/kotlin/digdaserver/admin/diary/presentation/dto/res/AdminDiaryResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/diary/presentation/dto/res/AdminDiaryResponse.kt
@@ -35,11 +35,14 @@ data class AdminDiaryResponse(
     @Schema(description = "날씨(0~3)")
     val weather: Int,
 
-    @Schema(description = "기분(0~3)")
+    @Schema(description = "기분(0~4)")
     val mood: Int,
 
-    @Schema(description = "이미지 URL")
-    val imageUrl: String?,
+    @Schema(description = "장소")
+    val location: String?,
+
+    @Schema(description = "이미지 URL 목록 (정렬 순)")
+    val imageUrls: List<String>,
 
     @Schema(description = "생성 시각")
     val createdAt: LocalDateTime,
@@ -59,7 +62,8 @@ data class AdminDiaryResponse(
             date = diary.date,
             weather = diary.weather,
             mood = diary.mood,
-            imageUrl = diary.imageUrl,
+            location = diary.location,
+            imageUrls = diary.images.sortedBy { it.sortOrder }.map { it.url },
             createdAt = diary.createdAt,
             updatedAt = diary.updatedAt
         )

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
@@ -1,10 +1,13 @@
 package digdaserver.domain.diary.application.service
 
 import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import java.time.YearMonth
 import java.util.UUID
@@ -22,4 +25,13 @@ interface DiaryService {
     fun updateDiary(userId: UUID, groupRoomId: Long, diaryId: Long, request: UpdateDiaryRequest): DiaryResponse
 
     fun deleteDiary(userId: UUID, groupRoomId: Long, diaryId: Long)
+
+    fun toggleLike(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryLikeResponse
+
+    fun toggleReaction(
+        userId: UUID,
+        groupRoomId: Long,
+        diaryId: Long,
+        request: ToggleDiaryReactionRequest
+    ): DiaryReactionToggleResponse
 }

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -4,13 +4,22 @@ import digdaserver.domain.comment.domain.entity.CommentTargetType
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.diary.application.service.DiaryService
 import digdaserver.domain.diary.domain.entity.Diary
+import digdaserver.domain.diary.domain.entity.DiaryLike
+import digdaserver.domain.diary.domain.entity.DiaryReaction
+import digdaserver.domain.diary.domain.entity.DiaryReactionType
+import digdaserver.domain.diary.domain.repository.DiaryLikeRepository
+import digdaserver.domain.diary.domain.repository.DiaryReactionRepository
 import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryCommentResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryReactionSummary
+import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import digdaserver.domain.diary.presentation.dto.res.DiarySummaryResponse
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
@@ -41,38 +50,25 @@ class DiaryServiceImpl(
     private val userRepository: UserRepository,
     private val notificationService: NotificationService,
     private val userActionLogService: UserActionLogService,
-    private val uploadedImageRepository: UploadedImageRepository
+    private val uploadedImageRepository: UploadedImageRepository,
+    private val diaryLikeRepository: DiaryLikeRepository,
+    private val diaryReactionRepository: DiaryReactionRepository
 ) : DiaryService {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    /**
-     * 클라이언트가 보내는 imageId(=UploadedImage 의 PK 문자열) 를 실제 S3 URL 로 변환.
-     * 입력이 null/blank/숫자가 아니거나 lookup 실패 시 null 을 반환한다.
-     * (기존엔 PK 문자열을 그대로 image_url 컬럼에 저장하여 클라이언트에서 이미지 로딩 실패)
-     */
-    private fun resolveImageUrl(imageId: String?): String? {
-        if (imageId.isNullOrBlank()) return null
-        val id = imageId.toLongOrNull() ?: run {
-            log.warn("imageId 가 Long 이 아님: imageId={}", imageId)
-            return null
-        }
-        val image = uploadedImageRepository.findById(id).orElse(null)
-        if (image == null) {
-            log.warn("imageId 에 해당하는 업로드 레코드 없음: imageId={}", id)
-            return null
-        }
-        return image.url
+    companion object {
+        private const val MAX_IMAGES_PER_DIARY = 10
     }
 
-    override fun getDiaries(userId: UUID, groupRoomId: Long, month: YearMonth?, limit: Int, offset: Int): DiaryListResponse {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
-
-        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
-
-        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
-            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+    override fun getDiaries(
+        userId: UUID,
+        groupRoomId: Long,
+        month: YearMonth?,
+        limit: Int,
+        offset: Int
+    ): DiaryListResponse {
+        ensureMember(userId, groupRoomId)
 
         val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
 
@@ -84,7 +80,9 @@ class DiaryServiceImpl(
             diaryRepository.findAllByGroupRoomId(groupRoomId, pageable)
         }
 
-        val diaryIds = page.content.map { it.id }
+        val diaries = page.content
+        val diaryIds = diaries.map { it.id }
+
         val commentCountMap: Map<Long, Int> = if (diaryIds.isNotEmpty()) {
             commentRepository.countByTargetTypeAndTargetIdIn(CommentTargetType.DIARY, diaryIds)
                 .associate { row -> (row[0] as Long) to (row[1] as Long).toInt() }
@@ -92,47 +90,55 @@ class DiaryServiceImpl(
             emptyMap()
         }
 
+        val likeCountMap: Map<Long, Long> = if (diaryIds.isNotEmpty()) {
+            diaryLikeRepository.countByDiaryIdIn(diaryIds)
+                .associate { row -> (row[0] as Long) to (row[1] as Long) }
+        } else {
+            emptyMap()
+        }
+
+        val likedByMeSet: Set<Long> = if (diaryIds.isNotEmpty()) {
+            diaryLikeRepository.findLikedDiaryIds(diaryIds, userId).toSet()
+        } else {
+            emptySet()
+        }
+
         return DiaryListResponse(
-            diaries = page.content.map { diary ->
-                val commentCount = commentCountMap[diary.id] ?: 0
-                DiarySummaryResponse.from(diary, commentCount)
+            diaries = diaries.map { diary ->
+                DiarySummaryResponse.from(
+                    diary = diary,
+                    commentCount = commentCountMap[diary.id] ?: 0,
+                    likeCount = likeCountMap[diary.id] ?: 0L,
+                    likedByMe = diary.id in likedByMeSet
+                )
             },
             total = page.totalElements
         )
     }
 
     override fun getDiaryCalendar(userId: UUID, groupRoomId: Long, month: YearMonth): DiaryCalendarResponse {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
-
-        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
-
-        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
-            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
-
+        ensureMember(userId, groupRoomId)
         val startDate = month.atDay(1)
         val endDate = month.atEndOfMonth()
         val dates = diaryRepository.findDistinctDatesByGroupRoomIdAndMonth(groupRoomId, startDate, endDate)
-
         return DiaryCalendarResponse(dates = dates)
     }
 
     override fun getDiaryDetail(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDetailResponse {
-        val groupRoom = groupRoomRepository.findById(groupRoomId)
-            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
-
-        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
-
-        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
-            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+        ensureMember(userId, groupRoomId)
 
         val diary = diaryRepository.findById(diaryId)
             .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
 
-        val comments = commentRepository.findAllByTargetTypeAndTargetIdOrderByCreatedAtAsc(CommentTargetType.DIARY, diaryId)
+        val comments = commentRepository
+            .findAllByTargetTypeAndTargetIdOrderByCreatedAtAsc(CommentTargetType.DIARY, diaryId)
+
+        val likeCount = diaryLikeRepository.countByDiaryId(diaryId)
+        val likedByMe = diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
+        val reactions = buildReactionSummariesForOneDiary(diaryId, userId)
 
         return DiaryDetailResponse(
-            diary = DiaryResponse.from(diary),
+            diary = DiaryResponse.from(diary, likeCount, likedByMe, reactions),
             comments = comments.map { DiaryCommentResponse.from(it) }
         )
     }
@@ -150,40 +156,48 @@ class DiaryServiceImpl(
         if (request.date.isAfter(LocalDate.now())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
         validateWeather(request.weather)
         validateMood(request.mood)
+        validateImageCount(request.imageIds.size)
 
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
-        val diary = diaryRepository.save(
-            Diary(
-                groupRoom = groupRoom,
-                title = request.title,
-                content = request.content,
-                date = request.date,
-                weather = request.weather,
-                mood = request.mood,
-                imageUrl = resolveImageUrl(request.imageId),
-                createdBy = user
-            )
+        val resolvedUrls = resolveImageUrls(request.imageIds)
+
+        val diary = Diary(
+            groupRoom = groupRoom,
+            title = request.title,
+            content = request.content,
+            date = request.date,
+            weather = request.weather,
+            mood = request.mood,
+            location = request.location?.takeIf { it.isNotBlank() },
+            createdBy = user
         )
+        diary.replaceImages(resolvedUrls)
+        val saved = diaryRepository.save(diary)
 
         groupRoom.updateLastActivity()
 
-        notificationService.notifyDiaryWritten(groupRoomId, diary.id, userId, diary.title)
+        notificationService.notifyDiaryWritten(groupRoomId, saved.id, userId, saved.title)
 
         userActionLogService.record(
             actorId = userId,
             action = UserAction.CREATE_DIARY,
             targetType = "DIARY",
-            targetId = diary.id.toString(),
-            detail = "groupRoomId=$groupRoomId, title=${diary.title}"
+            targetId = saved.id.toString(),
+            detail = "groupRoomId=$groupRoomId, title=${saved.title}, images=${resolvedUrls.size}"
         )
 
-        return DiaryResponse.from(diary)
+        return DiaryResponse.from(saved, likeCount = 0L, likedByMe = false, reactions = emptyList())
     }
 
     @Transactional
-    override fun updateDiary(userId: UUID, groupRoomId: Long, diaryId: Long, request: UpdateDiaryRequest): DiaryResponse {
+    override fun updateDiary(
+        userId: UUID,
+        groupRoomId: Long,
+        diaryId: Long,
+        request: UpdateDiaryRequest
+    ): DiaryResponse {
         val groupRoom = groupRoomRepository.findById(groupRoomId)
             .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
 
@@ -204,19 +218,27 @@ class DiaryServiceImpl(
         }
         request.weather?.let { validateWeather(it) }
         request.mood?.let { validateMood(it) }
+        request.imageIds?.let { validateImageCount(it.size) }
 
-        diary.update(
+        diary.updateBasics(
             title = request.title,
             content = request.content,
             date = request.date,
             weather = request.weather,
             mood = request.mood,
-            imageUrl = resolveImageUrl(request.imageId)
+            location = request.location?.takeIf { it.isNotBlank() }
         )
+        request.imageIds?.let { ids ->
+            diary.replaceImages(resolveImageUrls(ids))
+        }
 
         groupRoom.updateLastActivity()
 
-        return DiaryResponse.from(diary)
+        val likeCount = diaryLikeRepository.countByDiaryId(diaryId)
+        val likedByMe = diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
+        val reactions = buildReactionSummariesForOneDiary(diaryId, userId)
+
+        return DiaryResponse.from(diary, likeCount, likedByMe, reactions)
     }
 
     @Transactional
@@ -248,11 +270,103 @@ class DiaryServiceImpl(
         )
     }
 
+    @Transactional
+    override fun toggleLike(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryLikeResponse {
+        ensureMember(userId, groupRoomId)
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        val alreadyLiked = diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
+        if (alreadyLiked) {
+            diaryLikeRepository.deleteByDiaryIdAndUserId(diaryId, userId)
+            log.info("action=일기 좋아요 취소, userId={}, diaryId={}", userId, diaryId)
+        } else {
+            val user = userRepository.findById(userId)
+                .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+            diaryLikeRepository.save(DiaryLike(diary = diary, user = user))
+            log.info("action=일기 좋아요, userId={}, diaryId={}", userId, diaryId)
+        }
+        val newCount = diaryLikeRepository.countByDiaryId(diaryId)
+        return DiaryLikeResponse(likedByMe = !alreadyLiked, likeCount = newCount)
+    }
+
+    @Transactional
+    override fun toggleReaction(
+        userId: UUID,
+        groupRoomId: Long,
+        diaryId: Long,
+        request: ToggleDiaryReactionRequest
+    ): DiaryReactionToggleResponse {
+        ensureMember(userId, groupRoomId)
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+
+        val type = request.type
+        val exists = diaryReactionRepository.existsByDiaryIdAndUserIdAndType(diaryId, userId, type)
+        if (exists) {
+            diaryReactionRepository.deleteOne(diaryId, userId, type)
+            log.info("action=일기 리액션 취소, userId={}, diaryId={}, type={}", userId, diaryId, type)
+        } else {
+            val user = userRepository.findById(userId)
+                .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+            diaryReactionRepository.save(DiaryReaction(diary = diary, user = user, type = type))
+            log.info("action=일기 리액션, userId={}, diaryId={}, type={}", userId, diaryId, type)
+        }
+
+        val reactions = buildReactionSummariesForOneDiary(diaryId, userId)
+        return DiaryReactionToggleResponse(reactions = reactions)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private fun ensureMember(userId: UUID, groupRoomId: Long) {
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+    }
+
     private fun validateWeather(weather: Int) {
         if (weather !in 0..3) throw DigdaException(ErrorCode.INVALID_WEATHER_VALUE)
     }
 
     private fun validateMood(mood: Int) {
-        if (mood !in 0..3) throw DigdaException(ErrorCode.INVALID_MOOD_VALUE)
+        if (mood !in 0..4) throw DigdaException(ErrorCode.INVALID_MOOD_VALUE)
+    }
+
+    private fun validateImageCount(count: Int) {
+        if (count > MAX_IMAGES_PER_DIARY) throw DigdaException(ErrorCode.FILE_TOO_LARGE)
+    }
+
+    private fun resolveImageUrls(imageIds: List<String>): List<String> {
+        if (imageIds.isEmpty()) return emptyList()
+        val urls = mutableListOf<String>()
+        for (raw in imageIds) {
+            val id = raw.toLongOrNull()
+            if (id == null) {
+                log.warn("imageId 가 Long 이 아님: imageId={}", raw)
+                continue
+            }
+            val img = uploadedImageRepository.findById(id).orElse(null)
+            if (img == null) {
+                log.warn("imageId 에 해당하는 업로드 레코드 없음: imageId={}", id)
+                continue
+            }
+            urls.add(img.url)
+        }
+        return urls
+    }
+
+    private fun buildReactionSummariesForOneDiary(diaryId: Long, userId: UUID): List<DiaryReactionSummary> {
+        val all = diaryReactionRepository.findAllByDiaryId(diaryId)
+        if (all.isEmpty()) return emptyList()
+        val counts: Map<DiaryReactionType, Int> = all.groupingBy { it.type }.eachCount()
+        val mine: Set<DiaryReactionType> = all.filter { it.user.id == userId }.map { it.type }.toSet()
+        return counts.entries
+            .sortedBy { it.key.ordinal }
+            .map { (type, count) ->
+                DiaryReactionSummary(type = type, count = count, reactedByMe = type in mine)
+            }
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
@@ -3,6 +3,7 @@ package digdaserver.domain.diary.domain.entity
 import digdaserver.domain.group_room.domain.entity.GroupRoom
 import digdaserver.domain.user.domain.entity.User
 import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -11,6 +12,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
 import java.time.LocalDate
 
@@ -42,21 +45,40 @@ class Diary(
     @Column(nullable = false)
     var mood: Int,
 
-    @Column(name = "image_url")
-    var imageUrl: String? = null,
+    @Column(name = "location", length = 100)
+    var location: String? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by", nullable = false)
-    val createdBy: User
+    val createdBy: User,
+
+    @OneToMany(mappedBy = "diary", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("sortOrder ASC")
+    val images: MutableList<DiaryImage> = mutableListOf()
 
 ) : BaseTimeEntity() {
 
-    fun update(title: String?, content: String?, date: LocalDate?, weather: Int?, mood: Int?, imageUrl: String?) {
+    fun updateBasics(
+        title: String?,
+        content: String?,
+        date: LocalDate?,
+        weather: Int?,
+        mood: Int?,
+        location: String?
+    ) {
         title?.let { this.title = it }
         content?.let { this.content = it }
         date?.let { this.date = it }
         weather?.let { this.weather = it }
         mood?.let { this.mood = it }
-        this.imageUrl = imageUrl
+        this.location = location
+    }
+
+    /** 이미지를 전부 재구성. urls 순서대로 sort_order 0..N-1 부여. */
+    fun replaceImages(urls: List<String>) {
+        images.clear()
+        urls.forEachIndexed { index, url ->
+            images.add(DiaryImage(diary = this, url = url, sortOrder = index))
+        }
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryImage.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryImage.kt
@@ -1,0 +1,39 @@
+package digdaserver.domain.diary.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "diary_image",
+    indexes = [Index(name = "idx_diary_image_diary", columnList = "diary_id")]
+)
+class DiaryImage(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_image_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    val diary: Diary,
+
+    @Column(nullable = false, length = 500)
+    val url: String,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryLike.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryLike.kt
@@ -1,0 +1,40 @@
+package digdaserver.domain.diary.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "diary_like",
+    uniqueConstraints = [UniqueConstraint(name = "uk_diary_like", columnNames = ["diary_id", "user_id"])],
+    indexes = [Index(name = "idx_diary_like_diary", columnList = "diary_id")]
+)
+class DiaryLike(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_like_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    val diary: Diary,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryReaction.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryReaction.kt
@@ -1,0 +1,51 @@
+package digdaserver.domain.diary.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "diary_reaction",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_diary_reaction",
+            columnNames = ["diary_id", "user_id", "reaction_type"]
+        )
+    ],
+    indexes = [Index(name = "idx_diary_reaction_diary", columnList = "diary_id")]
+)
+class DiaryReaction(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_reaction_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    val diary: Diary,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type", nullable = false, length = 32)
+    val type: DiaryReactionType,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryReactionType.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/DiaryReactionType.kt
@@ -1,0 +1,13 @@
+package digdaserver.domain.diary.domain.entity
+
+/**
+ * 일기에 달 수 있는 이모지 리액션 종류.
+ * 클라이언트는 enum name 문자열로 주고받는다.
+ */
+enum class DiaryReactionType {
+    HEART, // ❤️
+    CRY, // 🥹
+    SPARKLE, // ✨
+    LAUGH, // 😆
+    FIRE // 🔥
+}

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryLikeRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryLikeRepository.kt
@@ -1,0 +1,47 @@
+package digdaserver.domain.diary.domain.repository
+
+import digdaserver.domain.diary.domain.entity.DiaryLike
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface DiaryLikeRepository : JpaRepository<DiaryLike, Long> {
+
+    fun existsByDiaryIdAndUserId(diaryId: Long, userId: UUID): Boolean
+
+    fun countByDiaryId(diaryId: Long): Long
+
+    @Modifying
+    @Query("DELETE FROM DiaryLike dl WHERE dl.diary.id = :diaryId AND dl.user.id = :userId")
+    fun deleteByDiaryIdAndUserId(@Param("diaryId") diaryId: Long, @Param("userId") userId: UUID): Int
+
+    @Query(
+        """
+        SELECT dl.diary.id, COUNT(dl)
+        FROM DiaryLike dl
+        WHERE dl.diary.id IN :diaryIds
+        GROUP BY dl.diary.id
+        """
+    )
+    fun countByDiaryIdIn(@Param("diaryIds") diaryIds: List<Long>): List<Array<Any>>
+
+    @Query(
+        """
+        SELECT dl.diary.id
+        FROM DiaryLike dl
+        WHERE dl.diary.id IN :diaryIds AND dl.user.id = :userId
+        """
+    )
+    fun findLikedDiaryIds(
+        @Param("diaryIds") diaryIds: List<Long>,
+        @Param("userId") userId: UUID
+    ): List<Long>
+
+    @Modifying
+    @Query("DELETE FROM DiaryLike dl WHERE dl.user.id = :userId")
+    fun deleteAllByUserId(@Param("userId") userId: UUID)
+}

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryReactionRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryReactionRepository.kt
@@ -1,0 +1,57 @@
+package digdaserver.domain.diary.domain.repository
+
+import digdaserver.domain.diary.domain.entity.DiaryReaction
+import digdaserver.domain.diary.domain.entity.DiaryReactionType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface DiaryReactionRepository : JpaRepository<DiaryReaction, Long> {
+
+    fun existsByDiaryIdAndUserIdAndType(diaryId: Long, userId: UUID, type: DiaryReactionType): Boolean
+
+    @Modifying
+    @Query(
+        """
+        DELETE FROM DiaryReaction dr
+        WHERE dr.diary.id = :diaryId AND dr.user.id = :userId AND dr.type = :type
+        """
+    )
+    fun deleteOne(
+        @Param("diaryId") diaryId: Long,
+        @Param("userId") userId: UUID,
+        @Param("type") type: DiaryReactionType
+    ): Int
+
+    fun findAllByDiaryId(diaryId: Long): List<DiaryReaction>
+
+    @Query(
+        """
+        SELECT dr.diary.id, dr.type, COUNT(dr)
+        FROM DiaryReaction dr
+        WHERE dr.diary.id IN :diaryIds
+        GROUP BY dr.diary.id, dr.type
+        """
+    )
+    fun countGroupedByDiaryAndType(@Param("diaryIds") diaryIds: List<Long>): List<Array<Any>>
+
+    @Query(
+        """
+        SELECT dr.diary.id, dr.type
+        FROM DiaryReaction dr
+        WHERE dr.diary.id IN :diaryIds AND dr.user.id = :userId
+        """
+    )
+    fun findMyReactions(
+        @Param("diaryIds") diaryIds: List<Long>,
+        @Param("userId") userId: UUID
+    ): List<Array<Any>>
+
+    @Modifying
+    @Query("DELETE FROM DiaryReaction dr WHERE dr.user.id = :userId")
+    fun deleteAllByUserId(@Param("userId") userId: UUID)
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
@@ -2,10 +2,13 @@ package digdaserver.domain.diary.presentation.controller
 
 import digdaserver.domain.diary.application.service.DiaryService
 import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -64,7 +67,7 @@ class DiaryController(
         return ResponseEntity.ok(response)
     }
 
-    @Operation(summary = "일기 작성", description = "새 일기를 작성합니다.")
+    @Operation(summary = "일기 작성", description = "새 일기를 작성합니다. 이미지는 imageIds 배열로 0..10장.")
     @PostMapping("/group-rooms/{groupRoomId}/diaries")
     fun createDiary(
         @AuthenticationPrincipal userId: String,
@@ -96,5 +99,28 @@ class DiaryController(
     ): ResponseEntity<Void> {
         diaryService.deleteDiary(UUID.fromString(userId), groupRoomId, diaryId)
         return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "일기 좋아요 토글", description = "해당 일기에 좋아요를 누르거나 취소합니다.")
+    @PostMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}/like")
+    fun toggleLike(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long
+    ): ResponseEntity<DiaryLikeResponse> {
+        val response = diaryService.toggleLike(UUID.fromString(userId), groupRoomId, diaryId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "일기 이모지 리액션 토글", description = "type 이미 누른 상태면 취소, 아니면 추가.")
+    @PostMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}/reactions")
+    fun toggleReaction(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long,
+        @RequestBody request: ToggleDiaryReactionRequest
+    ): ResponseEntity<DiaryReactionToggleResponse> {
+        val response = diaryService.toggleReaction(UUID.fromString(userId), groupRoomId, diaryId, request)
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
@@ -8,5 +8,7 @@ data class CreateDiaryRequest(
     val date: LocalDate,
     val weather: Int,
     val mood: Int,
-    val imageId: String? = null
+    val location: String? = null,
+    /** UploadedImage.id (Long) 의 문자열 리스트. 0..10 장. 순서대로 sort_order 부여. */
+    val imageIds: List<String> = emptyList()
 )

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/ToggleDiaryReactionRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/ToggleDiaryReactionRequest.kt
@@ -1,0 +1,7 @@
+package digdaserver.domain.diary.presentation.dto.req
+
+import digdaserver.domain.diary.domain.entity.DiaryReactionType
+
+data class ToggleDiaryReactionRequest(
+    val type: DiaryReactionType
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
@@ -2,11 +2,19 @@ package digdaserver.domain.diary.presentation.dto.req
 
 import java.time.LocalDate
 
+/**
+ * 일기 수정 요청.
+ *
+ * null = 변경 없음.
+ * [location] / [imageIds] 는 명시적으로 빈 값을 보내려면 빈 문자열 / 빈 리스트로 전달.
+ */
 data class UpdateDiaryRequest(
     val title: String? = null,
     val content: String? = null,
     val date: LocalDate? = null,
     val weather: Int? = null,
     val mood: Int? = null,
-    val imageId: String? = null
+    val location: String? = null,
+    /** null = 이미지 변경 없음. 빈 리스트 = 이미지 전부 제거. 값 있으면 그 순서대로 교체. */
+    val imageIds: List<String>? = null
 )

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryImageResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryImageResponse.kt
@@ -1,0 +1,17 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.diary.domain.entity.DiaryImage
+
+data class DiaryImageResponse(
+    val id: Long,
+    val url: String,
+    val sortOrder: Int
+) {
+    companion object {
+        fun from(image: DiaryImage): DiaryImageResponse = DiaryImageResponse(
+            id = image.id,
+            url = image.url,
+            sortOrder = image.sortOrder
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryLikeResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryLikeResponse.kt
@@ -1,0 +1,6 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+data class DiaryLikeResponse(
+    val likedByMe: Boolean,
+    val likeCount: Long
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryReactionSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryReactionSummary.kt
@@ -1,0 +1,16 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import digdaserver.domain.diary.domain.entity.DiaryReactionType
+
+/**
+ * 일기 1개에 대한 이모지 리액션 집계.
+ *
+ * @property type 리액션 종류 (enum name)
+ * @property count 해당 종류 총 카운트
+ * @property reactedByMe 현재 사용자가 이 종류를 눌렀는지
+ */
+data class DiaryReactionSummary(
+    val type: DiaryReactionType,
+    val count: Int,
+    val reactedByMe: Boolean
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryReactionToggleResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryReactionToggleResponse.kt
@@ -1,0 +1,5 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+data class DiaryReactionToggleResponse(
+    val reactions: List<DiaryReactionSummary>
+)

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
@@ -11,23 +11,36 @@ data class DiaryResponse(
     val date: LocalDate,
     val weather: Int,
     val mood: Int,
-    val imageUrl: String?,
+    val location: String?,
+    val imageUrls: List<String>,
     val createdBy: DiaryUserSummary,
     val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val updatedAt: LocalDateTime,
+    val likeCount: Long,
+    val likedByMe: Boolean,
+    val reactions: List<DiaryReactionSummary>
 ) {
     companion object {
-        fun from(diary: Diary): DiaryResponse = DiaryResponse(
+        fun from(
+            diary: Diary,
+            likeCount: Long,
+            likedByMe: Boolean,
+            reactions: List<DiaryReactionSummary>
+        ): DiaryResponse = DiaryResponse(
             id = diary.id,
             title = diary.title,
             content = diary.content,
             date = diary.date,
             weather = diary.weather,
             mood = diary.mood,
-            imageUrl = diary.imageUrl,
+            location = diary.location,
+            imageUrls = diary.images.sortedBy { it.sortOrder }.map { it.url },
             createdBy = DiaryUserSummary.from(diary.createdBy),
             createdAt = diary.createdAt,
-            updatedAt = diary.updatedAt
+            updatedAt = diary.updatedAt,
+            likeCount = likeCount,
+            likedByMe = likedByMe,
+            reactions = reactions
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
@@ -10,22 +10,38 @@ data class DiarySummaryResponse(
     val date: LocalDate,
     val weather: Int,
     val mood: Int,
-    val imageUrl: String?,
+    val location: String?,
+    val thumbnailUrl: String?,
+    val imageCount: Int,
     val createdBy: DiaryUserSummary,
     val commentCount: Int,
+    val likeCount: Long,
+    val likedByMe: Boolean,
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(diary: Diary, commentCount: Int): DiarySummaryResponse = DiarySummaryResponse(
-            id = diary.id,
-            title = diary.title,
-            date = diary.date,
-            weather = diary.weather,
-            mood = diary.mood,
-            imageUrl = diary.imageUrl,
-            createdBy = DiaryUserSummary.from(diary.createdBy),
-            commentCount = commentCount,
-            createdAt = diary.createdAt
-        )
+        fun from(
+            diary: Diary,
+            commentCount: Int,
+            likeCount: Long,
+            likedByMe: Boolean
+        ): DiarySummaryResponse {
+            val sorted = diary.images.sortedBy { it.sortOrder }
+            return DiarySummaryResponse(
+                id = diary.id,
+                title = diary.title,
+                date = diary.date,
+                weather = diary.weather,
+                mood = diary.mood,
+                location = diary.location,
+                thumbnailUrl = sorted.firstOrNull()?.url,
+                imageCount = sorted.size,
+                createdBy = DiaryUserSummary.from(diary.createdBy),
+                commentCount = commentCount,
+                likeCount = likeCount,
+                likedByMe = likedByMe,
+                createdAt = diary.createdAt
+            )
+        }
     }
 }

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
@@ -2,6 +2,8 @@ package digdaserver.domain.oauth2.application.service.impl.auth
 
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.device.domain.repository.DeviceRepository
+import digdaserver.domain.diary.domain.repository.DiaryLikeRepository
+import digdaserver.domain.diary.domain.repository.DiaryReactionRepository
 import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
@@ -34,6 +36,8 @@ class AccountServiceImpl(
     private val scheduleRepository: ScheduleRepository,
     private val commentRepository: CommentRepository,
     private val diaryRepository: DiaryRepository,
+    private val diaryLikeRepository: DiaryLikeRepository,
+    private val diaryReactionRepository: DiaryReactionRepository,
     private val todoRepository: TodoRepository,
     private val notificationRepository: NotificationRepository,
     private val deviceRepository: DeviceRepository,
@@ -66,7 +70,9 @@ class AccountServiceImpl(
         scheduleParticipantRepository.deleteAllByUserId(userId)
         scheduleParticipantRepository.deleteAllByScheduleCreatedById(userId)
 
-        // 내가 만든 컨텐츠 삭제
+        // 내가 만든 컨텐츠 삭제 (다른 사람 일기에 단 좋아요·리액션은 cascade 가 아닌 직접 정리)
+        diaryLikeRepository.deleteAllByUserId(userId)
+        diaryReactionRepository.deleteAllByUserId(userId)
         scheduleRepository.deleteAllByCreatedById(userId)
         commentRepository.deleteAllByCreatedById(userId)
         diaryRepository.deleteAllByCreatedById(userId)

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -9,15 +9,15 @@ import org.springframework.stereotype.Component
 
 /**
  * prod 는 `ddl-auto: none` 이라 Hibernate 가 스키마를 갱신하지 않는다. Flyway/Liquibase 도
- * 없는 상태에서 enum 값 추가 같은 변경이 누락되면 insert 가 "Data truncated for column"
- * 으로 통째로 실패하고, 운영에서는 catch-up 로그를 깔기 전엔 알기도 어렵다.
+ * 없는 상태에서 enum 값 추가·컬럼 추가·테이블 추가 같은 변경이 누락되면 insert 가 통째로
+ * 실패하고, 운영에서는 catch-up 로그를 깔기 전엔 알기도 어렵다.
  *
- * 그래서 알려진 schema drift 케이스를 startup 시 멱등하게 정정한다. 새 변경이 생길 때마다
- * [requiredColumns] 에 정의만 추가하면 자동 ALTER 가 적용된다.
+ * 그래서 알려진 schema drift 케이스를 startup 시 멱등하게 정정한다.
  *
- * - 컬럼 타입이 이미 기대값이면 ALTER 를 치지 않고 skip (멱등)
- * - 한 컬럼 실패가 다른 컬럼 마이그레이션을 막지 않도록 row 단위 try/catch
- * - 실패해도 애플리케이션 부팅은 막지 않는다 (운영에서 회복할 시간 확보)
+ * - [requiredColumns]: 컬럼 타입 정합. 이미 OK 면 skip (멱등)
+ * - [oneShotStatements]: CREATE TABLE / ALTER ADD COLUMN / DROP COLUMN /
+ *   TRUNCATE 등 멱등 SQL. 실행 전 [SkipCondition] 으로 빠른 skip 판단.
+ * - 한 step 실패가 다른 step 마이그레이션·앱 부팅을 막지 않도록 try/catch
  */
 @Component
 class SchemaAutoMigration(
@@ -27,12 +27,9 @@ class SchemaAutoMigration(
     private val log = LoggerFactory.getLogger(javaClass)
 
     /**
-     * 정정 대상 컬럼 목록.
+     * 컬럼 타입 정정 대상.
      *
-     * 현재 등록된 케이스:
-     *  - `notification.type`: 초기 MySQL ENUM(8) 으로 생성됐는데 이후 [NotificationType]
-     *    에 SCHEDULE_DAY_BEFORE / SCHEDULE_TODAY / MEMBER_LEFT / OWNERSHIP_TRANSFERRED /
-     *    ANNOUNCEMENT 5개 값이 추가되면서 새 값 insert 가 "Data truncated" 로 실패.
+     * - `notification.type`: 초기 MySQL ENUM(8) → 새 값 insert 가 "Data truncated".
      *    더 이상 enum 정의를 늘릴 때마다 SQL 을 손대지 않도록 VARCHAR(64) 로 일반화.
      */
     private val requiredColumns: List<RequiredColumn> = listOf(
@@ -46,15 +43,118 @@ class SchemaAutoMigration(
         )
     )
 
+    /**
+     * 멱등 SQL step 목록.
+     *
+     * 현재 등록된 케이스:
+     *  - 일기 리뉴얼(다중이미지/장소/좋아요/리액션, 기분 5종 확장):
+     *    기존 데이터를 비우고 image_url 컬럼을 제거, location 추가,
+     *    diary_image / diary_like / diary_reaction 신규 테이블 생성.
+     *    기존 diary 데이터는 작성자가 의도적으로 폐기 결정 → TRUNCATE.
+     */
+    private val oneShotStatements: List<OneShotStatement> = listOf(
+        // 1. 기존 일기·일기 댓글 삭제 (사진 단일 기준 데이터 모두 폐기)
+        OneShotStatement(
+            id = "diary-truncate-legacy-2026-05-25",
+            sql = "DELETE FROM comment WHERE target_type = 'DIARY'",
+            // 항상 실행해도 무해(이미 없으면 0건). 한 번만 돌도록 ledger 로 가드.
+            skip = SkipCondition.LedgerExecuted("diary-truncate-legacy-2026-05-25")
+        ),
+        OneShotStatement(
+            id = "diary-delete-all-rows-2026-05-25",
+            sql = "DELETE FROM diary",
+            skip = SkipCondition.LedgerExecuted("diary-delete-all-rows-2026-05-25")
+        ),
+        // 2. diary 테이블 컬럼 변경: image_url 제거, location 추가
+        OneShotStatement(
+            id = "diary-drop-image-url",
+            sql = "ALTER TABLE diary DROP COLUMN image_url",
+            skip = SkipCondition.ColumnAbsent(table = "diary", column = "image_url").inverse()
+        ),
+        OneShotStatement(
+            id = "diary-add-location",
+            sql = "ALTER TABLE diary ADD COLUMN location VARCHAR(100) NULL",
+            skip = SkipCondition.ColumnAbsent(table = "diary", column = "location")
+        ),
+        // 3. 신규 테이블
+        OneShotStatement(
+            id = "create-diary-image",
+            sql = """
+                CREATE TABLE IF NOT EXISTS diary_image (
+                  diary_image_id BIGINT NOT NULL AUTO_INCREMENT,
+                  diary_id BIGINT NOT NULL,
+                  url VARCHAR(500) NOT NULL,
+                  sort_order INT NOT NULL,
+                  created_at DATETIME NOT NULL,
+                  PRIMARY KEY (diary_image_id),
+                  KEY idx_diary_image_diary (diary_id),
+                  CONSTRAINT fk_diary_image_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """,
+            skip = SkipCondition.TableExists("diary_image")
+        ),
+        OneShotStatement(
+            id = "create-diary-like",
+            sql = """
+                CREATE TABLE IF NOT EXISTS diary_like (
+                  diary_like_id BIGINT NOT NULL AUTO_INCREMENT,
+                  diary_id BIGINT NOT NULL,
+                  user_id BINARY(16) NOT NULL,
+                  created_at DATETIME NOT NULL,
+                  PRIMARY KEY (diary_like_id),
+                  UNIQUE KEY uk_diary_like (diary_id, user_id),
+                  KEY idx_diary_like_diary (diary_id),
+                  CONSTRAINT fk_diary_like_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """,
+            skip = SkipCondition.TableExists("diary_like")
+        ),
+        OneShotStatement(
+            id = "create-diary-reaction",
+            sql = """
+                CREATE TABLE IF NOT EXISTS diary_reaction (
+                  diary_reaction_id BIGINT NOT NULL AUTO_INCREMENT,
+                  diary_id BIGINT NOT NULL,
+                  user_id BINARY(16) NOT NULL,
+                  reaction_type VARCHAR(32) NOT NULL,
+                  created_at DATETIME NOT NULL,
+                  PRIMARY KEY (diary_reaction_id),
+                  UNIQUE KEY uk_diary_reaction (diary_id, user_id, reaction_type),
+                  KEY idx_diary_reaction_diary (diary_id),
+                  CONSTRAINT fk_diary_reaction_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """,
+            skip = SkipCondition.TableExists("diary_reaction")
+        ),
+        // 4. ledger 테이블 (멱등 실행 기록)
+        OneShotStatement(
+            id = "create-schema-migration-ledger",
+            sql = """
+                CREATE TABLE IF NOT EXISTS schema_migration_ledger (
+                  migration_id VARCHAR(128) NOT NULL,
+                  executed_at DATETIME NOT NULL,
+                  PRIMARY KEY (migration_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """,
+            skip = SkipCondition.TableExists("schema_migration_ledger")
+        )
+    )
+
     override fun run(args: ApplicationArguments?) {
-        log.info("action=startup schema auto-migration 시작, 대상={}건", requiredColumns.size)
+        log.info("action=startup schema auto-migration 시작")
+        runRequiredColumns()
+        runOneShotStatements()
+        log.info("action=startup schema auto-migration 완료")
+    }
+
+    private fun runRequiredColumns() {
+        log.info("action=schema auto-migration column 단계, 대상={}건", requiredColumns.size)
         for (rc in requiredColumns) {
             try {
-                migrateOne(rc)
+                migrateOneColumn(rc)
             } catch (e: Exception) {
-                // 한 컬럼 실패가 다른 컬럼·앱 부팅을 막지 않게.
                 log.error(
-                    "action=startup schema auto-migration 실패, table={}, column={}, error={}",
+                    "action=schema auto-migration column 실패, table={}, column={}, error={}",
                     rc.table,
                     rc.column,
                     e.message,
@@ -62,14 +162,112 @@ class SchemaAutoMigration(
                 )
             }
         }
-        log.info("action=startup schema auto-migration 완료")
     }
 
-    private fun migrateOne(rc: RequiredColumn) {
+    private fun runOneShotStatements() {
+        log.info("action=schema auto-migration one-shot 단계, 대상={}건", oneShotStatements.size)
+        // ledger 테이블 자체 부트스트랩이 먼저 필요할 수 있어, ledger CREATE 가 있다면
+        // 다른 ledger 가드 step 보다 먼저 시도. 등록 순서를 유지하되 ledger 부족 시 한번 더 끌어올림.
+        val ledgerFirst = oneShotStatements.firstOrNull { it.id == "create-schema-migration-ledger" }
+        val rest = oneShotStatements.filterNot { it == ledgerFirst }
+        val ordered = listOfNotNull(ledgerFirst) + rest
+
+        for (step in ordered) {
+            try {
+                migrateOneStatement(step)
+            } catch (e: Exception) {
+                log.error(
+                    "action=schema auto-migration one-shot 실패, id={}, error={}",
+                    step.id,
+                    e.message,
+                    e
+                )
+            }
+        }
+    }
+
+    private fun migrateOneStatement(step: OneShotStatement) {
+        if (shouldSkip(step)) {
+            log.info("action=schema auto-migration one-shot skip(이미 충족), id={}", step.id)
+            return
+        }
+        log.warn("action=schema auto-migration one-shot 실행, id={}", step.id)
+        jdbcTemplate.execute(step.sql.trimIndent())
+        recordLedger(step.id)
+        log.info("action=schema auto-migration one-shot 완료, id={}", step.id)
+    }
+
+    private fun shouldSkip(step: OneShotStatement): Boolean {
+        val condition = step.skip ?: return false
+        return try {
+            when (condition) {
+                is SkipCondition.LedgerExecuted -> isLedgerExecuted(condition.migrationId)
+                is SkipCondition.TableExists -> doesTableExist(condition.table)
+                is SkipCondition.ColumnAbsent -> !doesColumnExist(condition.table, condition.column)
+                is SkipCondition.Inverted -> !shouldSkip(OneShotStatement(step.id, step.sql, condition.inner))
+            }
+        } catch (e: Exception) {
+            log.warn(
+                "action=schema auto-migration skip 조건 평가 실패(보수적으로 실행), id={}, error={}",
+                step.id,
+                e.message
+            )
+            false
+        }
+    }
+
+    private fun isLedgerExecuted(migrationId: String): Boolean {
+        if (!doesTableExist("schema_migration_ledger")) return false
+        val count = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM schema_migration_ledger WHERE migration_id = ?",
+            Int::class.java,
+            migrationId
+        ) ?: 0
+        return count > 0
+    }
+
+    private fun recordLedger(migrationId: String) {
+        if (!doesTableExist("schema_migration_ledger")) return
+        try {
+            jdbcTemplate.update(
+                "INSERT IGNORE INTO schema_migration_ledger(migration_id, executed_at) VALUES(?, NOW())",
+                migrationId
+            )
+        } catch (e: Exception) {
+            log.warn("action=schema auto-migration ledger 기록 실패, id={}, error={}", migrationId, e.message)
+        }
+    }
+
+    private fun doesTableExist(table: String): Boolean {
+        val count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+            """.trimIndent(),
+            Int::class.java,
+            table
+        ) ?: 0
+        return count > 0
+    }
+
+    private fun doesColumnExist(table: String, column: String): Boolean {
+        val count = jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
+            """.trimIndent(),
+            Int::class.java,
+            table,
+            column
+        ) ?: 0
+        return count > 0
+    }
+
+    private fun migrateOneColumn(rc: RequiredColumn) {
         val info = readColumnInfo(rc.table, rc.column)
         if (info == null) {
             log.warn(
-                "action=startup schema auto-migration 스킵(컬럼 없음), table={}, column={}",
+                "action=schema auto-migration column 스킵(컬럼 없음), table={}, column={}",
                 rc.table,
                 rc.column
             )
@@ -77,7 +275,7 @@ class SchemaAutoMigration(
         }
         if (rc.matches(info)) {
             log.info(
-                "action=startup schema auto-migration 스킵(이미 OK), table={}, column={}, current={}",
+                "action=schema auto-migration column 스킵(이미 OK), table={}, column={}, current={}",
                 rc.table,
                 rc.column,
                 info
@@ -85,7 +283,7 @@ class SchemaAutoMigration(
             return
         }
         log.warn(
-            "action=startup schema auto-migration ALTER 실행, table={}, column={}, before={}, sql={}",
+            "action=schema auto-migration column ALTER 실행, table={}, column={}, before={}, sql={}",
             rc.table,
             rc.column,
             info,
@@ -94,7 +292,7 @@ class SchemaAutoMigration(
         jdbcTemplate.execute(rc.alterSql)
         val after = readColumnInfo(rc.table, rc.column)
         log.info(
-            "action=startup schema auto-migration ALTER 완료, table={}, column={}, after={}",
+            "action=schema auto-migration column ALTER 완료, table={}, column={}, after={}",
             rc.table,
             rc.column,
             after
@@ -123,7 +321,7 @@ class SchemaAutoMigration(
             ).firstOrNull()
         } catch (e: DataAccessException) {
             log.warn(
-                "action=startup schema auto-migration 컬럼 메타 조회 실패, table={}, column={}, error={}",
+                "action=schema auto-migration 컬럼 메타 조회 실패, table={}, column={}, error={}",
                 table,
                 column,
                 e.message
@@ -153,5 +351,20 @@ class SchemaAutoMigration(
             if (info.nullable != nullable) return false
             return true
         }
+    }
+
+    private data class OneShotStatement(
+        val id: String,
+        val sql: String,
+        val skip: SkipCondition? = null
+    )
+
+    sealed class SkipCondition {
+        data class LedgerExecuted(val migrationId: String) : SkipCondition()
+        data class TableExists(val table: String) : SkipCondition()
+        data class ColumnAbsent(val table: String, val column: String) : SkipCondition()
+        data class Inverted(val inner: SkipCondition) : SkipCondition()
+
+        fun inverse(): SkipCondition = Inverted(this)
     }
 }


### PR DESCRIPTION
## Summary
일기 화면 리뉴얼(스펙: docs/re/) 백엔드 작업. 단일 이미지/4종 기분 모델을 다중 이미지/장소/좋아요/리액션/5종 기분 모델로 확장.

## 주요 변경
- **Diary 엔티티**: `image_url` 제거, `location` 추가, `DiaryImage` 1:N 관계 도입
- **신규 엔티티**: `DiaryImage`, `DiaryLike`, `DiaryReaction` (+ `DiaryReactionType` enum: HEART/CRY/SPARKLE/LAUGH/FIRE)
- **DTO**:
  - `DiaryResponse` / `DiarySummaryResponse` 에 `location`, `imageUrls[]`, `likeCount`, `likedByMe`, `reactions[]` 추가
  - 작성/수정 요청: `imageIds[]`(0..10장), `location`
- **신규 API**:
  - `POST /group-rooms/{groupRoomId}/diaries/{diaryId}/like` — 좋아요 토글
  - `POST /group-rooms/{groupRoomId}/diaries/{diaryId}/reactions` — 이모지 리액션 토글 (body: `{type: HEART}`)
- **기분 확장**: validation `0..3 → 0..4` (행복/평온/슬픔/화남/피곤)
- **SchemaAutoMigration 확장**: 멱등 one-shot SQL 스텝 추가
  - `LedgerExecuted` / `TableExists` / `ColumnAbsent` 가드로 멱등 보장
  - 기존 diary / comment(target=DIARY) DELETE (작성자 요청으로 폐기)
  - `diary.image_url` DROP, `diary.location` ADD
  - `diary_image` / `diary_like` / `diary_reaction` 신규 CREATE TABLE
  - `schema_migration_ledger` 신규 (실행 기록)
- **AccountServiceImpl**: 회원탈퇴 시 `diary_like` / `diary_reaction` 정리 추가

## 운영 주의
- prod 첫 부팅 시 startup 로그에서 `action=schema auto-migration one-shot 실행` 메시지 5건+ 확인
- 기존 일기 데이터는 의도적으로 폐기됨 (작성자 결정)
- 모든 step 실패해도 부팅 막지 않음 (try/catch + error 로그)

## Test plan
- [ ] 신규 일기 작성: imageIds 0/1/3/10 장 케이스 모두 동작
- [ ] 일기 수정: imageIds null=변경없음, 빈배열=이미지전부제거, 값=교체
- [ ] 좋아요 토글: 두 번 누르면 카운트 ±1 왔다갔다
- [ ] 리액션 토글: type별 카운트 / reactedByMe 정상
- [ ] 회원탈퇴: 다른 사람 일기에 단 좋아요/리액션도 함께 정리
- [ ] startup 마이그레이션: 두 번 부팅해도 두 번째는 skip 로그

🤖 Generated with [Claude Code](https://claude.com/claude-code)