### PR TITLE
fix(diary+upload): 마이그레이션 강건화 + 업로드 50MB + 에러 메시지 한글

### DIFF
--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -27,7 +27,7 @@ class UploadServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val MAX_SIZE_BYTES = 8L * 1024 * 1024
+        private const val MAX_SIZE_BYTES = 50L * 1024 * 1024
         private val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/jpg")
     }
 

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -91,8 +91,8 @@ enum class ErrorCode(
     DEVICE_NOT_FOUND("DEVICE_NOT_FOUND", "존재하지 않는 디바이스입니다.", 404),
 
     // ── Upload ──
-    FILE_TOO_LARGE("FILE_TOO_LARGE", "파일 크기가 8MB를 초과합니다.", 413),
-    INVALID_FILE_TYPE("INVALID_FILE_TYPE", "PNG 또는 JPEG 파일만 업로드할 수 있습니다.", 400),
+    FILE_TOO_LARGE("FILE_TOO_LARGE", "사진 용량이 너무 커요. 50MB 이하로 올려주세요.", 413),
+    INVALID_FILE_TYPE("INVALID_FILE_TYPE", "PNG 또는 JPEG 사진만 올릴 수 있어요.", 400),
     IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", "존재하지 않는 이미지입니다.", 404),
 
     // ── Rate Limit ──

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -3,6 +3,8 @@ package digdaserver.global.infra.migration
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
 import org.springframework.dao.DataAccessException
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
@@ -141,11 +143,82 @@ class SchemaAutoMigration(
     )
 
     override fun run(args: ApplicationArguments?) {
-        log.info("action=startup schema auto-migration 시작")
+        runAll(trigger = "ApplicationRunner")
+    }
+
+    /**
+     * 일부 환경(컨테이너 health-check 이전 traffic) 에서 ApplicationRunner 가 늦게 도는
+     * 케이스를 방어. 같은 ledger 가드로 멱등이라 두 번 돌아도 안전.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun onReady() {
+        runAll(trigger = "ApplicationReadyEvent")
+    }
+
+    private fun runAll(trigger: String) {
+        log.info("action=schema auto-migration 시작, trigger={}", trigger)
         runRequiredColumns()
         runOneShotStatements()
-        log.info("action=startup schema auto-migration 완료")
+        verifyCriticalSchema()
+        log.info("action=schema auto-migration 완료, trigger={}", trigger)
     }
+
+    /**
+     * 마이그레이션이 모두 성공했는지 사후 검증.
+     * 어떤 이유로 step 이 catch 되거나 traffic 이 먼저 도착해 컬럼이 비어있을 때
+     * 운영 대시보드에서 즉시 알 수 있도록 error 로그 + 한 번 더 직접 ALTER 시도.
+     */
+    private fun verifyCriticalSchema() {
+        val checks = listOf(
+            CriticalColumn(
+                table = "diary",
+                column = "location",
+                rescueSql = "ALTER TABLE diary ADD COLUMN location VARCHAR(100) NULL"
+            )
+        )
+        for (c in checks) {
+            if (doesColumnExist(c.table, c.column)) {
+                log.info("action=schema verify OK, table={}, column={}", c.table, c.column)
+                continue
+            }
+            log.error(
+                "action=schema verify 누락, table={}, column={} — rescue ALTER 시도",
+                c.table,
+                c.column
+            )
+            try {
+                jdbcTemplate.execute(c.rescueSql)
+                log.warn(
+                    "action=schema verify rescue 성공, table={}, column={}",
+                    c.table,
+                    c.column
+                )
+            } catch (e: Exception) {
+                log.error(
+                    "action=schema verify rescue 실패, table={}, column={}, error={}",
+                    c.table,
+                    c.column,
+                    e.message,
+                    e
+                )
+            }
+        }
+
+        val tableChecks = listOf("diary_image", "diary_like", "diary_reaction")
+        for (t in tableChecks) {
+            if (doesTableExist(t)) {
+                log.info("action=schema verify OK, table={}", t)
+            } else {
+                log.error("action=schema verify 누락 테이블={}", t)
+            }
+        }
+    }
+
+    private data class CriticalColumn(
+        val table: String,
+        val column: String,
+        val rescueSql: String
+    )
 
     private fun runRequiredColumns() {
         log.info("action=schema auto-migration column 단계, 대상={}건", requiredColumns.size)


### PR DESCRIPTION
## Summary
- 운영에서 일기 화면 진입 시 \`Unknown column 'd1_0.location' in 'field list'\` SQL 에러 발생 → SchemaAutoMigration 이 늦게 돌거나 누락된 케이스 방어
- 업로드 한도가 8MB라 사용자가 자주 막힘 → 50MB 로 풀고 메시지 한글로
- 일부 인프라(컨테이너 health-check 이전 traffic) 에서 ApplicationRunner 가 늦게 도는 케이스를 \`@EventListener(ApplicationReadyEvent)\` 로 이중화

## 변경
- \`SchemaAutoMigration\`
  - ApplicationRunner + ApplicationReadyEvent 두 trigger (멱등 ledger 가드)
  - 끝에 \`verifyCriticalSchema\`: \`diary.location\` 및 신규 테이블 3종 존재 확인, 누락 시 rescue ALTER 직접 시도
- \`UploadServiceImpl\` MAX_SIZE_BYTES 8MB → 50MB
- \`ErrorCode\` FILE_TOO_LARGE / INVALID_FILE_TYPE 메시지 한글 갱신

## 즉시 조치 안내
머지 후 prod 재배포가 트리거되면 startup 로그에서:
\`action=schema verify OK, table=diary, column=location\`
\`action=schema verify OK, table=diary_image\`
등이 보여야 합니다. \`action=schema verify 누락\` 가 보이면 rescue ALTER 가 도는지 따라 확인.

## Test plan
- [ ] startup 로그에 verify OK 5건 (diary.location, diary_image, diary_like, diary_reaction)
- [ ] 일기 목록/상세 진입 정상
- [ ] 8MB 초과 사진 업로드 (~30MB) 정상
- [ ] 60MB 사진 업로드 시 한글 에러 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)