### PR TITLE
chore(migration): diary 일회성 step / verify 로직 제거 — 부팅 ERROR 로그 정리

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -3,23 +3,24 @@ package digdaserver.global.infra.migration
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
-import org.springframework.boot.context.event.ApplicationReadyEvent
-import org.springframework.context.event.EventListener
 import org.springframework.dao.DataAccessException
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
 
 /**
  * prod 는 `ddl-auto: none` 이라 Hibernate 가 스키마를 갱신하지 않는다. Flyway/Liquibase 도
- * 없는 상태에서 enum 값 추가·컬럼 추가·테이블 추가 같은 변경이 누락되면 insert 가 통째로
- * 실패하고, 운영에서는 catch-up 로그를 깔기 전엔 알기도 어렵다.
+ * 없는 상태에서 enum 값 추가·컬럼 타입 변경 같은 schema drift 가 누락되면 insert 가
+ * "Data truncated for column" 으로 통째로 실패하므로, 알려진 drift 케이스를 startup 시
+ * 멱등하게 정정한다.
  *
- * 그래서 알려진 schema drift 케이스를 startup 시 멱등하게 정정한다.
+ * 현재 등록된 케이스는 [requiredColumns] 만. 새 drift 가 생기면 거기에 추가.
+ * (테이블/컬럼 추가 같은 대규모 변경은 운영 DB 에 직접 ALTER 를 친 뒤, 신규 환경 셋업은
+ *  dev 의 ddl-auto: create 또는 entity 기반 init 으로 처리한다. 일회성 ALTER 를 코드에
+ *  남겨두면 다음 부팅마다 "이미 충족" 로그 또는 에러로 노이즈가 누적되어 제거하기로 했다.)
  *
- * - [requiredColumns]: 컬럼 타입 정합. 이미 OK 면 skip (멱등)
- * - [oneShotStatements]: CREATE TABLE / ALTER ADD COLUMN / DROP COLUMN /
- *   TRUNCATE 등 멱등 SQL. 실행 전 [SkipCondition] 으로 빠른 skip 판단.
- * - 한 step 실패가 다른 step 마이그레이션·앱 부팅을 막지 않도록 try/catch
+ * - 컬럼 타입이 이미 기대값이면 ALTER 를 치지 않고 skip (멱등)
+ * - 한 컬럼 실패가 다른 컬럼 마이그레이션을 막지 않도록 row 단위 try/catch
+ * - 실패해도 애플리케이션 부팅은 막지 않는다 (운영에서 회복할 시간 확보)
  */
 @Component
 class SchemaAutoMigration(
@@ -29,10 +30,11 @@ class SchemaAutoMigration(
     private val log = LoggerFactory.getLogger(javaClass)
 
     /**
-     * 컬럼 타입 정정 대상.
+     * 정정 대상 컬럼 목록.
      *
-     * - `notification.type`: 초기 MySQL ENUM(8) → 새 값 insert 가 "Data truncated".
-     *    더 이상 enum 정의를 늘릴 때마다 SQL 을 손대지 않도록 VARCHAR(64) 로 일반화.
+     * - `notification.type`: 초기 MySQL ENUM(8) 으로 생성됐는데 이후 [NotificationType]
+     *    에 값이 추가되면서 insert 가 "Data truncated" 로 실패. 새 enum 값 추가 시마다
+     *    SQL 을 손대지 않도록 VARCHAR(64) 로 일반화.
      */
     private val requiredColumns: List<RequiredColumn> = listOf(
         RequiredColumn(
@@ -45,189 +47,15 @@ class SchemaAutoMigration(
         )
     )
 
-    /**
-     * 멱등 SQL step 목록.
-     *
-     * 현재 등록된 케이스:
-     *  - 일기 리뉴얼(다중이미지/장소/좋아요/리액션, 기분 5종 확장):
-     *    기존 데이터를 비우고 image_url 컬럼을 제거, location 추가,
-     *    diary_image / diary_like / diary_reaction 신규 테이블 생성.
-     *    기존 diary 데이터는 작성자가 의도적으로 폐기 결정 → TRUNCATE.
-     */
-    private val oneShotStatements: List<OneShotStatement> = listOf(
-        // 1. 기존 일기·일기 댓글 삭제 (사진 단일 기준 데이터 모두 폐기)
-        OneShotStatement(
-            id = "diary-truncate-legacy-2026-05-25",
-            sql = "DELETE FROM comment WHERE target_type = 'DIARY'",
-            // 항상 실행해도 무해(이미 없으면 0건). 한 번만 돌도록 ledger 로 가드.
-            skip = SkipCondition.LedgerExecuted("diary-truncate-legacy-2026-05-25")
-        ),
-        OneShotStatement(
-            id = "diary-delete-all-rows-2026-05-25",
-            sql = "DELETE FROM diary",
-            skip = SkipCondition.LedgerExecuted("diary-delete-all-rows-2026-05-25")
-        ),
-        // 2. diary 테이블 컬럼 변경: image_url 제거, location 추가
-        OneShotStatement(
-            id = "diary-drop-image-url",
-            sql = "ALTER TABLE diary DROP COLUMN image_url",
-            skip = SkipCondition.ColumnAbsent(table = "diary", column = "image_url").inverse()
-        ),
-        OneShotStatement(
-            id = "diary-add-location",
-            sql = "ALTER TABLE diary ADD COLUMN location VARCHAR(100) NULL",
-            skip = SkipCondition.ColumnAbsent(table = "diary", column = "location")
-        ),
-        // 3. 신규 테이블
-        OneShotStatement(
-            id = "create-diary-image",
-            sql = """
-                CREATE TABLE IF NOT EXISTS diary_image (
-                  diary_image_id BIGINT NOT NULL AUTO_INCREMENT,
-                  diary_id BIGINT NOT NULL,
-                  url VARCHAR(500) NOT NULL,
-                  sort_order INT NOT NULL,
-                  created_at DATETIME NOT NULL,
-                  PRIMARY KEY (diary_image_id),
-                  KEY idx_diary_image_diary (diary_id),
-                  CONSTRAINT fk_diary_image_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-            """,
-            skip = SkipCondition.TableExists("diary_image")
-        ),
-        OneShotStatement(
-            id = "create-diary-like",
-            sql = """
-                CREATE TABLE IF NOT EXISTS diary_like (
-                  diary_like_id BIGINT NOT NULL AUTO_INCREMENT,
-                  diary_id BIGINT NOT NULL,
-                  user_id BINARY(16) NOT NULL,
-                  created_at DATETIME NOT NULL,
-                  PRIMARY KEY (diary_like_id),
-                  UNIQUE KEY uk_diary_like (diary_id, user_id),
-                  KEY idx_diary_like_diary (diary_id),
-                  CONSTRAINT fk_diary_like_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-            """,
-            skip = SkipCondition.TableExists("diary_like")
-        ),
-        OneShotStatement(
-            id = "create-diary-reaction",
-            sql = """
-                CREATE TABLE IF NOT EXISTS diary_reaction (
-                  diary_reaction_id BIGINT NOT NULL AUTO_INCREMENT,
-                  diary_id BIGINT NOT NULL,
-                  user_id BINARY(16) NOT NULL,
-                  reaction_type VARCHAR(32) NOT NULL,
-                  created_at DATETIME NOT NULL,
-                  PRIMARY KEY (diary_reaction_id),
-                  UNIQUE KEY uk_diary_reaction (diary_id, user_id, reaction_type),
-                  KEY idx_diary_reaction_diary (diary_id),
-                  CONSTRAINT fk_diary_reaction_diary FOREIGN KEY (diary_id) REFERENCES diary(diary_id) ON DELETE CASCADE
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-            """,
-            skip = SkipCondition.TableExists("diary_reaction")
-        ),
-        // 4. ledger 테이블 (멱등 실행 기록)
-        OneShotStatement(
-            id = "create-schema-migration-ledger",
-            sql = """
-                CREATE TABLE IF NOT EXISTS schema_migration_ledger (
-                  migration_id VARCHAR(128) NOT NULL,
-                  executed_at DATETIME NOT NULL,
-                  PRIMARY KEY (migration_id)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-            """,
-            skip = SkipCondition.TableExists("schema_migration_ledger")
-        )
-    )
-
     override fun run(args: ApplicationArguments?) {
-        runAll(trigger = "ApplicationRunner")
-    }
-
-    /**
-     * 일부 환경(컨테이너 health-check 이전 traffic) 에서 ApplicationRunner 가 늦게 도는
-     * 케이스를 방어. 같은 ledger 가드로 멱등이라 두 번 돌아도 안전.
-     */
-    @EventListener(ApplicationReadyEvent::class)
-    fun onReady() {
-        runAll(trigger = "ApplicationReadyEvent")
-    }
-
-    private fun runAll(trigger: String) {
-        log.info("action=schema auto-migration 시작, trigger={}", trigger)
-        runRequiredColumns()
-        runOneShotStatements()
-        verifyCriticalSchema()
-        log.info("action=schema auto-migration 완료, trigger={}", trigger)
-    }
-
-    /**
-     * 마이그레이션이 모두 성공했는지 사후 검증.
-     * 어떤 이유로 step 이 catch 되거나 traffic 이 먼저 도착해 컬럼이 비어있을 때
-     * 운영 대시보드에서 즉시 알 수 있도록 error 로그 + 한 번 더 직접 ALTER 시도.
-     */
-    private fun verifyCriticalSchema() {
-        val checks = listOf(
-            CriticalColumn(
-                table = "diary",
-                column = "location",
-                rescueSql = "ALTER TABLE diary ADD COLUMN location VARCHAR(100) NULL"
-            )
-        )
-        for (c in checks) {
-            if (doesColumnExist(c.table, c.column)) {
-                log.info("action=schema verify OK, table={}, column={}", c.table, c.column)
-                continue
-            }
-            log.error(
-                "action=schema verify 누락, table={}, column={} — rescue ALTER 시도",
-                c.table,
-                c.column
-            )
-            try {
-                jdbcTemplate.execute(c.rescueSql)
-                log.warn(
-                    "action=schema verify rescue 성공, table={}, column={}",
-                    c.table,
-                    c.column
-                )
-            } catch (e: Exception) {
-                log.error(
-                    "action=schema verify rescue 실패, table={}, column={}, error={}",
-                    c.table,
-                    c.column,
-                    e.message,
-                    e
-                )
-            }
-        }
-
-        val tableChecks = listOf("diary_image", "diary_like", "diary_reaction")
-        for (t in tableChecks) {
-            if (doesTableExist(t)) {
-                log.info("action=schema verify OK, table={}", t)
-            } else {
-                log.error("action=schema verify 누락 테이블={}", t)
-            }
-        }
-    }
-
-    private data class CriticalColumn(
-        val table: String,
-        val column: String,
-        val rescueSql: String
-    )
-
-    private fun runRequiredColumns() {
-        log.info("action=schema auto-migration column 단계, 대상={}건", requiredColumns.size)
+        log.info("action=startup schema auto-migration 시작, 대상={}건", requiredColumns.size)
         for (rc in requiredColumns) {
             try {
-                migrateOneColumn(rc)
+                migrateOne(rc)
             } catch (e: Exception) {
+                // 한 컬럼 실패가 다른 컬럼·앱 부팅을 막지 않게.
                 log.error(
-                    "action=schema auto-migration column 실패, table={}, column={}, error={}",
+                    "action=startup schema auto-migration 실패, table={}, column={}, error={}",
                     rc.table,
                     rc.column,
                     e.message,
@@ -235,112 +63,14 @@ class SchemaAutoMigration(
                 )
             }
         }
+        log.info("action=startup schema auto-migration 완료")
     }
 
-    private fun runOneShotStatements() {
-        log.info("action=schema auto-migration one-shot 단계, 대상={}건", oneShotStatements.size)
-        // ledger 테이블 자체 부트스트랩이 먼저 필요할 수 있어, ledger CREATE 가 있다면
-        // 다른 ledger 가드 step 보다 먼저 시도. 등록 순서를 유지하되 ledger 부족 시 한번 더 끌어올림.
-        val ledgerFirst = oneShotStatements.firstOrNull { it.id == "create-schema-migration-ledger" }
-        val rest = oneShotStatements.filterNot { it == ledgerFirst }
-        val ordered = listOfNotNull(ledgerFirst) + rest
-
-        for (step in ordered) {
-            try {
-                migrateOneStatement(step)
-            } catch (e: Exception) {
-                log.error(
-                    "action=schema auto-migration one-shot 실패, id={}, error={}",
-                    step.id,
-                    e.message,
-                    e
-                )
-            }
-        }
-    }
-
-    private fun migrateOneStatement(step: OneShotStatement) {
-        if (shouldSkip(step)) {
-            log.info("action=schema auto-migration one-shot skip(이미 충족), id={}", step.id)
-            return
-        }
-        log.warn("action=schema auto-migration one-shot 실행, id={}", step.id)
-        jdbcTemplate.execute(step.sql.trimIndent())
-        recordLedger(step.id)
-        log.info("action=schema auto-migration one-shot 완료, id={}", step.id)
-    }
-
-    private fun shouldSkip(step: OneShotStatement): Boolean {
-        val condition = step.skip ?: return false
-        return try {
-            when (condition) {
-                is SkipCondition.LedgerExecuted -> isLedgerExecuted(condition.migrationId)
-                is SkipCondition.TableExists -> doesTableExist(condition.table)
-                is SkipCondition.ColumnAbsent -> !doesColumnExist(condition.table, condition.column)
-                is SkipCondition.Inverted -> !shouldSkip(OneShotStatement(step.id, step.sql, condition.inner))
-            }
-        } catch (e: Exception) {
-            log.warn(
-                "action=schema auto-migration skip 조건 평가 실패(보수적으로 실행), id={}, error={}",
-                step.id,
-                e.message
-            )
-            false
-        }
-    }
-
-    private fun isLedgerExecuted(migrationId: String): Boolean {
-        if (!doesTableExist("schema_migration_ledger")) return false
-        val count = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM schema_migration_ledger WHERE migration_id = ?",
-            Int::class.java,
-            migrationId
-        ) ?: 0
-        return count > 0
-    }
-
-    private fun recordLedger(migrationId: String) {
-        if (!doesTableExist("schema_migration_ledger")) return
-        try {
-            jdbcTemplate.update(
-                "INSERT IGNORE INTO schema_migration_ledger(migration_id, executed_at) VALUES(?, NOW())",
-                migrationId
-            )
-        } catch (e: Exception) {
-            log.warn("action=schema auto-migration ledger 기록 실패, id={}, error={}", migrationId, e.message)
-        }
-    }
-
-    private fun doesTableExist(table: String): Boolean {
-        val count = jdbcTemplate.queryForObject(
-            """
-            SELECT COUNT(*) FROM information_schema.TABLES
-            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
-            """.trimIndent(),
-            Int::class.java,
-            table
-        ) ?: 0
-        return count > 0
-    }
-
-    private fun doesColumnExist(table: String, column: String): Boolean {
-        val count = jdbcTemplate.queryForObject(
-            """
-            SELECT COUNT(*) FROM information_schema.COLUMNS
-            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
-            """.trimIndent(),
-            Int::class.java,
-            table,
-            column
-        ) ?: 0
-        return count > 0
-    }
-
-    private fun migrateOneColumn(rc: RequiredColumn) {
+    private fun migrateOne(rc: RequiredColumn) {
         val info = readColumnInfo(rc.table, rc.column)
         if (info == null) {
             log.warn(
-                "action=schema auto-migration column 스킵(컬럼 없음), table={}, column={}",
+                "action=startup schema auto-migration 스킵(컬럼 없음), table={}, column={}",
                 rc.table,
                 rc.column
             )
@@ -348,7 +78,7 @@ class SchemaAutoMigration(
         }
         if (rc.matches(info)) {
             log.info(
-                "action=schema auto-migration column 스킵(이미 OK), table={}, column={}, current={}",
+                "action=startup schema auto-migration 스킵(이미 OK), table={}, column={}, current={}",
                 rc.table,
                 rc.column,
                 info
@@ -356,7 +86,7 @@ class SchemaAutoMigration(
             return
         }
         log.warn(
-            "action=schema auto-migration column ALTER 실행, table={}, column={}, before={}, sql={}",
+            "action=startup schema auto-migration ALTER 실행, table={}, column={}, before={}, sql={}",
             rc.table,
             rc.column,
             info,
@@ -365,7 +95,7 @@ class SchemaAutoMigration(
         jdbcTemplate.execute(rc.alterSql)
         val after = readColumnInfo(rc.table, rc.column)
         log.info(
-            "action=schema auto-migration column ALTER 완료, table={}, column={}, after={}",
+            "action=startup schema auto-migration ALTER 완료, table={}, column={}, after={}",
             rc.table,
             rc.column,
             after
@@ -394,7 +124,7 @@ class SchemaAutoMigration(
             ).firstOrNull()
         } catch (e: DataAccessException) {
             log.warn(
-                "action=schema auto-migration 컬럼 메타 조회 실패, table={}, column={}, error={}",
+                "action=startup schema auto-migration 컬럼 메타 조회 실패, table={}, column={}, error={}",
                 table,
                 column,
                 e.message
@@ -424,20 +154,5 @@ class SchemaAutoMigration(
             if (info.nullable != nullable) return false
             return true
         }
-    }
-
-    private data class OneShotStatement(
-        val id: String,
-        val sql: String,
-        val skip: SkipCondition? = null
-    )
-
-    sealed class SkipCondition {
-        data class LedgerExecuted(val migrationId: String) : SkipCondition()
-        data class TableExists(val table: String) : SkipCondition()
-        data class ColumnAbsent(val table: String, val column: String) : SkipCondition()
-        data class Inverted(val inner: SkipCondition) : SkipCondition()
-
-        fun inverse(): SkipCondition = Inverted(this)
     }
 }


### PR DESCRIPTION
## 문제
운영 부팅 로그에 매번 동일한 SQL 에러가 도배됨.
\`\`\`
ERROR ... action=schema auto-migration one-shot 실패, id=diary-drop-image-url, error=Can't DROP 'image_url'
ERROR ... action=schema auto-migration one-shot 실패, id=diary-add-location, error=Duplicate column name 'location'
\`\`\`

## 원인
- prod schema 는 이미 정상 (verify OK 4건 다 통과)
- 그런데도 diary 관련 일회성 step 들이 매 부팅마다 다시 시도
- skip 조건의 \`.inverse()\` 가 의도와 반대로 동작해 멱등성이 깨짐
- 두 번 trigger (ApplicationRunner + ApplicationReadyEvent) 라 ERROR 가 두 배

## 결정
사용자 의도(엔티티 = source of truth, 일회성 ALTER 코드 제거) 에 맞춰 정리.

## 변경
- \`oneShotStatements\` 인프라 (OneShotStatement, SkipCondition, ledger, ApplicationReadyEvent 트리거) 전부 제거
- \`verifyCriticalSchema\` 제거 (정상화 후 검증 로직도 노이즈)
- \`requiredColumns\` 의 notification.type VARCHAR(64) 정정만 유지 (멱등 OK, 기존 동작 그대로)
- 코드 -310 / +25

## 영향
- prod: 다음 부팅부터 SQL 에러 0건, 로그는 notification.type "이미 OK skip" 한 줄만
- dev: \`ddl-auto: create\` 라 매번 schema 재생성 — 영향 없음
- 미적용 환경: 없음 (현재 prod / dev 둘 다 schema 일치)

## 향후 schema drift 가 또 생기면
\`requiredColumns\` 에 새 \`RequiredColumn(...)\` 한 줄 추가. (테이블 신규 같은 대규모 변경은
운영 DB 에 직접 ALTER 친 뒤 코드에는 남기지 않는다 — 본 PR 의 교훈.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)