### PR TITLE
feat(diary): 일기 수정 시 기존 사진 URL 유지 — imageIds 에 URL/ID 혼합 허용

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -339,13 +339,29 @@ class DiaryServiceImpl(
         if (count > MAX_IMAGES_PER_DIARY) throw DigdaException(ErrorCode.FILE_TOO_LARGE)
     }
 
+    /**
+     * 클라이언트가 보낸 항목별로 처리하여 일기 image_url 리스트로 변환.
+     *
+     * - "http://" 또는 "https://" 로 시작하는 항목은 *기존 사진 URL* 로 간주하고 그대로 보존.
+     *   (수정 시 보유 사진 일부만 추가/삭제할 수 있게 함)
+     * - 그 외 숫자 문자열은 *신규 업로드 ID* 로 간주하고 UploadedImage 에서 lookup.
+     * - 어느 쪽도 아니거나 lookup 실패 항목은 로그만 남기고 건너뜀.
+     *
+     * 순서는 입력 순서를 유지해 클라이언트가 정렬 순서를 결정한다.
+     */
     private fun resolveImageUrls(imageIds: List<String>): List<String> {
         if (imageIds.isEmpty()) return emptyList()
         val urls = mutableListOf<String>()
         for (raw in imageIds) {
-            val id = raw.toLongOrNull()
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) continue
+            if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+                urls.add(trimmed)
+                continue
+            }
+            val id = trimmed.toLongOrNull()
             if (id == null) {
-                log.warn("imageId 가 Long 이 아님: imageId={}", raw)
+                log.warn("imageIds 항목이 URL/Long 둘 다 아님: value={}", trimmed)
                 continue
             }
             val img = uploadedImageRepository.findById(id).orElse(null)


### PR DESCRIPTION
## 문제
일기 수정 시 보유 사진 일부만 추가/삭제하려 해도 **모든 사진을 다시 업로드**해야 했음. 6장 중 1장만 추가하려면 기존 6장 + 신규 1장 = 7번 업로드. 사용자 불편 크고 비용도 낭비.

## 변경
\`DiaryServiceImpl.resolveImageUrls\` 가 \`imageIds\` 항목별로 자동 판별:
- \`http://\` / \`https://\` 로 시작 → **기존 사진 URL 그대로 보존**
- 숫자 → \`UploadedImage\` lookup (기존 동작)
- 그 외 / lookup 실패 → 로그 후 skip

## 효과
- 수정 시 "유지할 기존 URL + 새 업로드 ID" 를 클라가 섞어 보내면 그 순서대로 image_url 리스트 재구성
- 6장 중 1장 추가: 기존 6 URL + 신규 1 ID 보내면 끝
- 일부만 삭제: 삭제할 URL 만 빼고 보내면 끝

## Backward compatibility
기존 클라(앱 PR 67) 는 ID 만 보냄 → 동작 동일. 클라 PR (앱 별도 PR) 머지 전에도 이 PR 단독 머지 안전.

## Test plan
- [ ] 신규 작성: 사진 0/3/10장 모두 정상
- [ ] 수정 시 imageIds 에 \`[url1, url2, "42"]\` 보내면 url1, url2, (id=42 의 url) 순서대로 저장
- [ ] 수정 시 \`["url-잘못된형식"]\` 보내면 skip 후 로그

🤖 Generated with [Claude Code](https://claude.com/claude-code)