### PR TITLE
fix(upload): Tomcat 한도 풀기 + 413 한글 응답

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/GlobalExceptionHandler.kt
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
@@ -46,6 +47,28 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(e.httpStatusCode)
             .body(ErrorResponse.of(e))
+    }
+
+    /**
+     * Spring multipart 가 application yml 의 max-file-size / max-request-size 한도를
+     * 넘는 업로드를 거부할 때 던지는 예외. 기본 Spring 응답은 영문 "Request Entity Too Large"
+     * 라 사용자에게 그대로 노출되면 의미 전달 안 됨. ErrorCode.FILE_TOO_LARGE 의 한글
+     * 메시지로 통일해서 413 으로 응답.
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException::class)
+    fun handleMaxUploadSizeExceeded(
+        e: MaxUploadSizeExceededException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
+        log.warn(
+            "업로드 크기 초과 {}, maxUploadSize={}, message={}",
+            requestContext(request),
+            e.maxUploadSize,
+            e.message
+        )
+        return ResponseEntity
+            .status(ErrorCode.FILE_TOO_LARGE.httpCode)
+            .body(ErrorResponse.of(ErrorCode.FILE_TOO_LARGE))
     }
 
     @ExceptionHandler(NoResourceFoundException::class)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  tomcat:
+    max-http-form-post-size: 60MB
+    max-swallow-size: 60MB
 
 spring:
   config:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,13 @@
 server:
   port: 8080
   forward-headers-strategy: framework
+  tomcat:
+    # 사진 50MB 업로드 시 Tomcat 단에서 잘리지 않도록 풀어둠.
+    # max-http-form-post-size: multipart 본문 size limit (default 2MB).
+    # max-swallow-size: max-file-size 초과 시 클라이언트가 끝까지 보낸 바이트를 빨아들이는 한도.
+    #   너무 작으면 connection reset 으로 클라에 한글 에러가 못 가고 끊김.
+    max-http-form-post-size: 60MB
+    max-swallow-size: 60MB
 
 spring:
   config:


### PR DESCRIPTION
## 사용자 보고
사진 업로드 시 \"REQUEST ENTITY TOO LARGE\" 영문 노출. 한글로 + 한도 풀기 요청.

## 원인
- Tomcat \`max-http-form-post-size\` / \`max-swallow-size\` 기본값(2MB) 가 application yml multipart 50MB 보다 작아 사진이 Tomcat 단에서 컷
- Spring 의 \`MaxUploadSizeExceededException\` 을 GlobalExceptionHandler 가 안 잡아 기본 영문 \"Request Entity Too Large\" 응답

## 변경
- \`application-prod.yml\` / \`application-dev.yml\`: \`server.tomcat.max-http-form-post-size\`, \`max-swallow-size\` 둘 다 60MB
- \`GlobalExceptionHandler.handleMaxUploadSizeExceeded\`: \`ErrorCode.FILE_TOO_LARGE\`("사진 용량이 너무 커요. 50MB 이하로 올려주세요.") 한글 + 413 응답

## 운영 주의
앞에 nginx / ALB / Cloudflare 같은 리버스 프록시가 있다면 거기도 \`client_max_body_size 60M\` (nginx) 또는 같은 설정 필요. 안 그러면 프록시 단에서 컷되어 우리 한글 응답 못 감.

## Test plan
- [ ] 30MB JPEG 업로드 성공
- [ ] 60MB 파일 시도 시 한글 메시지 + 413
- [ ] 100MB 같은 초대형 파일 시도 시 (프록시 없는 환경에서) 우리 핸들러 한글 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)