### PR TITLE
fix(upload+diary): 업로드 한도 100MB 통일 + 일기 삭제 cascade 처리

### DIFF
--- a/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
@@ -35,4 +35,11 @@ interface CommentRepository : JpaRepository<Comment, Long> {
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.createdBy.id = :userId")
     fun deleteAllByCreatedById(@Param("userId") userId: UUID)
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.targetType = :targetType AND c.targetId = :targetId")
+    fun deleteAllByTargetTypeAndTargetId(
+        @Param("targetType") targetType: CommentTargetType,
+        @Param("targetId") targetId: Long
+    ): Int
 }

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -259,6 +259,22 @@ class DiaryServiceImpl(
         }
 
         val title = diary.title
+
+        // diary 에 매달린 자식 레코드들을 먼저 정리해야 FK constraint 위반을 피한다.
+        //   · diary_like / diary_reaction : diary_id FK + cascade 미설정 → 수동 삭제
+        //   · comment : FK 는 없지만 target_type=DIARY 로 매핑돼있어 orphan 으로 남음 → 같이 삭제
+        val likeDeleted = diaryLikeRepository.deleteAllByDiaryId(diaryId)
+        val reactionDeleted = diaryReactionRepository.deleteAllByDiaryId(diaryId)
+        val commentDeleted =
+            commentRepository.deleteAllByTargetTypeAndTargetId(CommentTargetType.DIARY, diaryId)
+        log.info(
+            "diary 삭제 준비 - diaryId={}, likes={}, reactions={}, comments={}",
+            diaryId,
+            likeDeleted,
+            reactionDeleted,
+            commentDeleted
+        )
+
         diaryRepository.delete(diary)
 
         userActionLogService.record(

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryLikeRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryLikeRepository.kt
@@ -44,4 +44,8 @@ interface DiaryLikeRepository : JpaRepository<DiaryLike, Long> {
     @Modifying
     @Query("DELETE FROM DiaryLike dl WHERE dl.user.id = :userId")
     fun deleteAllByUserId(@Param("userId") userId: UUID)
+
+    @Modifying
+    @Query("DELETE FROM DiaryLike dl WHERE dl.diary.id = :diaryId")
+    fun deleteAllByDiaryId(@Param("diaryId") diaryId: Long): Int
 }

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryReactionRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryReactionRepository.kt
@@ -54,4 +54,8 @@ interface DiaryReactionRepository : JpaRepository<DiaryReaction, Long> {
     @Modifying
     @Query("DELETE FROM DiaryReaction dr WHERE dr.user.id = :userId")
     fun deleteAllByUserId(@Param("userId") userId: UUID)
+
+    @Modifying
+    @Query("DELETE FROM DiaryReaction dr WHERE dr.diary.id = :diaryId")
+    fun deleteAllByDiaryId(@Param("diaryId") diaryId: Long): Int
 }

--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -27,7 +27,7 @@ class UploadServiceImpl(
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val MAX_SIZE_BYTES = 50L * 1024 * 1024
+        private const val MAX_SIZE_BYTES = 100L * 1024 * 1024
         private val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/jpg")
     }
 

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -91,7 +91,7 @@ enum class ErrorCode(
     DEVICE_NOT_FOUND("DEVICE_NOT_FOUND", "존재하지 않는 디바이스입니다.", 404),
 
     // ── Upload ──
-    FILE_TOO_LARGE("FILE_TOO_LARGE", "사진 용량이 너무 커요. 50MB 이하로 올려주세요.", 413),
+    FILE_TOO_LARGE("FILE_TOO_LARGE", "사진 용량이 너무 커요. 100MB 이하로 올려주세요.", 413),
     INVALID_FILE_TYPE("INVALID_FILE_TYPE", "PNG 또는 JPEG 사진만 올릴 수 있어요.", 400),
     IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", "존재하지 않는 이미지입니다.", 404),
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,8 +1,8 @@
 server:
   port: 8080
   tomcat:
-    max-http-form-post-size: 60MB
-    max-swallow-size: 60MB
+    max-http-form-post-size: 110MB
+    max-swallow-size: 110MB
 
 spring:
   config:
@@ -38,8 +38,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 100MB
+      max-request-size: 100MB
 
   task:
     scheduling:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,12 +2,12 @@ server:
   port: 8080
   forward-headers-strategy: framework
   tomcat:
-    # 사진 50MB 업로드 시 Tomcat 단에서 잘리지 않도록 풀어둠.
+    # 사진 100MB 업로드 시 Tomcat 단에서 잘리지 않도록 풀어둠.
     # max-http-form-post-size: multipart 본문 size limit (default 2MB).
     # max-swallow-size: max-file-size 초과 시 클라이언트가 끝까지 보낸 바이트를 빨아들이는 한도.
     #   너무 작으면 connection reset 으로 클라에 한글 에러가 못 가고 끊김.
-    max-http-form-post-size: 60MB
-    max-swallow-size: 60MB
+    max-http-form-post-size: 110MB
+    max-swallow-size: 110MB
 
 spring:
   config:
@@ -42,8 +42,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 100MB
+      max-request-size: 100MB
 
   task:
     scheduling:


### PR DESCRIPTION
## Summary
- 업로드 한도를 50MB → **100MB** 로 통일 (multipart, Tomcat, UploadService, FILE_TOO_LARGE 메시지)
- 일기 삭제 시 `diary_like` / `diary_reaction` / `comment(target=DIARY)` 를 먼저 정리. 좋아요·리액션이 달린 일기를 삭제하면 FK constraint violation 으로 500 이 떨어지던 버그 해소
- Tomcat 한도는 multipart 한도보다 10MB 여유 (110MB)

## Changes
- `application-{dev,prod}.yml` — multipart 100MB, Tomcat 110MB
- `UploadServiceImpl.MAX_SIZE_BYTES` — 100MB
- `ErrorCode.FILE_TOO_LARGE` — 안내 100MB
- `DiaryServiceImpl.deleteDiary` — like/reaction/comment 선삭제 + count 로그
- `DiaryLikeRepository.deleteAllByDiaryId`, `DiaryReactionRepository.deleteAllByDiaryId` 추가
- `CommentRepository.deleteAllByTargetTypeAndTargetId` 추가 (orphan 댓글 정리)

## Test plan
- [ ] 좋아요/리액션/댓글 달린 일기 삭제 → 200 OK
- [ ] 100MB 이내 사진 업로드 정상 (nginx 한도도 같이 올린 뒤)
- [ ] 100MB 초과 시 413 + "사진 용량이 너무 커요. 100MB 이하로 올려주세요."