### PR TITLE
feat(character): 디코(조력자) 등장 + 이미지 퀴즈 지원

### DIFF
--- a/docs/migration/character_diko_and_quiz_image.sql
+++ b/docs/migration/character_diko_and_quiz_image.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- 디코(조력자) 등장 + 이미지 퀴즈 지원
+--
+-- - group_character.diko_unlocked: 그룹별 디코 해금 여부 (Lv.10 도달 시 true 로 전환)
+-- - character_quiz.image_url: 이미지 퀴즈일 때만 채워지는 S3 URL (NULL = 기존 텍스트 퀴즈)
+--
+-- 운영 DB 적용 후, 신규 환경 셋업은 entity 기반 ddl-auto 가 흡수.
+-- 부팅 시 누락된 컬럼은 SchemaAutoMigration 이 idempotent 하게 ADD 한다.
+-- ============================================================
+
+ALTER TABLE `group_character`
+    ADD COLUMN `diko_unlocked` BIT(1) NOT NULL DEFAULT b'0';
+
+-- 기존 행 중 이미 Lv.10 이상이면 디코를 즉시 해금 처리해 일관성 확보.
+UPDATE `group_character`
+SET    `diko_unlocked` = b'1'
+WHERE  `level` >= 10;
+
+ALTER TABLE `character_quiz`
+    ADD COLUMN `image_url` VARCHAR(2048) NULL;

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterGearInitializer.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterGearInitializer.kt
@@ -28,7 +28,7 @@ class CharacterGearInitializer(
 
         defaults.forEach { def ->
             if (!groupCharacterItemRepository
-                    .existsByGroupRoomIdAndShopItemId(groupRoomId, def.id)
+                .existsByGroupRoomIdAndShopItemId(groupRoomId, def.id)
             ) {
                 groupCharacterItemRepository.save(
                     GroupCharacterItem(

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -66,6 +66,7 @@ class CharacterQuizServiceImpl(
         val author = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
+        val normalizedImageUrl = request.imageUrl?.trim()?.ifEmpty { null }
         val quiz = quizRepository.save(
             CharacterQuiz(
                 groupRoom = groupRoom,
@@ -77,7 +78,8 @@ class CharacterQuizServiceImpl(
                 option3 = request.options[2],
                 option4 = request.options[3],
                 correctIndex = request.correctIndex,
-                expMultiplier = request.expMultiplier
+                expMultiplier = request.expMultiplier,
+                imageUrl = normalizedImageUrl
             )
         )
         log.info(
@@ -200,10 +202,17 @@ class CharacterQuizServiceImpl(
                     stageName = gain.stageAfter.displayName
                 )
             }
+            if (gain.dikoJustUnlocked) {
+                notificationService.notifyDikoUnlocked(
+                    groupRoomId = quiz.groupRoom.id,
+                    actorUserId = userId
+                )
+            }
         } catch (e: Exception) {
             log.warn(
                 "action=character_quiz_attempt_notify_failed, quizId={}, error={}",
-                quizId, e.message
+                quizId,
+                e.message
             )
         }
 
@@ -219,7 +228,8 @@ class CharacterQuizServiceImpl(
             levelGained = gain.levelGained,
             stageBefore = gain.stageBefore,
             stageAfter = gain.stageAfter,
-            stageChanged = gain.stageChanged
+            stageChanged = gain.stageChanged,
+            dikoJustUnlocked = gain.dikoJustUnlocked
         )
     }
 

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterServiceImpl.kt
@@ -41,7 +41,10 @@ class CharacterServiceImpl(
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)
         log.info(
             "action=character_get, userId={}, groupRoomId={}, stage={}, level={}",
-            userId, groupRoomId, character.stage, character.level
+            userId,
+            groupRoomId,
+            character.stage,
+            character.level
         )
         return CharacterStateResponse.from(character, equipped)
     }
@@ -81,7 +84,23 @@ class CharacterServiceImpl(
             } catch (e: Exception) {
                 log.warn(
                     "action=character_gain_exp_notify_failed, groupRoomId={}, error={}",
-                    groupRoomId, e.message
+                    groupRoomId,
+                    e.message
+                )
+            }
+        }
+
+        if (result.dikoJustUnlocked) {
+            try {
+                notificationService.notifyDikoUnlocked(
+                    groupRoomId = groupRoomId,
+                    actorUserId = userId
+                )
+            } catch (e: Exception) {
+                log.warn(
+                    "action=character_gain_exp_diko_notify_failed, groupRoomId={}, error={}",
+                    groupRoomId,
+                    e.message
                 )
             }
         }
@@ -105,7 +124,10 @@ class CharacterServiceImpl(
 
         log.info(
             "action=character_master_game_start, userId={}, groupRoomId={}, fee={}, balanceAfter={}",
-            userId, groupRoomId, MASTER_GAME_ENTRY_FEE, character.coin
+            userId,
+            groupRoomId,
+            MASTER_GAME_ENTRY_FEE,
+            character.coin
         )
 
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)
@@ -135,7 +157,12 @@ class CharacterServiceImpl(
         log.info(
             "action=character_master_game_reward, userId={}, groupRoomId={}, score={}, " +
                 "tier={}, coinReward={}, balanceAfter={}",
-            userId, groupRoomId, score, tier, coinReward, character.coin
+            userId,
+            groupRoomId,
+            score,
+            tier,
+            coinReward,
+            character.coin
         )
 
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterShopServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterShopServiceImpl.kt
@@ -106,7 +106,11 @@ class CharacterShopServiceImpl(
 
         log.info(
             "action=character_shop_buy_item, userId={}, groupRoomId={}, itemKey={}, cost={}, balanceAfter={}",
-            userId, groupRoomId, itemKey, item.cost, character.coin
+            userId,
+            groupRoomId,
+            itemKey,
+            item.cost,
+            character.coin
         )
 
         return getShop(userId, groupRoomId)
@@ -132,7 +136,10 @@ class CharacterShopServiceImpl(
 
         log.info(
             "action=character_shop_equip, userId={}, groupRoomId={}, itemKey={}, itemType={}",
-            userId, groupRoomId, itemKey, item.itemType
+            userId,
+            groupRoomId,
+            itemKey,
+            item.itemType
         )
 
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)
@@ -162,7 +169,9 @@ class CharacterShopServiceImpl(
 
         log.info(
             "action=character_shop_unequip, userId={}, groupRoomId={}, itemType={}",
-            userId, groupRoomId, itemType
+            userId,
+            groupRoomId,
+            itemType
         )
 
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/CharacterQuiz.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/CharacterQuiz.kt
@@ -68,6 +68,13 @@ class CharacterQuiz(
     @Column(name = "exp_multiplier", nullable = false)
     val expMultiplier: Int,
 
+    /**
+     * 이미지 퀴즈일 때만 채워지는 S3 URL. NULL 이면 텍스트 전용 퀴즈 (기존 호환).
+     * 길이는 다른 도메인의 image URL 컬럼(2048) 과 맞춤.
+     */
+    @Column(name = "image_url", nullable = true, length = 2048)
+    val imageUrl: String? = null,
+
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
 ) {

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
@@ -27,6 +27,9 @@ import jakarta.persistence.UniqueConstraint
  *
  * 외형(색·아이템)은 이 엔티티가 직접 갖지 않고 [GroupCharacterEquipped] 에서 카테고리
  * 슬롯별로 관리한다 (스킨 1 + 모자/안경/머리핀/액세서리/잡화 각 1).
+ *
+ * 조력자 캐릭터 디코는 [dikoUnlocked] 플래그 하나로만 표현한다. 별도 레벨/성장 시스템이
+ * 없는 동반 캐릭터라 엔티티를 새로 두지 않고 모찌 행에 같이 매단다.
  */
 @Entity
 @Table(
@@ -55,7 +58,10 @@ class GroupCharacter(
     var exp: Int = 0,
 
     @Column(nullable = false)
-    var coin: Int = 0
+    var coin: Int = 0,
+
+    @Column(name = "diko_unlocked", nullable = false)
+    var dikoUnlocked: Boolean = false
 
 ) : BaseTimeEntity() {
 
@@ -64,12 +70,23 @@ class GroupCharacter(
      * (대량 보상 케이스). 반환값은 이번 호출로 도달한 새 레벨 수(>=0).
      *
      * 동시 호출에 대한 race 는 호출자에서 트랜잭션·잠금으로 처리.
+     *
+     * 추가로, 이번 호출 도중 [DIKO_UNLOCK_LEVEL] 이상에 처음 도달하면 [dikoUnlocked] 를
+     * true 로 전환하고 [GainResult.dikoJustUnlocked] 에 한 번만 true 로 반영한다.
      */
     fun gainExp(amount: Int): GainResult {
         require(amount >= 0) { "exp gain must be non-negative" }
-        if (amount == 0) return GainResult(levelGained = 0, stageBefore = stage, stageAfter = stage)
+        if (amount == 0) {
+            return GainResult(
+                levelGained = 0,
+                stageBefore = stage,
+                stageAfter = stage,
+                dikoJustUnlocked = false
+            )
+        }
 
         val stageBefore = stage
+        val dikoWasUnlocked = dikoUnlocked
         var remaining = exp + amount
         var levelsGained = 0
         while (remaining >= CharacterLevelTable.expForNextLevel(level)) {
@@ -83,7 +100,20 @@ class GroupCharacter(
         }
         exp = remaining
         stage = CharacterStage.forLevel(level)
-        return GainResult(levelGained = levelsGained, stageBefore = stageBefore, stageAfter = stage)
+
+        val dikoJustUnlocked = if (!dikoWasUnlocked && level >= DIKO_UNLOCK_LEVEL) {
+            dikoUnlocked = true
+            true
+        } else {
+            false
+        }
+
+        return GainResult(
+            levelGained = levelsGained,
+            stageBefore = stageBefore,
+            stageAfter = stage,
+            dikoJustUnlocked = dikoJustUnlocked
+        )
     }
 
     fun addCoin(amount: Int) {
@@ -101,8 +131,14 @@ class GroupCharacter(
     data class GainResult(
         val levelGained: Int,
         val stageBefore: CharacterStage,
-        val stageAfter: CharacterStage
+        val stageAfter: CharacterStage,
+        val dikoJustUnlocked: Boolean = false
     ) {
         val stageChanged: Boolean get() = stageBefore != stageAfter
+    }
+
+    companion object {
+        /** 디코가 처음 등장하는 레벨. 모찌 본체 진화와는 별개 트리거. */
+        const val DIKO_UNLOCK_LEVEL: Int = 10
     }
 }

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacterEquipped.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacterEquipped.kt
@@ -27,10 +27,12 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "group_character_equipped",
-    uniqueConstraints = [UniqueConstraint(
-        name = "uq_gce_group_type",
-        columnNames = ["group_room_id", "item_type"]
-    )]
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_gce_group_type",
+            columnNames = ["group_room_id", "item_type"]
+        )
+    ]
 )
 class GroupCharacterEquipped(
 

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacterItem.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacterItem.kt
@@ -22,10 +22,12 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "group_character_item",
-    uniqueConstraints = [UniqueConstraint(
-        name = "uq_group_character_item",
-        columnNames = ["group_room_id", "shop_item_id"]
-    )]
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_group_character_item",
+            columnNames = ["group_room_id", "shop_item_id"]
+        )
+    ]
 )
 class GroupCharacterItem(
 

--- a/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterController.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterController.kt
@@ -95,7 +95,8 @@ class CharacterController(
     ): ResponseEntity<CharacterStateResponse> {
         log.info(
             "api=POST /character/master-game-start, userId={}, groupRoomId={}",
-            userId, groupRoomId
+            userId,
+            groupRoomId
         )
         return ResponseEntity.ok(
             characterService.startMasterGame(UUID.fromString(userId), groupRoomId)
@@ -114,11 +115,15 @@ class CharacterController(
     ): ResponseEntity<MasterGameRewardResponse> {
         log.info(
             "api=POST /character/master-game-reward, userId={}, groupRoomId={}, score={}",
-            userId, groupRoomId, request.score
+            userId,
+            groupRoomId,
+            request.score
         )
         return ResponseEntity.ok(
             characterService.claimMasterGameReward(
-                UUID.fromString(userId), groupRoomId, request.score
+                UUID.fromString(userId),
+                groupRoomId,
+                request.score
             )
         )
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterShopController.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterShopController.kt
@@ -56,7 +56,9 @@ class CharacterShopController(
     ): ResponseEntity<CharacterShopResponse> {
         log.info(
             "api=POST /character/shop/items/{}/buy, userId={}, groupRoomId={}",
-            itemKey, userId, groupRoomId
+            itemKey,
+            userId,
+            groupRoomId
         )
         return ResponseEntity.ok(
             shopService.buyItem(UUID.fromString(userId), groupRoomId, itemKey)
@@ -75,7 +77,9 @@ class CharacterShopController(
     ): ResponseEntity<CharacterStateResponse> {
         log.info(
             "api=PUT /character/shop/equip, userId={}, groupRoomId={}, itemKey={}",
-            userId, groupRoomId, request.itemKey
+            userId,
+            groupRoomId,
+            request.itemKey
         )
         return ResponseEntity.ok(
             shopService.equipItem(UUID.fromString(userId), groupRoomId, request.itemKey)
@@ -94,7 +98,9 @@ class CharacterShopController(
     ): ResponseEntity<CharacterStateResponse> {
         log.info(
             "api=DELETE /character/shop/equip/{}, userId={}, groupRoomId={}",
-            itemType, userId, groupRoomId
+            itemType,
+            userId,
+            groupRoomId
         )
         val type = ShopItemType.safeValueOf(itemType.uppercase())
             ?: throw DigdaException(ErrorCode.INVALID_PARAMETER)

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/req/CreateQuizRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/req/CreateQuizRequest.kt
@@ -2,11 +2,18 @@ package digdaserver.domain.character.presentation.dto.req
 
 import digdaserver.domain.character.domain.entity.QuizCategory
 
+/**
+ * 퀴즈 생성 요청.
+ *
+ * [imageUrl] 은 선택 — 채워서 보내면 이미지 퀴즈, null/빈 문자열이면 기존 텍스트 퀴즈.
+ * 업로드는 별도로 `/uploads/images?purpose=quiz` 를 호출해 URL 을 받은 뒤 여기에 넣는다.
+ */
 data class CreateQuizRequest(
     val groupRoomId: Long,
     val category: QuizCategory,
     val question: String,
     val options: List<String>,
     val correctIndex: Int,
-    val expMultiplier: Int
+    val expMultiplier: Int,
+    val imageUrl: String? = null
 )

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/AddExpResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/AddExpResponse.kt
@@ -7,6 +7,9 @@ import digdaserver.domain.character.domain.entity.GroupCharacterEquipped
 /**
  * exp 가산 결과 + 갱신된 캐릭터 상태. 클라이언트는 [levelGained]>0 이면 레벨업 연출,
  * [stageChanged]=true 이면 진화 연출을 띄울 수 있다.
+ *
+ * [dikoJustUnlocked]=true 이면 디코 등장 컷씬을 1회 띄운다 (서버는 보존된 상태로 더 이상
+ * true 를 내려주지 않음 — `character.dikoUnlocked` 만 true 로 유지).
  */
 data class AddExpResponse(
     val character: CharacterStateResponse,
@@ -14,7 +17,8 @@ data class AddExpResponse(
     val stageBefore: CharacterStage,
     val stageAfter: CharacterStage,
     val stageChanged: Boolean,
-    val coinDelta: Int
+    val coinDelta: Int,
+    val dikoJustUnlocked: Boolean
 ) {
     companion object {
         fun from(
@@ -29,7 +33,8 @@ data class AddExpResponse(
                 stageBefore = result.stageBefore,
                 stageAfter = result.stageAfter,
                 stageChanged = result.stageChanged,
-                coinDelta = coinDelta
+                coinDelta = coinDelta,
+                dikoJustUnlocked = result.dikoJustUnlocked
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -15,7 +15,8 @@ data class CharacterQuizResponse(
     val question: String,
     val options: List<String>,
     val expMultiplier: Int,
-    val authorName: String
+    val authorName: String,
+    val imageUrl: String?
 ) {
     companion object {
         fun from(quiz: CharacterQuiz): CharacterQuizResponse {
@@ -27,7 +28,8 @@ data class CharacterQuizResponse(
                 question = quiz.question,
                 options = quiz.options(),
                 expMultiplier = quiz.expMultiplier,
-                authorName = quiz.author.name
+                authorName = quiz.author.name,
+                imageUrl = quiz.imageUrl
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterStateResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterStateResponse.kt
@@ -20,6 +20,7 @@ data class CharacterStateResponse(
     val expForNextLevel: Int,
     val coin: Int,
     val maxLevelReached: Boolean,
+    val dikoUnlocked: Boolean,
     val equippedItems: List<EquippedItemResponse>
 ) {
     companion object {
@@ -37,6 +38,7 @@ data class CharacterStateResponse(
                 expForNextLevel = if (atMax) 0 else nextThreshold,
                 coin = character.coin,
                 maxLevelReached = atMax,
+                dikoUnlocked = character.dikoUnlocked,
                 equippedItems = equipped
                     .sortedBy { it.shopItem.layerOrder }
                     .map(EquippedItemResponse::from)

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/QuizAttemptResultResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/QuizAttemptResultResponse.kt
@@ -19,5 +19,6 @@ data class QuizAttemptResultResponse(
     val levelGained: Int,
     val stageBefore: CharacterStage,
     val stageAfter: CharacterStage,
-    val stageChanged: Boolean
+    val stageChanged: Boolean,
+    val dikoJustUnlocked: Boolean = false
 )

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
@@ -92,6 +92,9 @@ interface NotificationService {
         stageName: String
     )
 
+    /** 디코(조력자) 최초 등장. 그룹 멤버 전원에게 1회만 발송. */
+    fun notifyDikoUnlocked(groupRoomId: Long, actorUserId: UUID)
+
     fun sendAnnouncement(
         targetUserIds: List<UUID>?,
         title: String,

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -470,6 +470,24 @@ class NotificationServiceImpl(
     }
 
     @Transactional
+    override fun notifyDikoUnlocked(groupRoomId: Long, actorUserId: UUID) {
+        val groupRoom = findGroupRoom(groupRoomId)
+        // 디코 등장은 그룹 멤버 전원이 보도록 actor 도 포함.
+        val recipients = membershipRepository.findAllByGroupRoomId(groupRoomId).map { it.user }
+
+        notify(
+            recipients,
+            NotificationPayload(
+                type = NotificationType.DIKO_UNLOCKED,
+                title = "디코 등장! ✨",
+                message = "모찌의 새로운 친구 디코가 등장했어요!",
+                groupRoomId = groupRoomId,
+                groupRoomName = groupRoom.name
+            )
+        )
+    }
+
+    @Transactional
     override fun sendAnnouncement(
         targetUserIds: List<UUID>?,
         title: String,

--- a/src/main/kotlin/digdaserver/domain/notification/domain/entity/NotificationType.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/domain/entity/NotificationType.kt
@@ -19,6 +19,7 @@ enum class NotificationType {
     QUIZ_CREATED,
     QUIZ_ANSWERED,
     MOCHI_LEVELUP,
+    DIKO_UNLOCKED,
     ANNOUNCEMENT;
 
     @JsonValue

--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -73,6 +73,7 @@ class UploadServiceImpl(
             "profile" -> ImagePurpose.PROFILE
             "group_thumbnail" -> ImagePurpose.GROUP_THUMBNAIL
             "diary" -> ImagePurpose.DIARY
+            "quiz" -> ImagePurpose.QUIZ
             else -> throw DigdaException(ErrorCode.INVALID_PARAMETER)
         }
     }

--- a/src/main/kotlin/digdaserver/domain/upload/domain/entity/ImagePurpose.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/domain/entity/ImagePurpose.kt
@@ -4,5 +4,6 @@ enum class ImagePurpose {
 
     PROFILE,
     GROUP_THUMBNAIL,
-    DIARY;
+    DIARY,
+    QUIZ;
 }

--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/NotificationPushDispatcherImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/NotificationPushDispatcherImpl.kt
@@ -69,6 +69,7 @@ class NotificationPushDispatcherImpl(
             NotificationType.QUIZ_CREATED,
             NotificationType.QUIZ_ANSWERED,
             NotificationType.MOCHI_LEVELUP,
+            NotificationType.DIKO_UNLOCKED,
             NotificationType.ANNOUNCEMENT -> true
         }
     }

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -47,8 +47,36 @@ class SchemaAutoMigration(
         )
     )
 
+    /**
+     * 신규 환경/누락 환경 보강용 — 엔티티에는 있지만 prod 테이블에 아직 없는 컬럼을
+     * 멱등하게 ADD. ADD COLUMN 은 컬럼이 존재하면 스킵해 안전하다.
+     *
+     * - `group_character.diko_unlocked`: 디코(조력자) 등장 여부. 기존 Lv.10+ 데이터는
+     *    추가 직후 한 번에 UPDATE 로 backfill.
+     * - `character_quiz.image_url`: 이미지 퀴즈 URL. NULL 허용이라 추가만으로 충분.
+     */
+    private val missingColumns: List<MissingColumn> = listOf(
+        MissingColumn(
+            table = "group_character",
+            column = "diko_unlocked",
+            addSql = "ALTER TABLE group_character ADD COLUMN diko_unlocked BIT(1) NOT NULL DEFAULT b'0'",
+            postSql = listOf(
+                "UPDATE group_character SET diko_unlocked = b'1' WHERE level >= 10"
+            )
+        ),
+        MissingColumn(
+            table = "character_quiz",
+            column = "image_url",
+            addSql = "ALTER TABLE character_quiz ADD COLUMN image_url VARCHAR(2048) NULL"
+        )
+    )
+
     override fun run(args: ApplicationArguments?) {
-        log.info("action=startup schema auto-migration 시작, 대상={}건", requiredColumns.size)
+        log.info(
+            "action=startup schema auto-migration 시작, modify={}건, addIfMissing={}건",
+            requiredColumns.size,
+            missingColumns.size
+        )
         for (rc in requiredColumns) {
             try {
                 migrateOne(rc)
@@ -63,7 +91,60 @@ class SchemaAutoMigration(
                 )
             }
         }
+        for (mc in missingColumns) {
+            try {
+                addIfMissing(mc)
+            } catch (e: Exception) {
+                log.error(
+                    "action=startup schema auto-migration ADD 실패, table={}, column={}, error={}",
+                    mc.table,
+                    mc.column,
+                    e.message,
+                    e
+                )
+            }
+        }
         log.info("action=startup schema auto-migration 완료")
+    }
+
+    private fun addIfMissing(mc: MissingColumn) {
+        val info = readColumnInfo(mc.table, mc.column)
+        if (info != null) {
+            log.info(
+                "action=startup schema auto-migration ADD 스킵(이미 있음), table={}, column={}",
+                mc.table,
+                mc.column
+            )
+            return
+        }
+        log.warn(
+            "action=startup schema auto-migration ADD 실행, table={}, column={}, sql={}",
+            mc.table,
+            mc.column,
+            mc.addSql
+        )
+        jdbcTemplate.execute(mc.addSql)
+        for (sql in mc.postSql) {
+            try {
+                val rows = jdbcTemplate.update(sql)
+                log.info(
+                    "action=startup schema auto-migration ADD post-sql 적용, table={}, column={}, rows={}, sql={}",
+                    mc.table,
+                    mc.column,
+                    rows,
+                    sql
+                )
+            } catch (e: Exception) {
+                log.error(
+                    "action=startup schema auto-migration ADD post-sql 실패, table={}, column={}, sql={}, error={}",
+                    mc.table,
+                    mc.column,
+                    sql,
+                    e.message,
+                    e
+                )
+            }
+        }
     }
 
     private fun migrateOne(rc: RequiredColumn) {
@@ -155,4 +236,12 @@ class SchemaAutoMigration(
             return true
         }
     }
+
+    /** [postSql] 은 backfill 처럼 ADD 직후 1회 더 돌릴 SQL. 실패해도 부팅은 막지 않는다. */
+    private data class MissingColumn(
+        val table: String,
+        val column: String,
+        val addSql: String,
+        val postSql: List<String> = emptyList()
+    )
 }


### PR DESCRIPTION
## Summary
- 모찌 옆 보조 캐릭터 디코를 신설했어요. 별도 레벨/성장 시스템 없이 `GroupCharacter.dikoUnlocked` 한 플래그로만 관리하고, Lv.10 도달 시 자동 해금돼 `dikoJustUnlocked` 가 응답에 1회 노출됩니다.
- 캐릭터 퀴즈에 `imageUrl` 컬럼이 추가됐어요. `/uploads/images?purpose=quiz` 로 선업로드 후 받은 URL 을 `CreateQuizRequest.imageUrl` 에 담아 보내는 방식이라 기존 텍스트 퀴즈도 그대로 동작합니다.
- 신규 `NotificationType.DIKO_UNLOCKED` 알림을 그룹 전원에게 발송하고, FCM 디스패처에도 분기를 추가했어요.
- 운영 DB 는 `docs/migration/character_diko_and_quiz_image.sql` 로 ALTER, 신규/누락 환경은 `SchemaAutoMigration` 이 컬럼 ADD + Lv.10+ backfill UPDATE 를 멱등 처리합니다.

## Test plan
- [ ] Lv.9 그룹에서 EXP 가산해 Lv.10 도달 → `dikoJustUnlocked=true`, `dikoUnlocked=true`, 알림 1회 발송
- [ ] 같은 그룹에서 다음 EXP 가산 → `dikoJustUnlocked=false` (재발화 안 함)
- [ ] 이미 Lv.10+ 인 기존 그룹은 부팅 후 `diko_unlocked=true` 로 backfill 됐는지 확인
- [ ] 텍스트 퀴즈(이미지 없음) 생성/응시 정상 동작
- [ ] 이미지 퀴즈 생성: 업로드 → `imageUrl` 전달 → 응답 / 응시 응답에 `imageUrl` 포함
- [ ] `./gradlew ktlintFormat` / `compileKotlin` 성공