### PR TITLE
fix(quiz): 사진 퀴즈를 디코 해금 그룹에서만 허용

### DIFF
--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -67,6 +67,14 @@ class CharacterQuizServiceImpl(
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
         val normalizedImageUrl = request.imageUrl?.trim()?.ifEmpty { null }
+        // 사진 퀴즈는 디코가 등장한 그룹에서만 등록할 수 있다. 디코는 모찌의 사진 퀴즈
+        // 메이트 컨셉이라, 디코 없는 그룹은 텍스트 퀴즈만 운영하도록 게이트.
+        if (normalizedImageUrl != null) {
+            val character = groupCharacterRepository.findByGroupRoomId(request.groupRoomId)
+            if (character == null || !character.dikoUnlocked) {
+                throw DigdaException(ErrorCode.QUIZ_IMAGE_REQUIRES_DIKO)
+            }
+        }
         val quiz = quizRepository.save(
             CharacterQuiz(
                 groupRoom = groupRoom,
@@ -128,12 +136,25 @@ class CharacterQuizServiceImpl(
     @Transactional
     override fun pickRandom(userId: UUID, groupRoomId: Long): CharacterQuizResponse {
         validateGroupMember(groupRoomId, userId)
-        val candidates = quizRepository.findAvailableForUser(groupRoomId, userId)
+        // 디코가 없는 그룹은 사진 퀴즈를 후보에서 제외 — 사용자에게 풀 수 없는 문제를
+        // 띄우면 안 되므로 repository 레벨에서 차단.
+        val excludeImage = !isDikoUnlocked(groupRoomId)
+        val candidates = quizRepository.findAvailableForUser(groupRoomId, userId, excludeImage)
         if (candidates.isEmpty()) throw DigdaException(ErrorCode.QUIZ_NO_AVAILABLE)
         // DB 종속 RAND() 회피 — JPQL 로 후보 가져온 뒤 Kotlin random.
         val picked = candidates.random()
-        log.info("action=character_quiz_pick, userId={}, quizId={}, groupRoomId={}", userId, picked.id, groupRoomId)
+        log.info(
+            "action=character_quiz_pick, userId={}, quizId={}, groupRoomId={}, excludeImage={}",
+            userId,
+            picked.id,
+            groupRoomId,
+            excludeImage
+        )
         return CharacterQuizResponse.from(picked)
+    }
+
+    private fun isDikoUnlocked(groupRoomId: Long): Boolean {
+        return groupCharacterRepository.findByGroupRoomId(groupRoomId)?.dikoUnlocked == true
     }
 
     @Transactional
@@ -151,6 +172,11 @@ class CharacterQuizServiceImpl(
 
         if (quiz.author.id == userId) throw DigdaException(ErrorCode.QUIZ_CANNOT_ATTEMPT_OWN)
         validateGroupMember(quiz.groupRoom.id, userId)
+
+        // 사진 퀴즈는 디코가 풀린 그룹에서만 응시 가능. URL 우회 방어용.
+        if (quiz.imageUrl != null && !isDikoUnlocked(quiz.groupRoom.id)) {
+            throw DigdaException(ErrorCode.QUIZ_IMAGE_REQUIRES_DIKO)
+        }
 
         if (attemptRepository.existsByQuizIdAndUserId(quizId, userId)) {
             throw DigdaException(ErrorCode.QUIZ_ALREADY_ATTEMPTED)

--- a/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizRepository.kt
@@ -28,12 +28,16 @@ interface CharacterQuizRepository : JpaRepository<CharacterQuiz, Long> {
      * 자기 작성이 아니고 + 아직 응시하지 않은 퀴즈 목록.
      * 랜덤 픽은 서비스 계층에서 결과 리스트에 대해 Kotlin random 으로 수행
      * (JPQL/DB 종속 RAND() 회피).
+     *
+     * [excludeImageQuiz]=true 면 imageUrl 이 있는 (사진) 퀴즈를 후보에서 제외 —
+     * 디코가 풀리지 않은 그룹에서 사진 퀴즈를 풀지 못하게 만들 때 사용한다.
      */
     @Query(
         """
         SELECT q FROM CharacterQuiz q
         WHERE q.groupRoom.id = :groupRoomId
           AND q.author.id <> :userId
+          AND (:excludeImageQuiz = false OR q.imageUrl IS NULL)
           AND NOT EXISTS (
             SELECT 1 FROM CharacterQuizAttempt a
             WHERE a.quiz = q AND a.user.id = :userId
@@ -42,6 +46,7 @@ interface CharacterQuizRepository : JpaRepository<CharacterQuiz, Long> {
     )
     fun findAvailableForUser(
         @Param("groupRoomId") groupRoomId: Long,
-        @Param("userId") userId: UUID
+        @Param("userId") userId: UUID,
+        @Param("excludeImageQuiz") excludeImageQuiz: Boolean
     ): List<CharacterQuiz>
 }

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -118,6 +118,7 @@ enum class ErrorCode(
     QUIZ_QUESTION_INVALID("QUIZ_QUESTION_INVALID", "문제는 1자 이상 200자 이하여야 합니다.", 400),
     QUIZ_INVALID_CORRECT_INDEX("QUIZ_INVALID_CORRECT_INDEX", "정답 번호는 1-4 사이여야 합니다.", 400),
     QUIZ_INVALID_MULTIPLIER("QUIZ_INVALID_MULTIPLIER", "EXP 배수는 1-3 사이여야 합니다.", 400),
+    QUIZ_IMAGE_REQUIRES_DIKO("QUIZ_IMAGE_REQUIRES_DIKO", "사진 퀴즈는 디코가 등장한 그룹에서만 사용할 수 있어요.", 400),
 
     // ── Rate Limit ──
     RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),


### PR DESCRIPTION
디코 없는 그룹에서도 사진 퀴즈가 풀리던 버그 수정. ErrorCode 추가, 만들기/풀기/랜덤 후보 모두 차단.