### PR TITLE
feat(admin): 모찌·알림 관리 모듈 + 퀴즈 createdAt 노출

### DIFF
--- a/src/main/kotlin/digdaserver/admin/character/application/service/AdminCharacterService.kt
+++ b/src/main/kotlin/digdaserver/admin/character/application/service/AdminCharacterService.kt
@@ -1,0 +1,19 @@
+package digdaserver.admin.character.application.service
+
+import digdaserver.admin.character.presentation.dto.req.AdminUpdateCharacterRequest
+import digdaserver.admin.character.presentation.dto.res.AdminCharacterResponse
+import digdaserver.admin.common.dto.res.AdminPageResponse
+
+interface AdminCharacterService {
+
+    fun search(
+        keyword: String?,
+        includeDeletedGroups: Boolean,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminCharacterResponse>
+
+    fun getDetail(groupRoomId: Long): AdminCharacterResponse
+
+    fun update(groupRoomId: Long, request: AdminUpdateCharacterRequest): AdminCharacterResponse
+}

--- a/src/main/kotlin/digdaserver/admin/character/application/service/impl/AdminCharacterServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/character/application/service/impl/AdminCharacterServiceImpl.kt
@@ -1,0 +1,84 @@
+package digdaserver.admin.character.application.service.impl
+
+import digdaserver.admin.character.application.service.AdminCharacterService
+import digdaserver.admin.character.presentation.dto.req.AdminUpdateCharacterRequest
+import digdaserver.admin.character.presentation.dto.res.AdminCharacterResponse
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.domain.character.application.level.CharacterLevelTable
+import digdaserver.domain.character.domain.repository.GroupCharacterRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminCharacterServiceImpl(
+    private val groupCharacterRepository: GroupCharacterRepository
+) : AdminCharacterService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun search(
+        keyword: String?,
+        includeDeletedGroups: Boolean,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminCharacterResponse> {
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, 100)
+        val pageable = PageRequest.of(
+            safePage,
+            safeSize,
+            Sort.by(Sort.Direction.DESC, "updatedAt")
+        )
+        val result = groupCharacterRepository.searchForAdmin(
+            keyword?.takeIf { it.isNotBlank() },
+            includeDeletedGroups,
+            pageable
+        )
+        return AdminPageResponse.of(result, AdminCharacterResponse::from)
+    }
+
+    override fun getDetail(groupRoomId: Long): AdminCharacterResponse {
+        val character = groupCharacterRepository.findByGroupRoomId(groupRoomId)
+            ?: throw DigdaException(ErrorCode.CHARACTER_NOT_FOUND)
+        return AdminCharacterResponse.from(character)
+    }
+
+    @Transactional
+    override fun update(
+        groupRoomId: Long,
+        request: AdminUpdateCharacterRequest
+    ): AdminCharacterResponse {
+        val character = groupCharacterRepository.findByGroupRoomId(groupRoomId)
+            ?: throw DigdaException(ErrorCode.CHARACTER_NOT_FOUND)
+
+        request.level?.let { newLevel ->
+            // DTO Validation 으로 1..20 보장. 그래도 컨트롤러 우회/시리얼라이저 우회 대비 방어.
+            val clamped = newLevel.coerceIn(1, CharacterLevelTable.MAX_LEVEL)
+            character.adminSetLevel(clamped)
+        }
+        request.coin?.let { newCoin ->
+            val safe = newCoin.coerceAtLeast(0)
+            character.adminSetCoin(safe)
+        }
+        request.dikoUnlocked?.let { unlocked ->
+            character.adminSetDikoUnlocked(unlocked)
+        }
+
+        log.info(
+            "action=admin_character_update, groupRoomId={}, level={}, coin={}, " +
+                "stage={}, dikoUnlocked={}",
+            groupRoomId,
+            character.level,
+            character.coin,
+            character.stage,
+            character.dikoUnlocked
+        )
+        return AdminCharacterResponse.from(character)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/character/presentation/controller/AdminCharacterController.kt
+++ b/src/main/kotlin/digdaserver/admin/character/presentation/controller/AdminCharacterController.kt
@@ -1,0 +1,80 @@
+package digdaserver.admin.character.presentation.controller
+
+import digdaserver.admin.character.application.service.AdminCharacterService
+import digdaserver.admin.character.presentation.dto.req.AdminUpdateCharacterRequest
+import digdaserver.admin.character.presentation.dto.res.AdminCharacterResponse
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 어드민 모찌(GroupCharacter) 관리.
+ *
+ * 그룹방 1:1 캐릭터라 검색·상세 모두 `groupRoomId` 기준으로 다룬다 (캐릭터 PK 가 아닌).
+ * 어드민 입력값(레벨/코인/디코)은 서비스 계층에서 자동 정합 처리하므로 컨트롤러는 단순 위임.
+ */
+@RestController
+@RequestMapping("/api/admin/characters")
+@Tag(name = "Admin - Character", description = "관리자 모찌(그룹 캐릭터) 관리 API")
+class AdminCharacterController(
+    private val adminCharacterService: AdminCharacterService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(summary = "모찌 목록 조회", description = "키워드(그룹방 이름/방장 이름), 삭제 포함 여부, 페이지네이션")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "false") includeDeletedGroups: Boolean,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminCharacterResponse>> {
+        log.info(
+            "api=GET /api/admin/characters, keyword={}, includeDeletedGroups={}, page={}",
+            keyword,
+            includeDeletedGroups,
+            page
+        )
+        return ResponseEntity.ok(
+            adminCharacterService.search(keyword, includeDeletedGroups, page, size)
+        )
+    }
+
+    @Operation(summary = "모찌 상세 조회 (그룹방 ID 기준)")
+    @GetMapping("/{groupRoomId}")
+    fun getDetail(@PathVariable groupRoomId: Long): ResponseEntity<AdminCharacterResponse> {
+        return ResponseEntity.ok(adminCharacterService.getDetail(groupRoomId))
+    }
+
+    @Operation(
+        summary = "모찌 정보 수정 (레벨/코인/디코)",
+        description = "전송된 필드만 수정. 레벨 변경 시 stage·exp 자동 정합 + Lv.10 도달 시 디코 자동 해금."
+    )
+    @PatchMapping("/{groupRoomId}")
+    fun update(
+        @PathVariable groupRoomId: Long,
+        @Valid
+        @RequestBody
+        request: AdminUpdateCharacterRequest
+    ): ResponseEntity<AdminCharacterResponse> {
+        log.info(
+            "api=PATCH /api/admin/characters/{}, level={}, coin={}, dikoUnlocked={}",
+            groupRoomId,
+            request.level,
+            request.coin,
+            request.dikoUnlocked
+        )
+        return ResponseEntity.ok(adminCharacterService.update(groupRoomId, request))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/character/presentation/dto/req/AdminUpdateCharacterRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/character/presentation/dto/req/AdminUpdateCharacterRequest.kt
@@ -1,0 +1,30 @@
+package digdaserver.admin.character.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+/**
+ * 어드민 모찌 정보 수정. 모든 필드는 선택 — null 이면 해당 항목은 변경하지 않음.
+ *
+ * - [level]: 1..MAX(20). 변경 시 서버가 stage·exp 를 자동으로 정합 상태로 맞춘다
+ *   (stage=CharacterStage.forLevel, exp 는 새 임계치 미만이면 그대로 두고 초과면 0).
+ * - [coin]: 0.. 절대값. (delta 가 아닌 절대값 set 으로 단순화 — 어드민 수동 보정 용도.)
+ * - [dikoUnlocked]: 디코 해금 강제 토글. null 이면 변경 없음. 단, level>=10 이면 항상
+ *   자동으로 true 가 유지되므로, false 로 내려도 다음 레벨업 시 자동 복구.
+ */
+@Schema(description = "어드민용 모찌 정보 수정 요청")
+data class AdminUpdateCharacterRequest(
+
+    @field:Min(1)
+    @field:Max(20)
+    @Schema(description = "변경할 레벨(1-20). 미전송 시 변경 없음.", example = "10")
+    val level: Int? = null,
+
+    @field:Min(0)
+    @Schema(description = "변경할 코인 잔액 (절대값). 미전송 시 변경 없음.", example = "100")
+    val coin: Int? = null,
+
+    @Schema(description = "디코 해금 여부 강제 변경. 미전송 시 변경 없음.")
+    val dikoUnlocked: Boolean? = null
+)

--- a/src/main/kotlin/digdaserver/admin/character/presentation/dto/res/AdminCharacterResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/character/presentation/dto/res/AdminCharacterResponse.kt
@@ -1,0 +1,85 @@
+package digdaserver.admin.character.presentation.dto.res
+
+import digdaserver.domain.character.application.level.CharacterLevelTable
+import digdaserver.domain.character.domain.entity.CharacterStage
+import digdaserver.domain.character.domain.entity.GroupCharacter
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 어드민용 그룹 모찌 정보. 그룹방 컨텍스트(이름·삭제여부)와 캐릭터 본문(레벨·exp·코인·디코)
+ * 을 함께 노출해 어드민이 "어느 그룹의 모찌인지" 파악하기 쉽도록 했다.
+ *
+ * 응답에 다음 레벨까지의 임계치([expForNextLevel])를 함께 내려 어드민 진행률 바를 그릴 수 있다.
+ */
+@Schema(description = "어드민용 그룹 모찌 정보")
+data class AdminCharacterResponse(
+
+    @Schema(description = "캐릭터 PK")
+    val characterId: Long,
+
+    @Schema(description = "그룹방 ID")
+    val groupRoomId: Long,
+
+    @Schema(description = "그룹방 이름")
+    val groupRoomName: String,
+
+    @Schema(description = "방장 이름")
+    val ownerName: String,
+
+    @Schema(description = "그룹방 삭제 시각 (null = 활성)")
+    val groupRoomDeletedAt: LocalDateTime?,
+
+    @Schema(description = "현재 진화 단계")
+    val stage: CharacterStage,
+
+    @Schema(description = "현재 진화 단계 표시명")
+    val stageDisplayName: String,
+
+    @Schema(description = "현재 레벨")
+    val level: Int,
+
+    @Schema(description = "현재 누적 EXP (현재 레벨 내)")
+    val exp: Int,
+
+    @Schema(description = "다음 레벨까지 필요한 EXP. maxLevel 도달 시 0")
+    val expForNextLevel: Int,
+
+    @Schema(description = "보유 코인")
+    val coin: Int,
+
+    @Schema(description = "MAX 레벨 도달 여부")
+    val maxLevelReached: Boolean,
+
+    @Schema(description = "디코 해금 여부")
+    val dikoUnlocked: Boolean,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정 시각")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(character: GroupCharacter): AdminCharacterResponse {
+            val atMax = character.level >= CharacterLevelTable.MAX_LEVEL
+            return AdminCharacterResponse(
+                characterId = character.id,
+                groupRoomId = character.groupRoom.id,
+                groupRoomName = character.groupRoom.name,
+                ownerName = character.groupRoom.owner.name,
+                groupRoomDeletedAt = character.groupRoom.deletedAt,
+                stage = character.stage,
+                stageDisplayName = character.stage.displayName,
+                level = character.level,
+                exp = character.exp,
+                expForNextLevel = if (atMax) 0 else CharacterLevelTable.expForNextLevel(character.level),
+                coin = character.coin,
+                maxLevelReached = atMax,
+                dikoUnlocked = character.dikoUnlocked,
+                createdAt = character.createdAt,
+                updatedAt = character.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/notification/application/service/AdminNotificationService.kt
+++ b/src/main/kotlin/digdaserver/admin/notification/application/service/AdminNotificationService.kt
@@ -1,0 +1,16 @@
+package digdaserver.admin.notification.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.notification.presentation.dto.res.AdminNotificationResponse
+import digdaserver.domain.notification.domain.entity.NotificationType
+
+interface AdminNotificationService {
+
+    fun search(
+        types: Set<NotificationType>?,
+        groupRoomId: Long?,
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminNotificationResponse>
+}

--- a/src/main/kotlin/digdaserver/admin/notification/application/service/impl/AdminNotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/notification/application/service/impl/AdminNotificationServiceImpl.kt
@@ -1,0 +1,42 @@
+package digdaserver.admin.notification.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.notification.application.service.AdminNotificationService
+import digdaserver.admin.notification.presentation.dto.res.AdminNotificationResponse
+import digdaserver.domain.notification.domain.entity.NotificationType
+import digdaserver.domain.notification.domain.repository.NotificationRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminNotificationServiceImpl(
+    private val notificationRepository: NotificationRepository
+) : AdminNotificationService {
+
+    override fun search(
+        types: Set<NotificationType>?,
+        groupRoomId: Long?,
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminNotificationResponse> {
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, 100)
+        val pageable = PageRequest.of(
+            safePage,
+            safeSize,
+            Sort.by(Sort.Direction.DESC, "createdAt")
+        )
+        val safeTypes = types?.takeIf { it.isNotEmpty() }
+        val result = notificationRepository.searchForAdmin(
+            safeTypes,
+            groupRoomId,
+            keyword?.takeIf { it.isNotBlank() },
+            pageable
+        )
+        return AdminPageResponse.of(result, AdminNotificationResponse::from)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/notification/presentation/controller/AdminNotificationController.kt
+++ b/src/main/kotlin/digdaserver/admin/notification/presentation/controller/AdminNotificationController.kt
@@ -1,0 +1,64 @@
+package digdaserver.admin.notification.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.notification.application.service.AdminNotificationService
+import digdaserver.admin.notification.presentation.dto.res.AdminNotificationResponse
+import digdaserver.domain.notification.domain.entity.NotificationType
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 어드민용 알림 조회. 사용자별 알림 row 를 그대로 노출하므로 동일 이벤트가 그룹원 N명에게
+ * 전달된 경우 N개 row 가 보인다 (raw 데이터 우선).
+ *
+ * 모찌 관련만 추리려면 type 필터로 `MOCHI_LEVELUP/DIKO_UNLOCKED/QUIZ_CREATED/QUIZ_ANSWERED`
+ * 를 함께 전달.
+ */
+@RestController
+@RequestMapping("/api/admin/notifications")
+@Tag(name = "Admin - Notification", description = "관리자 알림 조회 API")
+class AdminNotificationController(
+    private val adminNotificationService: AdminNotificationService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(
+        summary = "알림 목록 조회",
+        description = "type(쉼표 구분 문자열, 예: MOCHI_LEVELUP,DIKO_UNLOCKED), groupRoomId, keyword 필터 + 페이지네이션"
+    )
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) type: String?,
+        @RequestParam(required = false) groupRoomId: Long?,
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminNotificationResponse>> {
+        val types: Set<NotificationType>? = type
+            ?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            ?.mapNotNull {
+                runCatching { NotificationType.valueOf(it.uppercase()) }.getOrNull()
+            }
+            ?.toSet()
+            ?.takeIf { it.isNotEmpty() }
+        log.info(
+            "api=GET /api/admin/notifications, types={}, groupRoomId={}, keyword={}, page={}",
+            types,
+            groupRoomId,
+            keyword,
+            page
+        )
+        return ResponseEntity.ok(
+            adminNotificationService.search(types, groupRoomId, keyword, page, size)
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/notification/presentation/dto/res/AdminNotificationResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/notification/presentation/dto/res/AdminNotificationResponse.kt
@@ -1,0 +1,64 @@
+package digdaserver.admin.notification.presentation.dto.res
+
+import digdaserver.domain.notification.domain.entity.Notification
+import digdaserver.domain.notification.domain.entity.NotificationType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 알림 행")
+data class AdminNotificationResponse(
+
+    @Schema(description = "알림 ID")
+    val notificationId: Long,
+
+    @Schema(description = "수신자 사용자 ID(UUID)")
+    val recipientUserId: String,
+
+    @Schema(description = "수신자 이름")
+    val recipientName: String,
+
+    @Schema(description = "알림 타입")
+    val type: NotificationType,
+
+    @Schema(description = "제목")
+    val title: String,
+
+    @Schema(description = "본문")
+    val message: String,
+
+    @Schema(description = "관련 그룹방 ID")
+    val groupRoomId: Long?,
+
+    @Schema(description = "관련 그룹방 이름")
+    val groupRoomName: String?,
+
+    @Schema(description = "관련 엔티티 ID")
+    val relatedId: Long?,
+
+    @Schema(description = "관련 엔티티 타입")
+    val relatedType: String?,
+
+    @Schema(description = "읽음 여부")
+    val isRead: Boolean,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(notification: Notification): AdminNotificationResponse =
+            AdminNotificationResponse(
+                notificationId = notification.id,
+                recipientUserId = notification.user.id.toString(),
+                recipientName = notification.user.name,
+                type = notification.type,
+                title = notification.title,
+                message = notification.message,
+                groupRoomId = notification.groupRoomId,
+                groupRoomName = notification.groupRoomName,
+                relatedId = notification.relatedId,
+                relatedType = notification.relatedType,
+                isRead = notification.isRead,
+                createdAt = notification.createdAt
+            )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
@@ -128,6 +128,43 @@ class GroupCharacter(
         coin -= amount
     }
 
+    /**
+     * 어드민 보정용. 호출자(서비스 계층)가 권한·범위 검증을 끝낸 뒤에만 호출할 것.
+     *
+     * - [newLevel]: 1..MAX_LEVEL 사이로 호출자가 clamp 해 넘겨준다. 본 함수는 추가 검증
+     *   없이 적용하고, [stage] 와 [exp] 를 새 레벨에 맞춰 자동 정합.
+     *   - stage: [CharacterStage.forLevel] 로 갱신
+     *   - exp: 새 레벨의 다음 임계치 미만이면 그대로 유지, 초과/MAX 도달 시 0 으로 clamp
+     * - [DIKO_UNLOCK_LEVEL] 이상으로 올렸다면 [dikoUnlocked] 도 자동으로 true 로 set.
+     *
+     * 일반 게임 플로우에서는 [gainExp] 만 사용하고 이 메서드는 호출하지 말 것.
+     */
+    fun adminSetLevel(newLevel: Int) {
+        require(newLevel in 1..CharacterLevelTable.MAX_LEVEL) {
+            "level out of range: $newLevel"
+        }
+        level = newLevel
+        stage = CharacterStage.forLevel(level)
+        if (level >= CharacterLevelTable.MAX_LEVEL) {
+            exp = 0
+        } else {
+            val nextThreshold = CharacterLevelTable.expForNextLevel(level)
+            if (exp >= nextThreshold) exp = 0
+        }
+        if (level >= DIKO_UNLOCK_LEVEL) dikoUnlocked = true
+    }
+
+    /** 어드민 보정 — 코인 절대값 set. 호출자에서 비음수 검증. */
+    fun adminSetCoin(newCoin: Int) {
+        require(newCoin >= 0) { "coin must be non-negative" }
+        coin = newCoin
+    }
+
+    /** 어드민 보정 — 디코 해금 플래그 강제 set. level<10 인 상태로 true 만들 수도 있음 (테스트용). */
+    fun adminSetDikoUnlocked(unlocked: Boolean) {
+        dikoUnlocked = unlocked
+    }
+
     data class GainResult(
         val levelGained: Int,
         val stageBefore: CharacterStage,

--- a/src/main/kotlin/digdaserver/domain/character/domain/repository/GroupCharacterRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/repository/GroupCharacterRepository.kt
@@ -1,10 +1,35 @@
 package digdaserver.domain.character.domain.repository
 
 import digdaserver.domain.character.domain.entity.GroupCharacter
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface GroupCharacterRepository : JpaRepository<GroupCharacter, Long> {
     fun findByGroupRoomId(groupRoomId: Long): GroupCharacter?
+
+    /**
+     * 어드민 페이지네이션 검색.
+     * - [keyword]: 그룹방 이름 또는 방장 이름 LIKE (대소문자 무시, null/빈 = 무필터)
+     * - [includeDeletedGroups]: false 면 deletedAt IS NULL 인 그룹방만
+     */
+    @Query(
+        """
+        SELECT c FROM GroupCharacter c
+        JOIN c.groupRoom g
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(g.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(g.owner.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+          AND (:includeDeletedGroups = true OR g.deletedAt IS NULL)
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        @Param("includeDeletedGroups") includeDeletedGroups: Boolean,
+        pageable: Pageable
+    ): Page<GroupCharacter>
 }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -2,10 +2,13 @@ package digdaserver.domain.character.presentation.dto.res
 
 import digdaserver.domain.character.domain.entity.CharacterQuiz
 import digdaserver.domain.character.domain.entity.QuizCategory
+import java.time.LocalDateTime
 
 /**
  * 퀴즈 1건. 응시 화면에서 사용되며, 정답 인덱스는 응답에 포함하지 않는다 (응시 전 노출 방지).
  * 정답 확인은 응시 결과 응답([QuizAttemptResultResponse]) 에서만 노출.
+ *
+ * [createdAt] 은 클라이언트가 퀴즈 목록을 날짜별로 그룹화할 수 있도록 함께 내려준다.
  */
 data class CharacterQuizResponse(
     val id: Long,
@@ -16,7 +19,8 @@ data class CharacterQuizResponse(
     val options: List<String>,
     val expMultiplier: Int,
     val authorName: String,
-    val imageUrl: String?
+    val imageUrl: String?,
+    val createdAt: LocalDateTime
 ) {
     companion object {
         fun from(quiz: CharacterQuiz): CharacterQuizResponse {
@@ -29,7 +33,8 @@ data class CharacterQuizResponse(
                 options = quiz.options(),
                 expMultiplier = quiz.expMultiplier,
                 authorName = quiz.author.name,
-                imageUrl = quiz.imageUrl
+                imageUrl = quiz.imageUrl,
+                createdAt = quiz.createdAt
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
@@ -28,4 +28,32 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.user.id = :userId")
     fun deleteAllByUserId(@Param("userId") userId: UUID)
+
+    /**
+     * 어드민 전체 알림 검색.
+     *
+     * - [types]: null/빈 리스트 = 전체. 모찌 관련 알림만 보고 싶을 때 호출 측에서
+     *   `[MOCHI_LEVELUP, DIKO_UNLOCKED, QUIZ_CREATED, QUIZ_ANSWERED]` 같이 전달.
+     * - [groupRoomId]: null = 전체 그룹.
+     * - [keyword]: 제목/본문 LIKE.
+     *
+     * 사용자별로 같은 이벤트가 여러 행으로 저장되는 점은 admin 화면에서 그대로 노출한다
+     * (어드민은 raw 데이터를 봐야 의미가 있음).
+     */
+    @Query(
+        """
+        SELECT n FROM Notification n
+        WHERE (:types IS NULL OR n.type IN :types)
+          AND (:groupRoomId IS NULL OR n.groupRoomId = :groupRoomId)
+          AND (:keyword IS NULL OR :keyword = ''
+              OR LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+              OR LOWER(n.message) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchForAdmin(
+        @Param("types") types: Collection<NotificationType>?,
+        @Param("groupRoomId") groupRoomId: Long?,
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<Notification>
 }


### PR DESCRIPTION
어드민에서 그룹 모찌 직접 보정 + 모찌 관련 알림 조회 + 퀴즈 응답에 createdAt 추가.