### PR TITLE
feat(character): 일기 EXP·진화 시험·남은 퀴즈 수·상점 확장·날짜 KST

### DIFF
--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -144,13 +144,15 @@ class CharacterQuizServiceImpl(
         // DB 종속 RAND() 회피 — JPQL 로 후보 가져온 뒤 Kotlin random.
         val picked = candidates.random()
         log.info(
-            "action=character_quiz_pick, userId={}, quizId={}, groupRoomId={}, excludeImage={}",
+            "action=character_quiz_pick, userId={}, quizId={}, groupRoomId={}, excludeImage={}, remaining={}",
             userId,
             picked.id,
             groupRoomId,
-            excludeImage
+            excludeImage,
+            candidates.size
         )
-        return CharacterQuizResponse.from(picked)
+        // 현재 문제를 포함해 지금 풀 수 있는 남은 퀴즈 수.
+        return CharacterQuizResponse.from(picked, remainingCount = candidates.size)
     }
 
     private fun isDikoUnlocked(groupRoomId: Long): Boolean {

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterServiceImpl.kt
@@ -114,7 +114,9 @@ class CharacterServiceImpl(
         validateGroupMember(groupRoomId, userId)
         val character = loadOrCreate(groupRoomId)
 
-        if (character.stage != CharacterStage.MASTER) {
+        // 레벨 20(MAX) 부터 챔피언 챌린지를 응시할 수 있다. 마스터 진화 전(GLOW)에는
+        // 이 게임이 "진화 시험" 으로, 진화 후(MASTER)에는 코인 파밍 콘텐츠로 동작한다.
+        if (!character.isMaxLevel()) {
             throw DigdaException(ErrorCode.NOT_MASTER_CHARACTER)
         }
         if (character.coin < MASTER_GAME_ENTRY_FEE) {
@@ -146,7 +148,7 @@ class CharacterServiceImpl(
         validateGroupMember(groupRoomId, userId)
         val character = loadOrCreate(groupRoomId)
 
-        if (character.stage != CharacterStage.MASTER) {
+        if (!character.isMaxLevel()) {
             throw DigdaException(ErrorCode.NOT_MASTER_CHARACTER)
         }
 
@@ -154,22 +156,51 @@ class CharacterServiceImpl(
         val tier = tierForScore(score)
         if (coinReward > 0) character.addCoin(coinReward)
 
+        // 진화 시험: 아직 마스터가 아니고 "훌륭" 이상(score>=MASTER_EVOLVE_MIN_SCORE) 이면
+        // 이번 도전으로 마스터 진화. 이미 마스터면 코인만 적립.
+        val evolvedToMaster =
+            if (!character.masterUnlocked && score >= MASTER_EVOLVE_MIN_SCORE) {
+                character.evolveToMaster()
+            } else {
+                false
+            }
+
         log.info(
             "action=character_master_game_reward, userId={}, groupRoomId={}, score={}, " +
-                "tier={}, coinReward={}, balanceAfter={}",
+                "tier={}, coinReward={}, evolvedToMaster={}, balanceAfter={}",
             userId,
             groupRoomId,
             score,
             tier,
             coinReward,
+            evolvedToMaster,
             character.coin
         )
+
+        if (evolvedToMaster) {
+            try {
+                notificationService.notifyMochiLevelUp(
+                    groupRoomId = groupRoomId,
+                    actorUserId = userId,
+                    newLevel = character.level,
+                    stageChanged = true,
+                    stageName = CharacterStage.MASTER.displayName
+                )
+            } catch (e: Exception) {
+                log.warn(
+                    "action=character_master_evolve_notify_failed, groupRoomId={}, error={}",
+                    groupRoomId,
+                    e.message
+                )
+            }
+        }
 
         val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(groupRoomId)
         return MasterGameRewardResponse(
             score = score,
             coinReward = coinReward,
             tier = tier,
+            evolvedToMaster = evolvedToMaster,
             character = CharacterStateResponse.from(character, equipped)
         )
     }
@@ -223,6 +254,9 @@ class CharacterServiceImpl(
 
         /** 마스터 게임 입장료 (코인). */
         private const val MASTER_GAME_ENTRY_FEE = 20
+
+        /** 마스터 진화 시험 통과 최소 점수 — "훌륭"(11점) 이상. */
+        private const val MASTER_EVOLVE_MIN_SCORE = 11
     }
 
     private fun loadOrCreate(groupRoomId: Long): GroupCharacter {

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
@@ -61,9 +61,47 @@ class GroupCharacter(
     var coin: Int = 0,
 
     @Column(name = "diko_unlocked", nullable = false)
-    var dikoUnlocked: Boolean = false
+    var dikoUnlocked: Boolean = false,
+
+    /**
+     * 마스터 진화 시험(챔피언 챌린지) 통과 여부.
+     *
+     * 레벨 20(MAX) 에 도달해도 이 플래그가 false 면 단계는 [CharacterStage.GLOW] 에 머문다.
+     * 챔피언 챌린지에서 "훌륭" 이상 등급을 받았을 때만 [evolveToMaster] 로 true 가 되고
+     * 그 시점에 비로소 [CharacterStage.MASTER] 로 진화한다.
+     */
+    @Column(name = "master_unlocked", nullable = false)
+    var masterUnlocked: Boolean = false
 
 ) : BaseTimeEntity() {
+
+    /**
+     * 현재 레벨/마스터해금 상태에서 도달 가능한 단계.
+     * 레벨상 MASTER 이지만 아직 진화 시험을 통과하지 않았으면 GLOW 로 묶어둔다.
+     */
+    private fun resolveStage(): CharacterStage {
+        val natural = CharacterStage.forLevel(level)
+        return if (natural == CharacterStage.MASTER && !masterUnlocked) {
+            CharacterStage.GLOW
+        } else {
+            natural
+        }
+    }
+
+    /** 레벨상 최고 단계(20)에 도달했는지 — 챔피언 챌린지(진화 시험) 응시 가능 여부. */
+    fun isMaxLevel(): Boolean = level >= CharacterLevelTable.MAX_LEVEL
+
+    /**
+     * 챔피언 챌린지 "훌륭" 이상 통과 시 호출 — 마스터로 진화시킨다.
+     * 레벨 20 미만이거나 이미 마스터면 아무 일도 하지 않고 false 를 반환한다.
+     */
+    fun evolveToMaster(): Boolean {
+        if (level < CharacterLevelTable.MAX_LEVEL) return false
+        if (masterUnlocked) return false
+        masterUnlocked = true
+        stage = CharacterStage.MASTER
+        return true
+    }
 
     /**
      * 경험치 가산 후 레벨/스테이지를 갱신. 한 번의 호출로 여러 레벨 점프가 가능하다
@@ -99,7 +137,9 @@ class GroupCharacter(
             }
         }
         exp = remaining
-        stage = CharacterStage.forLevel(level)
+        // 레벨 20 도달만으로는 MASTER 로 진화하지 않는다 — 진화 시험(evolveToMaster) 전까지
+        // GLOW 에 머문다.
+        stage = resolveStage()
 
         val dikoJustUnlocked = if (!dikoWasUnlocked && level >= DIKO_UNLOCK_LEVEL) {
             dikoUnlocked = true
@@ -144,7 +184,9 @@ class GroupCharacter(
             "level out of range: $newLevel"
         }
         level = newLevel
-        stage = CharacterStage.forLevel(level)
+        // 어드민이 MAX 로 올리는 것은 진화 시험 통과로 간주해 마스터까지 풀어준다(운영 보정 편의).
+        if (level >= CharacterLevelTable.MAX_LEVEL) masterUnlocked = true
+        stage = resolveStage()
         if (level >= CharacterLevelTable.MAX_LEVEL) {
             exp = 0
         } else {

--- a/src/main/kotlin/digdaserver/domain/character/infra/ShopItemSeeder.kt
+++ b/src/main/kotlin/digdaserver/domain/character/infra/ShopItemSeeder.kt
@@ -106,21 +106,39 @@ class ShopItemSeeder(
                 sortOrder = 20,
                 isDefault = false
             ),
+            // 신규 스킨 — 산뜻한 민트 톤. 배경 squircle 색만 바뀌므로 별도 아트워크 불필요.
+            ItemDef(
+                itemKey = "skin_mint",
+                itemType = ShopItemType.SKIN,
+                displayName = "민트 모찌",
+                description = "산뜻한 민트 톤의 모찌",
+                cost = 250,
+                assetKey = "skin/mint",
+                accentColor = "#5AD0B8",
+                layerOrder = 0,
+                sortOrder = 30,
+                isDefault = false
+            ),
             // ─── GLASSES ────────────────────────────────────────────
             ItemDef("glasses_round", ShopItemType.GLASSES, "동그란 안경", "클래식한 동글이 안경", 100, "item/glasses_round", null, 50, 10, false),
             ItemDef("glasses_heart", ShopItemType.GLASSES, "하트 선글라스", "하트 모양 선글라스", 150, "item/glasses_heart", null, 50, 20, false),
+            ItemDef("glasses_sun", ShopItemType.GLASSES, "선글라스", "멋쟁이 검정 선글라스", 130, "item/glasses_sun", null, 50, 30, false),
             // ─── HAIRPIN ────────────────────────────────────────────
             ItemDef("hairpin_star", ShopItemType.HAIRPIN, "별 머리핀", "반짝이는 별 머리핀", 60, "item/hairpin_star", null, 30, 10, false),
             ItemDef("hairpin_ribbon", ShopItemType.HAIRPIN, "리본 머리핀", "귀여운 리본 머리핀", 80, "item/hairpin_ribbon", null, 30, 20, false),
+            ItemDef("hairpin_flower", ShopItemType.HAIRPIN, "꽃 머리핀", "앙증맞은 꽃 머리핀", 90, "item/hairpin_flower", null, 30, 30, false),
             // ─── HAT ────────────────────────────────────────────────
             ItemDef("hat_party", ShopItemType.HAT, "파티 모자", "신나는 파티 모자", 80, "item/hat_party", null, 60, 10, false),
             ItemDef("hat_chef", ShopItemType.HAT, "요리사 모자", "하얀 요리사 모자", 150, "item/hat_chef", null, 60, 20, false),
             // ─── ACCESSORY ──────────────────────────────────────────
             ItemDef("accessory_bowtie", ShopItemType.ACCESSORY, "보타이", "깔끔한 보타이", 100, "item/bowtie", null, 20, 10, false),
             ItemDef("accessory_scarf", ShopItemType.ACCESSORY, "목도리", "따뜻한 목도리", 120, "item/scarf", null, 20, 20, false),
+            ItemDef("accessory_necklace", ShopItemType.ACCESSORY, "진주 목걸이", "반짝이는 진주 목걸이", 140, "item/necklace", null, 20, 30, false),
             // ─── MISC ───────────────────────────────────────────────
             ItemDef("misc_balloon", ShopItemType.MISC, "풍선", "함께 떠다니는 풍선", 80, "item/balloon", null, 5, 10, false),
-            ItemDef("misc_flower", ShopItemType.MISC, "꽃 한송이", "곁에 둔 꽃 한송이", 60, "item/flower", null, 5, 20, false)
+            ItemDef("misc_flower", ShopItemType.MISC, "꽃 한송이", "곁에 둔 꽃 한송이", 60, "item/flower", null, 5, 20, false),
+            ItemDef("misc_star", ShopItemType.MISC, "반짝 별", "곁에서 반짝이는 별", 70, "item/star", null, 5, 30, false),
+            ItemDef("misc_heart_balloon", ShopItemType.MISC, "하트 풍선", "두둥실 떠다니는 하트 풍선", 90, "item/balloon_heart", null, 5, 40, false)
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -9,6 +9,9 @@ import java.time.LocalDateTime
  * 정답 확인은 응시 결과 응답([QuizAttemptResultResponse]) 에서만 노출.
  *
  * [createdAt] 은 클라이언트가 퀴즈 목록을 날짜별로 그룹화할 수 있도록 함께 내려준다.
+ *
+ * [remainingCount] 는 퀴즈 풀기 화면(pickRandom) 에서만 채워지는 "지금 풀 수 있는 남은
+ * 퀴즈 수"(현재 문제 포함). 목록/생성 응답에서는 null.
  */
 data class CharacterQuizResponse(
     val id: Long,
@@ -20,10 +23,11 @@ data class CharacterQuizResponse(
     val expMultiplier: Int,
     val authorName: String,
     val imageUrl: String?,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    val remainingCount: Int? = null
 ) {
     companion object {
-        fun from(quiz: CharacterQuiz): CharacterQuizResponse {
+        fun from(quiz: CharacterQuiz, remainingCount: Int? = null): CharacterQuizResponse {
             return CharacterQuizResponse(
                 id = quiz.id,
                 groupRoomId = quiz.groupRoom.id,
@@ -34,7 +38,8 @@ data class CharacterQuizResponse(
                 expMultiplier = quiz.expMultiplier,
                 authorName = quiz.author.name,
                 imageUrl = quiz.imageUrl,
-                createdAt = quiz.createdAt
+                createdAt = quiz.createdAt,
+                remainingCount = remainingCount
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterStateResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterStateResponse.kt
@@ -21,6 +21,10 @@ data class CharacterStateResponse(
     val coin: Int,
     val maxLevelReached: Boolean,
     val dikoUnlocked: Boolean,
+    /** 마스터 진화 시험(챔피언 챌린지) 통과 여부. true 면 stage 가 MASTER. */
+    val masterUnlocked: Boolean,
+    /** 레벨 20 도달 — 챔피언 챌린지(진화 시험/코인 파밍) 응시 가능 여부. */
+    val canChallengeMaster: Boolean,
     val equippedItems: List<EquippedItemResponse>
 ) {
     companion object {
@@ -39,6 +43,8 @@ data class CharacterStateResponse(
                 coin = character.coin,
                 maxLevelReached = atMax,
                 dikoUnlocked = character.dikoUnlocked,
+                masterUnlocked = character.masterUnlocked,
+                canChallengeMaster = atMax,
                 equippedItems = equipped
                     .sortedBy { it.shopItem.layerOrder }
                     .map(EquippedItemResponse::from)

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/MasterGameRewardResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/MasterGameRewardResponse.kt
@@ -6,11 +6,13 @@ package digdaserver.domain.character.presentation.dto.res
  * - [score]: 클라가 보낸 점수 (서버는 음수만 0 으로 클램프)
  * - [coinReward]: 점수 등급에 따라 그룹 캐릭터에 가산된 코인량
  * - [tier]: 등급 라벨 (도전/우수/훌륭/전설)
- * - [character]: 코인이 반영된 갱신 캐릭터 상태
+ * - [evolvedToMaster]: 이번 도전(훌륭 이상)으로 마스터 진화가 일어났는지. 클라 진화 연출용.
+ * - [character]: 코인/진화가 반영된 갱신 캐릭터 상태
  */
 data class MasterGameRewardResponse(
     val score: Int,
     val coinReward: Int,
     val tier: String,
+    val evolvedToMaster: Boolean,
     val character: CharacterStateResponse
 )

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -1,5 +1,6 @@
 package digdaserver.domain.diary.application.service.impl
 
+import digdaserver.domain.character.application.service.CharacterService
 import digdaserver.domain.comment.domain.entity.CommentTargetType
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.diary.application.service.DiaryService
@@ -32,12 +33,14 @@ import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZoneId
 import java.util.UUID
 
 @Service
@@ -52,14 +55,27 @@ class DiaryServiceImpl(
     private val userActionLogService: UserActionLogService,
     private val uploadedImageRepository: UploadedImageRepository,
     private val diaryLikeRepository: DiaryLikeRepository,
-    private val diaryReactionRepository: DiaryReactionRepository
+    private val diaryReactionRepository: DiaryReactionRepository,
+    @Lazy private val characterService: CharacterService
 ) : DiaryService {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
         private const val MAX_IMAGES_PER_DIARY = 10
+
+        /**
+         * 날짜 판정 기준 타임존. 서버 기본 TZ 가 UTC 이면 KST 00~09 시 사이에 한국 사용자의
+         * "오늘" 이 서버의 UTC "오늘" 보다 하루 앞서 미래로 오판될 수 있어, 한국 기준으로 고정한다.
+         */
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+
+        /** 일기 1건 작성 시 모찌에게 지급하는 경험치. */
+        private const val DIARY_WRITE_EXP = 20
     }
+
+    /** 날짜 미래 여부 판정에 쓰는 "오늘"(한국 기준). */
+    private fun todayKst(): LocalDate = LocalDate.now(KST)
 
     override fun getDiaries(
         userId: UUID,
@@ -153,7 +169,7 @@ class DiaryServiceImpl(
         membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
-        if (request.date.isAfter(LocalDate.now())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
+        if (request.date.isAfter(todayKst())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
         validateWeather(request.weather)
         validateMood(request.mood)
         validateImageCount(request.imageIds.size)
@@ -188,6 +204,16 @@ class DiaryServiceImpl(
             detail = "groupRoomId=$groupRoomId, title=${saved.title}, images=${resolvedUrls.size}"
         )
 
+        // 일기 작성 보상 — 모찌 경험치 지급. 그룹 공용 캐릭터에 누적되며, 같은 트랜잭션으로
+        // 원자 처리한다(레벨업/진화 알림은 gainExp 내부에서 best-effort 로 처리됨).
+        characterService.gainExp(
+            userId = userId,
+            groupRoomId = groupRoomId,
+            amount = DIARY_WRITE_EXP,
+            coinDelta = 0,
+            source = "diary_write"
+        )
+
         return DiaryResponse.from(saved, likeCount = 0L, likedByMe = false, reactions = emptyList())
     }
 
@@ -214,7 +240,7 @@ class DiaryServiceImpl(
         }
 
         request.date?.let {
-            if (it.isAfter(LocalDate.now())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
+            if (it.isAfter(todayKst())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
         }
         request.weather?.let { validateWeather(it) }
         request.mood?.let { validateMood(it) }

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -68,6 +68,17 @@ class SchemaAutoMigration(
             table = "character_quiz",
             column = "image_url",
             addSql = "ALTER TABLE character_quiz ADD COLUMN image_url VARCHAR(2048) NULL"
+        ),
+        // 마스터 진화 시험 통과 여부. 기존에 이미 레벨 20 에 도달해 MASTER 로 보이던 그룹은
+        // 컬럼 추가 시 false 로 들어가 GLOW 로 후퇴하는 회귀가 생기므로, level>=20 인 행은
+        // 곧바로 true 로 backfill 해 마스터 상태를 보존한다.
+        MissingColumn(
+            table = "group_character",
+            column = "master_unlocked",
+            addSql = "ALTER TABLE group_character ADD COLUMN master_unlocked BIT(1) NOT NULL DEFAULT b'0'",
+            postSql = listOf(
+                "UPDATE group_character SET master_unlocked = b'1' WHERE level >= 20"
+            )
         )
     )
 


### PR DESCRIPTION
## 변경 (모찌 시스템)
- **일기 작성 EXP**: createDiary 시 모찌 EXP(20) 지급 (gainExp, 같은 트랜잭션)
- **일기 미래날짜 버그**: 판정을 `Asia/Seoul` 기준으로 보정 — UTC 서버에서 KST 00~09시에 "오늘"이 미래로 오판되던 문제 수정
- **진화 조건 변경**: 레벨20 도달만으로 MASTER 진화 금지. 챔피언 챌린지 "훌륭"(11점)+ 시 `evolveToMaster`로 진화. `group_character.master_unlocked` 컬럼 추가 + `level>=20` backfill
- **남은 퀴즈 수**: 퀴즈 풀기(pickRandom) 응답에 `remainingCount` 추가
- **상점 확장**: 민트 스킨 1종 + 잡화 5종(선글라스/꽃 머리핀/진주 목걸이/별/하트 풍선) 시드 추가

ktlintFormat + compileKotlin 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)