### PR TITLE
feat(admin): 모찌 EXP(포인트) 직접 설정

### DIFF
--- a/src/main/kotlin/digdaserver/admin/character/application/service/impl/AdminCharacterServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/character/application/service/impl/AdminCharacterServiceImpl.kt
@@ -62,6 +62,10 @@ class AdminCharacterServiceImpl(
             val clamped = newLevel.coerceIn(1, CharacterLevelTable.MAX_LEVEL)
             character.adminSetLevel(clamped)
         }
+        // EXP 는 레벨 적용 이후에 덮어쓴다 (adminSetLevel 이 exp 를 정합시키므로 순서 중요).
+        request.exp?.let { newExp ->
+            character.adminSetExp(newExp.coerceAtLeast(0))
+        }
         request.coin?.let { newCoin ->
             val safe = newCoin.coerceAtLeast(0)
             character.adminSetCoin(safe)
@@ -71,10 +75,11 @@ class AdminCharacterServiceImpl(
         }
 
         log.info(
-            "action=admin_character_update, groupRoomId={}, level={}, coin={}, " +
+            "action=admin_character_update, groupRoomId={}, level={}, exp={}, coin={}, " +
                 "stage={}, dikoUnlocked={}",
             groupRoomId,
             character.level,
+            character.exp,
             character.coin,
             character.stage,
             character.dikoUnlocked

--- a/src/main/kotlin/digdaserver/admin/character/presentation/dto/req/AdminUpdateCharacterRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/character/presentation/dto/req/AdminUpdateCharacterRequest.kt
@@ -9,6 +9,8 @@ import jakarta.validation.constraints.Min
  *
  * - [level]: 1..MAX(20). 변경 시 서버가 stage·exp 를 자동으로 정합 상태로 맞춘다
  *   (stage=CharacterStage.forLevel, exp 는 새 임계치 미만이면 그대로 두고 초과면 0).
+ * - [exp]: 0.. 현재 레벨 내 경험치(포인트) 절대값. [level] 과 함께 보내면 level 적용 후
+ *   해당 레벨 구간 안으로 clamp 된다. 자동 레벨업은 일으키지 않음.
  * - [coin]: 0.. 절대값. (delta 가 아닌 절대값 set 으로 단순화 — 어드민 수동 보정 용도.)
  * - [dikoUnlocked]: 디코 해금 강제 토글. null 이면 변경 없음. 단, level>=10 이면 항상
  *   자동으로 true 가 유지되므로, false 로 내려도 다음 레벨업 시 자동 복구.
@@ -20,6 +22,10 @@ data class AdminUpdateCharacterRequest(
     @field:Max(20)
     @Schema(description = "변경할 레벨(1-20). 미전송 시 변경 없음.", example = "10")
     val level: Int? = null,
+
+    @field:Min(0)
+    @Schema(description = "변경할 EXP(포인트, 현재 레벨 내 절대값). 미전송 시 변경 없음.", example = "50")
+    val exp: Int? = null,
 
     @field:Min(0)
     @Schema(description = "변경할 코인 잔액 (절대값). 미전송 시 변경 없음.", example = "100")

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/GroupCharacter.kt
@@ -202,6 +202,20 @@ class GroupCharacter(
         coin = newCoin
     }
 
+    /**
+     * 어드민 보정 — 현재 레벨 내 EXP(포인트) 절대값 set. 자동 레벨업은 일으키지 않고
+     * 현재 레벨 구간 [0, nextThreshold) 안으로 clamp 한다. MAX 레벨이면 항상 0.
+     * 레벨과 함께 보정할 때는 호출자가 [adminSetLevel] 을 먼저 적용한 뒤 호출해야 한다.
+     */
+    fun adminSetExp(newExp: Int) {
+        require(newExp >= 0) { "exp must be non-negative" }
+        exp = if (level >= CharacterLevelTable.MAX_LEVEL) {
+            0
+        } else {
+            newExp.coerceIn(0, CharacterLevelTable.expForNextLevel(level) - 1)
+        }
+    }
+
     /** 어드민 보정 — 디코 해금 플래그 강제 set. level<10 인 상태로 true 만들 수도 있음 (테스트용). */
     fun adminSetDikoUnlocked(unlocked: Boolean) {
         dikoUnlocked = unlocked


### PR DESCRIPTION
어드민 모찌 수정에 EXP(포인트) 직접 설정 추가. 코인/레벨/디코에 더해 현재 레벨 내 EXP 절대값을 설정(자동 레벨업 없이 구간 clamp). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)