### PR TITLE
fix(account): 회원탈퇴 FK 실패(탈퇴 안 됨) 해결 + 그룹 자식정리 공용화

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/scheduler/GroupRoomCleanupScheduler.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/scheduler/GroupRoomCleanupScheduler.kt
@@ -65,7 +65,7 @@ class GroupRoomCleanupScheduler(
 @Component
 class GroupRoomPurgeExecutor(
     private val groupRoomRepository: GroupRoomRepository,
-    private val em: EntityManager
+    private val childPurger: GroupRoomChildPurger
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -88,21 +88,32 @@ class GroupRoomPurgeExecutor(
             room.deleteScheduledAt
         )
         // GroupRoom cascade(ALL) 가 덮지 못하는 그룹 범위 자식부터 명시 삭제한 뒤 본체 삭제.
-        purgeGroupScopedChildren(groupRoomId)
+        childPurger.purgeChildren(groupRoomId)
         groupRoomRepository.delete(room)
     }
+}
 
-    /**
-     * GroupRoom 의 cascade(membership·invite·schedule→participant·diary→image·todo) 가
-     * 닿지 못하는 그룹 범위 자식 데이터를 FK 의존 순서로 직접 제거한다.
-     *
-     * - 캐릭터(모찌) 데이터는 **그룹별 소유물**이라 함께 삭제. 단 전역 마스터인
-     *   `shop_item` 카탈로그는 절대 건드리지 않는다.
-     * - diary_like/diary_reaction/comment 는 Diary 가 cascade 하지 않으므로, diary 가
-     *   cascade 로 지워지기 전에 먼저 제거해야 FK 위반(=purge 실패)을 막는다.
-     * - comment 는 polymorphic(target_type+target_id) 이라 FK 가 없어 직접 정리해야 한다.
-     */
-    private fun purgeGroupScopedChildren(groupRoomId: Long) {
+/**
+ * 그룹 범위 자식 데이터 정리 — 그룹 영구삭제(스케줄러)와 회원탈퇴 시 빈 그룹 삭제에서 공용.
+ *
+ * GroupRoom 의 cascade(membership·invite·schedule→participant·diary→image·todo) 가
+ * 닿지 못하는 그룹 범위 자식 데이터를 FK 의존 순서로 직접 제거한다.
+ *
+ * - 캐릭터(모찌) 데이터는 **그룹별 소유물**이라 함께 삭제. 단 전역 마스터인
+ *   `shop_item` 카탈로그는 절대 건드리지 않는다.
+ * - diary_like/diary_reaction/comment 는 Diary 가 cascade 하지 않으므로, diary 가
+ *   cascade 로 지워지기 전에 먼저 제거해야 FK 위반(=삭제 실패)을 막는다.
+ * - comment 는 polymorphic(target_type+target_id) 이라 FK 가 없어 직접 정리해야 한다.
+ *
+ * 자체 @Transactional 을 두지 않고 호출자의 트랜잭션에 합류한다.
+ */
+@Component
+class GroupRoomChildPurger(
+    private val em: EntityManager
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun purgeChildren(groupRoomId: Long) {
         fun run(jpql: String, vararg params: Pair<String, Any>): Int {
             val q = em.createQuery(jpql)
             params.forEach { (k, v) -> q.setParameter(k, v) }

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
@@ -1,10 +1,12 @@
 package digdaserver.domain.oauth2.application.service.impl.auth
 
+import digdaserver.domain.comment.domain.entity.CommentTargetType
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.device.domain.repository.DeviceRepository
 import digdaserver.domain.diary.domain.repository.DiaryLikeRepository
 import digdaserver.domain.diary.domain.repository.DiaryReactionRepository
 import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.group_room.application.scheduler.GroupRoomChildPurger
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
@@ -19,6 +21,7 @@ import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import digdaserver.global.jwt.domain.repository.JsonWebTokenRepository
 import digdaserver.global.jwt.domain.repository.SocialTokenRepository
+import jakarta.persistence.EntityManager
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -41,7 +44,9 @@ class AccountServiceImpl(
     private val todoRepository: TodoRepository,
     private val notificationRepository: NotificationRepository,
     private val deviceRepository: DeviceRepository,
-    private val uploadedImageRepository: UploadedImageRepository
+    private val uploadedImageRepository: UploadedImageRepository,
+    private val childPurger: GroupRoomChildPurger,
+    private val em: EntityManager
 ) : AccountService {
 
     private val log = LoggerFactory.getLogger(AccountServiceImpl::class.java)
@@ -70,6 +75,50 @@ class AccountServiceImpl(
         scheduleParticipantRepository.deleteAllByUserId(userId)
         scheduleParticipantRepository.deleteAllByScheduleCreatedById(userId)
 
+        // bulk JPQL delete 는 JPA cascade/orphanRemoval 을 타지 않으므로, 부모(일기·일정·유저)를
+        // 지우기 전에 FK 자식부터 직접 제거한다. (기존 삭제는 그대로 두고 자식 정리만 보강)
+        fun run(jpql: String, vararg params: Pair<String, Any>): Int {
+            val q = em.createQuery(jpql)
+            params.forEach { (k, v) -> q.setParameter(k, v) }
+            return q.executeUpdate()
+        }
+
+        // 캐릭터 퀴즈/응시 — character_quiz.author_id, character_quiz_attempt.user_id 가 유저 FK
+        // 라 정리하지 않으면 유저 행 삭제가 FK 위반으로 실패(=탈퇴 안 됨)한다.
+        run("DELETE FROM CharacterQuizAttempt a WHERE a.user.id = :uid", "uid" to userId)
+        run("DELETE FROM CharacterQuizAttempt a WHERE a.quiz.author.id = :uid", "uid" to userId)
+        run("DELETE FROM CharacterQuiz q WHERE q.author.id = :uid", "uid" to userId)
+
+        // 내가 쓴 일기에 달린 이미지/좋아요/리액션/댓글 — 일기 bulk 삭제 전에 먼저 (FK)
+        run(
+            "DELETE FROM DiaryImage di " +
+                "WHERE di.diary.id IN (SELECT d.id FROM Diary d WHERE d.createdBy.id = :uid)",
+            "uid" to userId
+        )
+        run(
+            "DELETE FROM DiaryLike dl " +
+                "WHERE dl.diary.id IN (SELECT d.id FROM Diary d WHERE d.createdBy.id = :uid)",
+            "uid" to userId
+        )
+        run(
+            "DELETE FROM DiaryReaction dr " +
+                "WHERE dr.diary.id IN (SELECT d.id FROM Diary d WHERE d.createdBy.id = :uid)",
+            "uid" to userId
+        )
+        run(
+            "DELETE FROM Comment c WHERE c.targetType = :t " +
+                "AND c.targetId IN (SELECT d.id FROM Diary d WHERE d.createdBy.id = :uid)",
+            "t" to CommentTargetType.DIARY,
+            "uid" to userId
+        )
+        // 내가 만든 일정에 달린 댓글 (참여자는 위에서 이미 정리됨)
+        run(
+            "DELETE FROM Comment c WHERE c.targetType = :t " +
+                "AND c.targetId IN (SELECT s.id FROM Schedule s WHERE s.createdBy.id = :uid)",
+            "t" to CommentTargetType.SCHEDULE,
+            "uid" to userId
+        )
+
         // 내가 만든 컨텐츠 삭제 (다른 사람 일기에 단 좋아요·리액션은 cascade 가 아닌 직접 정리)
         diaryLikeRepository.deleteAllByUserId(userId)
         diaryReactionRepository.deleteAllByUserId(userId)
@@ -83,6 +132,8 @@ class AccountServiceImpl(
         deviceRepository.deleteAllByUserId(userId)
         uploadedImageRepository.deleteAllByUserId(userId)
 
+        em.flush()
+
         // 멤버십 삭제 및 빈 그룹 정리
         val groupRoomIds = memberships.map { it.groupRoom.id!! }
         memberships.forEach { membership ->
@@ -90,9 +141,11 @@ class AccountServiceImpl(
         }
         membershipRepository.flush()
 
-        // 남은 멤버가 0명인 그룹 삭제 (cascade로 일기, 일정, 할일 등 모두 삭제)
+        // 남은 멤버가 0명인 그룹은 영구 삭제. cascade 가 닿지 못하는 자식(캐릭터·좋아요·리액션·
+        // 댓글·알림)까지 GroupRoomChildPurger 로 정리한 뒤 본체 삭제(나머지는 cascade).
         groupRoomIds.forEach { groupRoomId ->
             if (membershipRepository.countByGroupRoomId(groupRoomId) == 0) {
+                childPurger.purgeChildren(groupRoomId)
                 groupRoomRepository.deleteById(groupRoomId)
                 log.info("빈 그룹방 삭제: groupRoomId={}", groupRoomId)
             }


### PR DESCRIPTION
회원탈퇴 시 character_quiz/attempt(유저 FK)·일기 자식(이미지/좋아요/리액션/댓글)을 정리하지 않아 FK 위반으로 롤백돼 탈퇴가 안 되던 문제 수정. 빈 그룹 삭제도 GroupRoomChildPurger 재사용. 기존 삭제/가드는 유지(자식 정리만 보강). 🤖 Generated with [Claude Code](https://claude.com/claude-code)