### PR TITLE
fix(admin): 유령 ADMIN 강등으로 관리자 1명 보장

### DIFF
--- a/src/main/kotlin/digdaserver/admin/auth/config/AdminBootstrap.kt
+++ b/src/main/kotlin/digdaserver/admin/auth/config/AdminBootstrap.kt
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Component
 @Profile("dev", "prod")
@@ -30,6 +31,12 @@ class AdminBootstrap(
 
     @Transactional
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        ensureBootstrapAdmin()
+        demoteOrphanAdmins()
+    }
+
+    /** 부트스트랩 관리자(이메일 유니크) 가 없으면 1회 생성. 있으면 스킵 — 멱등. */
+    private fun ensureBootstrapAdmin() {
         if (adminCredentialRepository.findByEmail(email).isPresent) {
             log.info("[AdminBootstrap] 기존 관리자 존재 — 생성 스킵 (email={})", email)
             return
@@ -53,5 +60,26 @@ class AdminBootstrap(
         )
 
         log.info("[AdminBootstrap] 기본 관리자 생성 완료 (email={}, userId={})", email, user.id)
+    }
+
+    /**
+     * 관리자(ADMIN) 는 admin_credential 을 가진 계정만 실제로 로그인 가능하다.
+     * 자격증명 없이 role=ADMIN 으로만 떠 있는 "유령 관리자" 행은 로그인 불가하면서도
+     * 관리자 목록/카운트를 부풀리므로, **삭제하지 않고 USER 로 강등**해 관리자를 실제
+     * 로그인 가능한 계정 수와 일치시킨다. (보통 1명)
+     */
+    private fun demoteOrphanAdmins() {
+        val credentialedUserIds: Set<UUID> =
+            adminCredentialRepository.findAll().map { it.user.id }.toSet()
+        val orphanAdmins = userRepository.findAllByRole(Role.ADMIN)
+            .filter { it.id !in credentialedUserIds }
+        if (orphanAdmins.isEmpty()) return
+
+        orphanAdmins.forEach { it.demoteToUser() }
+        log.warn(
+            "[AdminBootstrap] 자격증명 없는 ADMIN {}건을 USER 로 강등(삭제 아님) — 관리자 정리, ids={}",
+            orphanAdmins.size,
+            orphanAdmins.map { it.id }
+        )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
@@ -105,4 +105,9 @@ class User(
     fun initPrivacySetting(setting: UserPrivacySetting) {
         this.privacySetting = setting
     }
+
+    /** 자격증명 없는 유령 ADMIN 정리용 — 역할만 USER 로 강등(데이터 삭제 아님). */
+    fun demoteToUser() {
+        this.role = Role.USER
+    }
 }

--- a/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
@@ -19,6 +19,8 @@ interface UserRepository : JpaRepository<User, UUID> {
 
     fun countByRole(role: Role): Long
 
+    fun findAllByRole(role: Role): List<User>
+
     @Query("SELECT u.id FROM User u")
     fun findAllIds(): List<UUID>
 


### PR DESCRIPTION
자격증명(admin_credential) 없이 role=ADMIN 으로만 남은 '유령 관리자' 행을 부팅 시 USER 로 강등(삭제 아님). 실제 로그인 가능한 관리자 수(보통 1명)와 일치시킴. 부트스트랩 생성은 멱등 그대로. 🤖 Generated with [Claude Code](https://claude.com/claude-code)