### PR TITLE
feat(quiz): 작성자 탈퇴 시 퀴즈 보존(작성자=탈퇴자)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -172,7 +172,8 @@ class CharacterQuizServiceImpl(
         val quiz = quizRepository.findById(quizId)
             .orElseThrow { DigdaException(ErrorCode.QUIZ_NOT_FOUND) }
 
-        if (quiz.author.id == userId) throw DigdaException(ErrorCode.QUIZ_CANNOT_ATTEMPT_OWN)
+        // 작성자 탈퇴(author=null)면 본인 출제 제한 대상이 아니므로 누구나 응시 가능.
+        if (quiz.author?.id == userId) throw DigdaException(ErrorCode.QUIZ_CANNOT_ATTEMPT_OWN)
         validateGroupMember(quiz.groupRoom.id, userId)
 
         // 사진 퀴즈는 디코가 풀린 그룹에서만 응시 가능. URL 우회 방어용.

--- a/src/main/kotlin/digdaserver/domain/character/domain/entity/CharacterQuiz.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/entity/CharacterQuiz.kt
@@ -39,9 +39,10 @@ class CharacterQuiz(
     @JoinColumn(name = "group_room_id", nullable = false)
     val groupRoom: GroupRoom,
 
+    // 작성자. 작성자가 회원탈퇴하면 NULL 로 비워 퀴즈는 보존하고 표시만 "탈퇴자"로 한다.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    val author: User,
+    @JoinColumn(name = "author_id", nullable = true)
+    val author: User?,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 32)

--- a/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizRepository.kt
@@ -36,7 +36,7 @@ interface CharacterQuizRepository : JpaRepository<CharacterQuiz, Long> {
         """
         SELECT q FROM CharacterQuiz q
         WHERE q.groupRoom.id = :groupRoomId
-          AND q.author.id <> :userId
+          AND (q.author IS NULL OR q.author.id <> :userId)
           AND (:excludeImageQuiz = false OR q.imageUrl IS NULL)
           AND NOT EXISTS (
             SELECT 1 FROM CharacterQuizAttempt a

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -36,7 +36,7 @@ data class CharacterQuizResponse(
                 question = quiz.question,
                 options = quiz.options(),
                 expMultiplier = quiz.expMultiplier,
-                authorName = quiz.author.name,
+                authorName = quiz.author?.name ?: "탈퇴자",
                 imageUrl = quiz.imageUrl,
                 createdAt = quiz.createdAt,
                 remainingCount = remainingCount

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/AccountServiceImpl.kt
@@ -83,11 +83,12 @@ class AccountServiceImpl(
             return q.executeUpdate()
         }
 
-        // 캐릭터 퀴즈/응시 — character_quiz.author_id, character_quiz_attempt.user_id 가 유저 FK
-        // 라 정리하지 않으면 유저 행 삭제가 FK 위반으로 실패(=탈퇴 안 됨)한다.
+        // 캐릭터 퀴즈/응시 정리.
+        // - 내가 출제한 퀴즈는 삭제하지 않고 author 만 NULL 로 비워 보존 → 표시는 "탈퇴자".
+        //   (그룹원들이 계속 풀 수 있게. character_quiz.author_id 는 nullable 로 변경됨)
+        // - 내 응시기록(character_quiz_attempt.user_id 가 유저 FK)은 본인 기록이라 삭제.
+        run("UPDATE CharacterQuiz q SET q.author = null WHERE q.author.id = :uid", "uid" to userId)
         run("DELETE FROM CharacterQuizAttempt a WHERE a.user.id = :uid", "uid" to userId)
-        run("DELETE FROM CharacterQuizAttempt a WHERE a.quiz.author.id = :uid", "uid" to userId)
-        run("DELETE FROM CharacterQuiz q WHERE q.author.id = :uid", "uid" to userId)
 
         // 내가 쓴 일기에 달린 이미지/좋아요/리액션/댓글 — 일기 bulk 삭제 전에 먼저 (FK)
         run(

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -44,6 +44,16 @@ class SchemaAutoMigration(
             expectedMaxLength = 64,
             nullable = false,
             alterSql = "ALTER TABLE notification MODIFY COLUMN type VARCHAR(64) NOT NULL"
+        ),
+        // 작성자 회원탈퇴 시 퀴즈를 보존(author=NULL)하려면 author_id 가 NULL 허용이어야 한다.
+        // 기존 prod 컬럼은 BINARY(16) NOT NULL 이라 nullable 로 완화. FK 제약은 그대로 유지된다.
+        RequiredColumn(
+            table = "character_quiz",
+            column = "author_id",
+            expectedDataType = "binary",
+            expectedMaxLength = 16,
+            nullable = true,
+            alterSql = "ALTER TABLE character_quiz MODIFY COLUMN author_id BINARY(16) NULL"
         )
     )
 


### PR DESCRIPTION
회원탈퇴 시 출제한 퀴즈를 삭제하지 않고 author 를 NULL 로 비워 보존(그룹원이 계속 응시 가능), 표시는 '탈퇴자'. character_quiz.author_id nullable 로 변경(prod 마이그레이션 포함, FK 유지). 본인 응시기록만 삭제. 🤖 Generated with [Claude Code](https://claude.com/claude-code)