### PR TITLE
fix(diary): 일기 작성 EXP 단일 10 (이중지급 제거)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -71,7 +71,7 @@ class DiaryServiceImpl(
         private val KST: ZoneId = ZoneId.of("Asia/Seoul")
 
         /** 일기 1건 작성 시 모찌에게 지급하는 경험치. */
-        private const val DIARY_WRITE_EXP = 20
+        private const val DIARY_WRITE_EXP = 10
     }
 
     /** 날짜 미래 여부 판정에 쓰는 "오늘"(한국 기준). */


### PR DESCRIPTION
앱 addExp(15) + 서버 grant(20) = 35 이중지급을 단일 10으로 정리(서버 createDiary 단일 지급). 🤖 Generated with [Claude Code](https://claude.com/claude-code)