### PR TITLE
feat(diary): 일기 캘린더 응답 enrich (entries + stats)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -14,7 +14,9 @@ import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
+import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarEntry
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarStats
 import digdaserver.domain.diary.presentation.dto.res.DiaryCommentResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
@@ -72,6 +74,9 @@ class DiaryServiceImpl(
 
         /** 일기 1건 작성 시 모찌에게 지급하는 경험치. */
         private const val DIARY_WRITE_EXP = 10
+
+        /** 연속 기록(streak) 계산 시 거슬러 올라가 조회할 최근 일 수. */
+        private const val STREAK_WINDOW_DAYS = 400L
     }
 
     /** 날짜 미래 여부 판정에 쓰는 "오늘"(한국 기준). */
@@ -136,8 +141,63 @@ class DiaryServiceImpl(
         ensureMember(userId, groupRoomId)
         val startDate = month.atDay(1)
         val endDate = month.atEndOfMonth()
-        val dates = diaryRepository.findDistinctDatesByGroupRoomIdAndMonth(groupRoomId, startDate, endDate)
-        return DiaryCalendarResponse(dates = dates)
+
+        // 사진 그리드용: 해당 월의 모든 일기를 이미지까지 한 번에 로드.
+        val monthDiaries = diaryRepository.findAllWithImagesByGroupRoomIdAndDateBetween(groupRoomId, startDate, endDate)
+
+        // 날짜별 그룹핑. 같은 날 여러 편이면 최신(createdAt DESC, 쿼리에서 이미 정렬)을 대표로 사용.
+        val byDate = monthDiaries.groupBy { it.date }
+        val entries = byDate.entries
+            .sortedBy { it.key }
+            .map { (date, diaries) ->
+                val representative = diaries.first()
+                DiaryCalendarEntry(
+                    date = date,
+                    diaryId = representative.id,
+                    thumbnailUrl = representative.images.minByOrNull { it.sortOrder }?.url,
+                    mood = representative.mood,
+                    count = diaries.size
+                )
+            }
+        val dates = entries.map { it.date }
+
+        // 통계: 편수 / 최다 기분 / 연속 기록.
+        val count = monthDiaries.size
+        val topMood = monthDiaries
+            .groupingBy { it.mood }
+            .eachCount()
+            .maxWithOrNull(compareBy({ it.value }, { -it.key }))
+            ?.key
+        val streak = computeStreak(groupRoomId)
+
+        return DiaryCalendarResponse(
+            dates = dates,
+            entries = entries,
+            stats = DiaryCalendarStats(count = count, streak = streak, topMood = topMood)
+        )
+    }
+
+    /**
+     * 오늘(KST) 기준 연속으로 일기를 쓴 일수를 계산한다.
+     * 오늘 작성했으면 오늘부터, 아니면 어제부터 거슬러 올라가며 빈 날을 만나면 중단.
+     * 월 경계를 넘을 수 있어 최근 [STREAK_WINDOW_DAYS] 일 범위의 작성 날짜 집합으로 판정한다.
+     */
+    private fun computeStreak(groupRoomId: Long): Int {
+        val today = todayKst()
+        val windowStart = today.minusDays(STREAK_WINDOW_DAYS)
+        val writtenDays = diaryRepository
+            .findDistinctDatesByGroupRoomIdAndMonth(groupRoomId, windowStart, today)
+            .toHashSet()
+        if (writtenDays.isEmpty()) return 0
+
+        // 오늘 미작성이면 어제부터 시작(오늘은 아직 쓸 수 있으므로 streak 을 깨지 않음).
+        var cursor = if (writtenDays.contains(today)) today else today.minusDays(1)
+        var streak = 0
+        while (writtenDays.contains(cursor)) {
+            streak++
+            cursor = cursor.minusDays(1)
+        }
+        return streak
     }
 
     override fun getDiaryDetail(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDetailResponse {

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -22,6 +22,21 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
     @Query("SELECT DISTINCT d.date FROM Diary d WHERE d.groupRoom.id = :groupRoomId AND d.date BETWEEN :startDate AND :endDate")
     fun findDistinctDatesByGroupRoomIdAndMonth(groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): List<LocalDate>
 
+    /**
+     * 기간 내 모든 일기를 이미지까지 fetch join 으로 한 번에 로드한다.
+     * 캘린더 그리드(날짜별 썸네일/기분)와 통계 계산용. 날짜 오름차순, 같은 날은 최신 작성 우선.
+     */
+    @Query(
+        "SELECT DISTINCT d FROM Diary d LEFT JOIN FETCH d.images " +
+            "WHERE d.groupRoom.id = :groupRoomId AND d.date BETWEEN :startDate AND :endDate " +
+            "ORDER BY d.date ASC, d.createdAt DESC"
+    )
+    fun findAllWithImagesByGroupRoomIdAndDateBetween(
+        groupRoomId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<Diary>
+
     @Query(
         """
         SELECT d FROM Diary d

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
@@ -2,6 +2,36 @@ package digdaserver.domain.diary.presentation.dto.res
 
 import java.time.LocalDate
 
+/**
+ * 일기 캘린더 응답.
+ *
+ * - [dates] : 일기가 존재하는 날짜 목록(하위호환 — 기존 dot marker 용).
+ * - [entries] : 날짜별 대표 일기 요약(사진 그리드용 썸네일/기분/편수).
+ * - [stats] : 이번 달 통계 스트립(편수·연속 기록·최다 기분).
+ */
 data class DiaryCalendarResponse(
-    val dates: List<LocalDate>
+    val dates: List<LocalDate>,
+    val entries: List<DiaryCalendarEntry> = emptyList(),
+    val stats: DiaryCalendarStats = DiaryCalendarStats()
+)
+
+/** 캘린더 한 칸(날짜)에 대응하는 대표 일기. 하루 여러 편이면 [count] 로 표시하고 대표 1건을 노출. */
+data class DiaryCalendarEntry(
+    val date: LocalDate,
+    val diaryId: Long,
+    val thumbnailUrl: String?,
+    val mood: Int,
+    val count: Int
+)
+
+/**
+ * 통계 스트립 값.
+ * - [count] : 해당 월 작성된 일기 편수.
+ * - [streak] : 오늘(KST) 기준 연속으로 일기를 쓴 일수. 오늘 미작성이면 어제까지의 연속 일수.
+ * - [topMood] : 해당 월 가장 많이 기록된 기분(0~4). 일기가 없으면 null.
+ */
+data class DiaryCalendarStats(
+    val count: Int = 0,
+    val streak: Int = 0,
+    val topMood: Int? = null
 )


### PR DESCRIPTION
@
## 개요
그림일기 캘린더 리뉴얼(사진 그리드·통계 스트립) 지원을 위해 `/group-rooms/{id}/diaries/calendar` 응답을 확장합니다.

## 변경
- `DiaryCalendarResponse`: 기존 `dates`(하위호환) + `entries` + `stats` 추가
  - `entries`: 날짜별 대표 일기 `{date, diaryId, thumbnailUrl, mood, count}`
  - `stats`: `count`(월 편수) / `streak`(KST 연속 기록) / `topMood`(최다 기분)
- `DiaryRepository.findAllWithImagesByGroupRoomIdAndDateBetween` (이미지 fetch join)
- `DiaryServiceImpl.getDiaryCalendar` 에서 그룹핑·통계·streak 계산

## 비고
- **스키마 변경 없음** (mood·images 기존 컬럼 활용)
- 기존 `dates` 필드 유지로 구버전 클라이언트 호환
- `ktlintFormat` + `compileKotlin` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@