### PR TITLE
feat(group-room): 그룹홈 집계 엔드포인트 + 일기/일정 권한 정리

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -289,13 +289,14 @@ class DiaryServiceImpl(
 
         if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
 
-        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
         val diary = diaryRepository.findById(diaryId)
             .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
 
-        if (diary.createdBy.id != userId && !membership.isOwner) {
+        // 일기는 작성자 본인만 수정 가능 (방장도 불가 — 일정과 반대).
+        if (diary.createdBy.id != userId) {
             throw DigdaException(ErrorCode.FORBIDDEN)
         }
 
@@ -334,13 +335,14 @@ class DiaryServiceImpl(
 
         if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
 
-        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
         val diary = diaryRepository.findById(diaryId)
             .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
 
-        if (diary.createdBy.id != userId && !membership.isOwner) {
+        // 일기는 작성자 본인만 삭제 가능 (방장도 불가 — 일정과 반대).
+        if (diary.createdBy.id != userId) {
             throw DigdaException(ErrorCode.FORBIDDEN)
         }
 

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -4,6 +4,7 @@ import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupHomeResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
@@ -16,6 +17,8 @@ interface GroupRoomService {
     fun getMyGroupRooms(userId: UUID): GroupRoomListResponse
 
     fun getGroupRoomDetail(userId: UUID, groupRoomId: Long): GroupRoomDetailResponse
+
+    fun getGroupHome(userId: UUID, groupRoomId: Long): GroupHomeResponse
 
     fun updateGroupRoom(userId: UUID, groupRoomId: Long, request: UpdateGroupRoomRequest): GroupRoomResponse
 

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -1,18 +1,23 @@
 package digdaserver.domain.group_room.application.service.impl
 
+import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.domain.entity.GroupRoom
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
+import digdaserver.domain.group_room.presentation.dto.res.ActiveGroupResponse
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupHomeResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListItem
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
 import digdaserver.domain.group_room.presentation.dto.res.MembershipSummary
+import digdaserver.domain.group_room.presentation.dto.res.NextEventResponse
+import digdaserver.domain.group_room.presentation.dto.res.TodaySummaryResponse
 import digdaserver.domain.invite.domain.entity.InviteCode
 import digdaserver.domain.invite.domain.repository.InviteCodeRepository
 import digdaserver.domain.log.application.service.UserActionLogService
@@ -20,14 +25,19 @@ import digdaserver.domain.log.domain.entity.UserAction
 import digdaserver.domain.membership.domain.entity.Membership
 import digdaserver.domain.membership.domain.repository.MembershipRepository
 import digdaserver.domain.notification.application.service.NotificationService
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
 import digdaserver.domain.upload.domain.repository.UploadedImageRepository
 import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
 import java.util.UUID
 
 @Service
@@ -39,7 +49,9 @@ class GroupRoomServiceImpl(
     private val inviteCodeRepository: InviteCodeRepository,
     private val notificationService: NotificationService,
     private val userActionLogService: UserActionLogService,
-    private val uploadedImageRepository: UploadedImageRepository
+    private val uploadedImageRepository: UploadedImageRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val diaryRepository: DiaryRepository
 ) : GroupRoomService {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -157,6 +169,57 @@ class GroupRoomServiceImpl(
             groupRoom = GroupRoomResponse.from(groupRoom, memberCount),
             memberships = memberships.map { MembershipSummary.from(it) },
             myRole = membership.role.name.lowercase()
+        )
+    }
+
+    override fun getGroupHome(userId: UUID, groupRoomId: Long): GroupHomeResponse {
+        log.info("userId={}, action=그룹 홈 조회, groupRoomId={}", userId, groupRoomId)
+
+        val groupRoom = groupRoomRepository.findById(groupRoomId)
+            .orElseThrow { DigdaException(ErrorCode.GROUP_ROOM_NOT_FOUND) }
+
+        if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
+
+        // 구성원만 접근 가능 (상세 조회와 동일 정책).
+        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+            .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        val memberships = membershipRepository.findAllByGroupRoomId(groupRoomId)
+        val today = LocalDate.now(KST)
+
+        // 오늘 요약: 오늘에 걸치는 일정 수 / 오늘 작성된 일기 수 / 안읽음 알림 수(집계값).
+        val scheduleCount =
+            scheduleRepository.findAllByGroupRoomIdAndDateRange(groupRoomId, today, today).size
+        val newDiaryCount = diaryRepository
+            .findAllByGroupRoomIdAndDateBetween(groupRoomId, today, today, PageRequest.of(0, 1))
+            .totalElements.toInt()
+        val unreadCount = notificationService.getNotifications(userId, 1, 0).unreadCount
+
+        // 다가오는 일정: 오늘 이후 1년 범위에서 시작일·시작시각이 가장 이른 1건.
+        val nextEvent = scheduleRepository
+            .findAllByGroupRoomIdAndDateRange(groupRoomId, today, today.plusYears(1))
+            .sortedWith(compareBy({ it.startDate }, { it.startTime ?: LocalTime.MIN }))
+            .firstOrNull()
+
+        return GroupHomeResponse(
+            userName = user.name,
+            today = TodaySummaryResponse(
+                scheduleCount = scheduleCount,
+                newDiaryCount = newDiaryCount,
+                unreadCount = unreadCount
+            ),
+            activeGroup = ActiveGroupResponse(
+                id = groupRoom.id,
+                name = groupRoom.name,
+                thumbnailImage = groupRoom.thumbnailImage,
+                memberCount = memberships.size,
+                myRole = membership.role.name.lowercase(),
+                members = memberships.map { MembershipSummary.from(it) },
+                nextEvent = nextEvent?.let { NextEventResponse.from(it) }
+            )
         )
     }
 
@@ -293,5 +356,9 @@ class GroupRoomServiceImpl(
     private fun generateRandomColor(): String {
         val colors = listOf("#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7", "#DDA0DD", "#98D8C8")
         return colors.random()
+    }
+
+    companion object {
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/controller/GroupRoomController.kt
@@ -4,6 +4,7 @@ import digdaserver.domain.group_room.application.service.GroupRoomService
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupHomeResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
@@ -56,6 +57,19 @@ class GroupRoomController(
         @PathVariable groupRoomId: Long
     ): ResponseEntity<GroupRoomDetailResponse> {
         val response = groupRoomService.getGroupRoomDetail(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(
+        summary = "그룹 홈 대시보드",
+        description = "그룹 홈 화면용 집계 — 오늘 요약(오늘 일정/새 일기/안읽음) + 활성 그룹(멤버·다가오는 일정)을 1회로 조회합니다. 구성원만 접근 가능합니다."
+    )
+    @GetMapping("/{groupRoomId}/home")
+    fun getGroupHome(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<GroupHomeResponse> {
+        val response = groupRoomService.getGroupHome(UUID.fromString(userId), groupRoomId)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupHomeResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/GroupHomeResponse.kt
@@ -1,0 +1,57 @@
+package digdaserver.domain.group_room.presentation.dto.res
+
+import digdaserver.domain.schedule.domain.entity.Schedule
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 그룹 홈(대시보드) 화면 1회 조회용 집계 응답.
+ *
+ * - [userName]    : 인사 헤더용 사용자 이름
+ * - [today]       : 오늘 요약 스트립(오늘 일정 수 / 오늘 새 일기 수 / 안읽음 알림 수)
+ * - [activeGroup] : 활성 그룹 카드(멤버 + 다가오는 일정 내장)
+ *
+ * 최근 소식(activity) 피드는 별도 `/notifications` 엔드포인트(cross-group)를 재사용하므로
+ * 이 응답에는 포함하지 않는다.
+ */
+data class GroupHomeResponse(
+    val userName: String,
+    val today: TodaySummaryResponse,
+    val activeGroup: ActiveGroupResponse
+)
+
+data class TodaySummaryResponse(
+    val scheduleCount: Int,
+    val newDiaryCount: Int,
+    val unreadCount: Int
+)
+
+data class ActiveGroupResponse(
+    val id: Long,
+    val name: String,
+    val thumbnailImage: String?,
+    val memberCount: Int,
+    val myRole: String,
+    val members: List<MembershipSummary>,
+    val nextEvent: NextEventResponse?
+)
+
+data class NextEventResponse(
+    val id: Long,
+    val title: String,
+    val startDate: LocalDate,
+    val startTime: LocalTime?,
+    val allDay: Boolean,
+    val color: String
+) {
+    companion object {
+        fun from(schedule: Schedule): NextEventResponse = NextEventResponse(
+            id = schedule.id,
+            title = schedule.title,
+            startDate = schedule.startDate,
+            startTime = schedule.startTime,
+            allDay = schedule.allDay,
+            color = schedule.color
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
@@ -149,15 +149,12 @@ class ScheduleServiceImpl(
 
         if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
 
-        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+        // 일정은 그룹 멤버 누구나 수정 가능 (작성자/방장 제한 없음 — 일기와 반대).
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
         val schedule = scheduleRepository.findById(scheduleId)
             .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
-
-        if (schedule.createdBy.id != userId && !membership.isOwner) {
-            throw DigdaException(ErrorCode.FORBIDDEN)
-        }
 
         val newStartDate = request.startDate ?: schedule.startDate
         val newEndDate = request.endDate ?: schedule.endDate
@@ -217,15 +214,12 @@ class ScheduleServiceImpl(
 
         if (groupRoom.deletedAt != null) throw DigdaException(ErrorCode.GROUP_ROOM_ALREADY_DELETED)
 
-        val membership = membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
+        // 일정은 그룹 멤버 누구나 삭제 가능 (작성자/방장 제한 없음 — 일기와 반대).
+        membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
         val schedule = scheduleRepository.findById(scheduleId)
             .orElseThrow { DigdaException(ErrorCode.SCHEDULE_NOT_FOUND) }
-
-        if (schedule.createdBy.id != userId && !membership.isOwner) {
-            throw DigdaException(ErrorCode.FORBIDDEN)
-        }
 
         val title = schedule.title
         scheduleRepository.delete(schedule)


### PR DESCRIPTION
@
## 변경 요약
- `GET /group-rooms/{id}/home` 그룹 홈 대시보드 집계 엔드포인트 추가
- 권한 정리: 일기는 작성자만 수정/삭제, 일정은 멤버 누구나
- dev 머지 반영

> 일정 리마인더 알림 미발송 건은 점검 결과 서버측(스케줄러/알림서비스/FCM/기본설정) 이상 없음 — 앱 측 FCM 토큰 재등록 누락이 원인이라 앱 리포에서 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@