### PR TITLE
fix(ktlint): GroupRoomService import 순서 정렬 (CI 복구)

### DIFF
--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/GroupRoomService.kt
@@ -3,8 +3,8 @@ package digdaserver.domain.group_room.application.service
 import digdaserver.domain.group_room.presentation.dto.req.CreateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.req.UpdateGroupRoomRequest
 import digdaserver.domain.group_room.presentation.dto.res.CreateGroupRoomResponse
-import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupHomeResponse
+import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDeleteResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomDetailResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomListResponse
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse


### PR DESCRIPTION
@
## 문제
dev CI(`./gradlew clean build -x test`)의 `ktlintMainSourceSetCheck` 실패:
`GroupRoomService.kt:3:1 Imports must be ordered in lexicographic order`

그룹 홈 집계 엔드포인트(PR #78) 추가 시 `GroupHomeResponse` import 가 사전순상
`GroupRoomDeleteResponse` 보다 앞이어야 하나 뒤에 들어가 위반.

## 조치
- import 순서 정렬. 로컬 `./gradlew ktlintMainSourceSetCheck` BUILD SUCCESSFUL 확인.
- impl/controller 동일 import 는 이미 정상 순서임을 확인(이 파일만 위반).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@