### PR TITLE
feat(exhibit): 역대 별명 전시관 백엔드 — 엔티티·앱/어드민 API

### DIFF
--- a/docs/migration/nickname_exhibit_init.sql
+++ b/docs/migration/nickname_exhibit_init.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- 디그다 역대 별명 전시관 (nickname exhibit) 초기 스키마 (prod 적용용)
+--
+-- prod 는 hibernate.ddl-auto=none 이므로 신규 테이블을 수동으로 생성한다.
+-- (dev 는 ddl-auto=create 로 엔티티에서 자동 생성됨)
+--
+-- - nickname_exhibit         : 전시관 별명 카드(전역 콘텐츠). 어드민이 CRUD.
+-- - nickname_exhibit_access  : 전시관 접근 허용 사용자(유저당 1행). 어드민이 등록/해제.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS `nickname_exhibit` (
+    `nickname_exhibit_id` BIGINT       NOT NULL AUTO_INCREMENT,
+    `nickname`            VARCHAR(100) NOT NULL,
+    `image_url`           VARCHAR(512) NULL,
+    `history`             TEXT         NULL,
+    `sort_order`          INT          NOT NULL DEFAULT 0,
+    `created_at`          DATETIME(6)  NOT NULL,
+    `updated_at`          DATETIME(6)  NOT NULL,
+    PRIMARY KEY (`nickname_exhibit_id`),
+    KEY `idx_nickname_exhibit_sort` (`sort_order`, `nickname_exhibit_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `nickname_exhibit_access` (
+    `nickname_exhibit_access_id` BIGINT      NOT NULL AUTO_INCREMENT,
+    `user_id`                    BINARY(16)  NOT NULL,
+    `created_at`                 DATETIME(6) NOT NULL,
+    `updated_at`                 DATETIME(6) NOT NULL,
+    PRIMARY KEY (`nickname_exhibit_access_id`),
+    UNIQUE KEY `uk_nickname_exhibit_access_user` (`user_id`),
+    CONSTRAINT `fk_nickname_exhibit_access_user`
+        FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/application/service/AdminNicknameExhibitService.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/application/service/AdminNicknameExhibitService.kt
@@ -1,0 +1,22 @@
+package digdaserver.admin.nicknameexhibit.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.CreateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.UpdateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminExhibitAccessResponse
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminNicknameExhibitResponse
+import java.util.UUID
+
+interface AdminNicknameExhibitService {
+
+    // ── 콘텐츠(별명 카드) CRUD ──
+    fun search(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminNicknameExhibitResponse>
+    fun create(request: CreateNicknameExhibitRequest): AdminNicknameExhibitResponse
+    fun update(id: Long, request: UpdateNicknameExhibitRequest): AdminNicknameExhibitResponse
+    fun delete(id: Long)
+
+    // ── 접근 허용 사용자 관리 ──
+    fun searchAccess(keyword: String?, page: Int, size: Int): AdminPageResponse<AdminExhibitAccessResponse>
+    fun addAccess(userId: UUID): AdminExhibitAccessResponse
+    fun removeAccess(userId: UUID)
+}

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/application/service/impl/AdminNicknameExhibitServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/application/service/impl/AdminNicknameExhibitServiceImpl.kt
@@ -1,0 +1,121 @@
+package digdaserver.admin.nicknameexhibit.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.nicknameexhibit.application.service.AdminNicknameExhibitService
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.CreateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.UpdateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminExhibitAccessResponse
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminNicknameExhibitResponse
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibit
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibitAccess
+import digdaserver.domain.nickname_exhibit.domain.repository.NicknameExhibitAccessRepository
+import digdaserver.domain.nickname_exhibit.domain.repository.NicknameExhibitRepository
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class AdminNicknameExhibitServiceImpl(
+    private val nicknameExhibitRepository: NicknameExhibitRepository,
+    private val nicknameExhibitAccessRepository: NicknameExhibitAccessRepository,
+    private val userRepository: UserRepository
+) : AdminNicknameExhibitService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun search(
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminNicknameExhibitResponse> {
+        val pageable = PageRequest.of(
+            page.coerceAtLeast(0),
+            size.coerceIn(1, 100),
+            Sort.by(Sort.Direction.ASC, "sortOrder").and(Sort.by(Sort.Direction.ASC, "id"))
+        )
+        val result = nicknameExhibitRepository.searchForAdmin(
+            keyword?.takeIf { it.isNotBlank() },
+            pageable
+        )
+        return AdminPageResponse.of(result, AdminNicknameExhibitResponse::from)
+    }
+
+    @Transactional
+    override fun create(request: CreateNicknameExhibitRequest): AdminNicknameExhibitResponse {
+        val saved = nicknameExhibitRepository.save(
+            NicknameExhibit(
+                nickname = request.nickname,
+                imageUrl = request.imageUrl?.takeIf { it.isNotBlank() },
+                history = request.history,
+                sortOrder = request.sortOrder
+            )
+        )
+        log.info("action=admin_exhibit_create, id={}, nickname={}", saved.id, saved.nickname)
+        return AdminNicknameExhibitResponse.from(saved)
+    }
+
+    @Transactional
+    override fun update(id: Long, request: UpdateNicknameExhibitRequest): AdminNicknameExhibitResponse {
+        val exhibit = nicknameExhibitRepository.findById(id)
+            .orElseThrow { DigdaException(ErrorCode.EXHIBIT_NOT_FOUND) }
+        exhibit.update(
+            nickname = request.nickname,
+            imageUrl = request.imageUrl,
+            history = request.history,
+            sortOrder = request.sortOrder
+        )
+        log.info("action=admin_exhibit_update, id={}", id)
+        return AdminNicknameExhibitResponse.from(exhibit)
+    }
+
+    @Transactional
+    override fun delete(id: Long) {
+        val exhibit = nicknameExhibitRepository.findById(id)
+            .orElseThrow { DigdaException(ErrorCode.EXHIBIT_NOT_FOUND) }
+        nicknameExhibitRepository.delete(exhibit)
+        log.info("action=admin_exhibit_delete, id={}", id)
+    }
+
+    override fun searchAccess(
+        keyword: String?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminExhibitAccessResponse> {
+        val pageable = PageRequest.of(
+            page.coerceAtLeast(0),
+            size.coerceIn(1, 100),
+            Sort.by(Sort.Direction.DESC, "createdAt")
+        )
+        val result = nicknameExhibitAccessRepository.searchForAdmin(
+            keyword?.takeIf { it.isNotBlank() },
+            pageable
+        )
+        return AdminPageResponse.of(result, AdminExhibitAccessResponse::from)
+    }
+
+    @Transactional
+    override fun addAccess(userId: UUID): AdminExhibitAccessResponse {
+        // 멱등 — 이미 허용된 사용자면 기존 행을 그대로 반환.
+        nicknameExhibitAccessRepository.findByUserId(userId)?.let {
+            return AdminExhibitAccessResponse.from(it)
+        }
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        val saved = nicknameExhibitAccessRepository.save(NicknameExhibitAccess(user = user))
+        log.info("action=admin_exhibit_access_add, userId={}", userId)
+        return AdminExhibitAccessResponse.from(saved)
+    }
+
+    @Transactional
+    override fun removeAccess(userId: UUID) {
+        nicknameExhibitAccessRepository.deleteByUserId(userId)
+        log.info("action=admin_exhibit_access_remove, userId={}", userId)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/controller/AdminNicknameExhibitController.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/controller/AdminNicknameExhibitController.kt
@@ -1,0 +1,108 @@
+package digdaserver.admin.nicknameexhibit.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.nicknameexhibit.application.service.AdminNicknameExhibitService
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.AddExhibitAccessRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.CreateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.req.UpdateNicknameExhibitRequest
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminExhibitAccessResponse
+import digdaserver.admin.nicknameexhibit.presentation.dto.res.AdminNicknameExhibitResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 어드민 디그다 역대 별명 전시관 관리.
+ * - 별명 카드(콘텐츠) CRUD
+ * - 접근 허용 사용자 등록/조회/해제
+ *
+ * `/api/admin/**` 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ */
+@RestController
+@RequestMapping("/api/admin/nickname-exhibits")
+@Tag(name = "Admin - Nickname Exhibit", description = "관리자 역대 별명 전시관 관리 API")
+class AdminNicknameExhibitController(
+    private val adminNicknameExhibitService: AdminNicknameExhibitService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    // ── 콘텐츠(별명 카드) CRUD ──
+
+    @Operation(summary = "별명 카드 목록 조회", description = "별명 키워드 검색 + 정렬순 페이지네이션")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminNicknameExhibitResponse>> {
+        log.info("api=GET /api/admin/nickname-exhibits, keyword={}, page={}", keyword, page)
+        return ResponseEntity.ok(adminNicknameExhibitService.search(keyword, page, size))
+    }
+
+    @Operation(summary = "별명 카드 등록")
+    @PostMapping
+    fun create(
+        @Valid @RequestBody request: CreateNicknameExhibitRequest
+    ): ResponseEntity<AdminNicknameExhibitResponse> {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(adminNicknameExhibitService.create(request))
+    }
+
+    @Operation(summary = "별명 카드 수정", description = "전송된 필드만 부분 수정")
+    @PatchMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateNicknameExhibitRequest
+    ): ResponseEntity<AdminNicknameExhibitResponse> {
+        return ResponseEntity.ok(adminNicknameExhibitService.update(id, request))
+    }
+
+    @Operation(summary = "별명 카드 삭제")
+    @DeleteMapping("/{id}")
+    fun delete(@PathVariable id: Long): ResponseEntity<Void> {
+        adminNicknameExhibitService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    // ── 접근 허용 사용자 관리 ──
+
+    @Operation(summary = "접근 허용 사용자 목록", description = "이름/이메일 키워드 검색 + 페이지네이션")
+    @GetMapping("/access")
+    fun searchAccess(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminExhibitAccessResponse>> {
+        return ResponseEntity.ok(adminNicknameExhibitService.searchAccess(keyword, page, size))
+    }
+
+    @Operation(summary = "접근 허용 추가", description = "이미 허용된 사용자면 멱등 처리")
+    @PostMapping("/access")
+    fun addAccess(
+        @Valid @RequestBody request: AddExhibitAccessRequest
+    ): ResponseEntity<AdminExhibitAccessResponse> {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(adminNicknameExhibitService.addAccess(request.userId))
+    }
+
+    @Operation(summary = "접근 허용 해제")
+    @DeleteMapping("/access/{userId}")
+    fun removeAccess(@PathVariable userId: UUID): ResponseEntity<Void> {
+        adminNicknameExhibitService.removeAccess(userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/AddExhibitAccessRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/AddExhibitAccessRequest.kt
@@ -1,0 +1,11 @@
+package digdaserver.admin.nicknameexhibit.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "전시관 접근 허용 추가 요청")
+data class AddExhibitAccessRequest(
+
+    @Schema(description = "허용할 사용자 ID")
+    val userId: UUID
+)

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/CreateNicknameExhibitRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/CreateNicknameExhibitRequest.kt
@@ -1,0 +1,25 @@
+package digdaserver.admin.nicknameexhibit.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "전시관 별명 카드 등록 요청")
+data class CreateNicknameExhibitRequest(
+
+    @field:NotBlank
+    @field:Size(max = 100)
+    @Schema(description = "별명", example = "디그다 박사")
+    val nickname: String,
+
+    @field:Size(max = 512)
+    @Schema(description = "카드 앞면 이미지 URL (선택)")
+    val imageUrl: String? = null,
+
+    @field:NotBlank
+    @Schema(description = "별명이 생긴 배경·역사·설명", example = "2024년 봄, 퀴즈를 가장 많이 만든 유저에게 붙은 별명")
+    val history: String,
+
+    @Schema(description = "목록 정렬 순서 (작을수록 앞). 미전송 시 0.", example = "0")
+    val sortOrder: Int = 0
+)

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/UpdateNicknameExhibitRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/req/UpdateNicknameExhibitRequest.kt
@@ -1,0 +1,25 @@
+package digdaserver.admin.nicknameexhibit.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+/**
+ * 전시관 별명 카드 부분 수정. 모든 필드 선택 — null 이면 변경하지 않음.
+ */
+@Schema(description = "전시관 별명 카드 수정 요청")
+data class UpdateNicknameExhibitRequest(
+
+    @field:Size(max = 100)
+    @Schema(description = "변경할 별명. 미전송 시 변경 없음.")
+    val nickname: String? = null,
+
+    @field:Size(max = 512)
+    @Schema(description = "변경할 이미지 URL. 미전송 시 변경 없음.")
+    val imageUrl: String? = null,
+
+    @Schema(description = "변경할 별명 역사/설명. 미전송 시 변경 없음.")
+    val history: String? = null,
+
+    @Schema(description = "변경할 정렬 순서. 미전송 시 변경 없음.")
+    val sortOrder: Int? = null
+)

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/res/AdminExhibitAccessResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/res/AdminExhibitAccessResponse.kt
@@ -1,0 +1,38 @@
+package digdaserver.admin.nicknameexhibit.presentation.dto.res
+
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibitAccess
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Schema(description = "관리자 전시관 접근 허용 사용자")
+data class AdminExhibitAccessResponse(
+
+    @Schema(description = "사용자 ID")
+    val userId: UUID,
+
+    @Schema(description = "사용자 이름")
+    val name: String,
+
+    @Schema(description = "사용자 이메일")
+    val email: String?,
+
+    @Schema(description = "프로필 이미지 URL")
+    val profileImage: String?,
+
+    @Schema(description = "허용된 시각")
+    val grantedAt: LocalDateTime
+) {
+    companion object {
+        fun from(entity: NicknameExhibitAccess): AdminExhibitAccessResponse {
+            val user = entity.user
+            return AdminExhibitAccessResponse(
+                userId = user.id,
+                name = user.name,
+                email = user.email,
+                profileImage = user.profileImage,
+                grantedAt = entity.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/res/AdminNicknameExhibitResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/dto/res/AdminNicknameExhibitResponse.kt
@@ -1,0 +1,42 @@
+package digdaserver.admin.nicknameexhibit.presentation.dto.res
+
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibit
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "관리자 전시관 별명 카드")
+data class AdminNicknameExhibitResponse(
+
+    @Schema(description = "카드 ID")
+    val id: Long,
+
+    @Schema(description = "별명")
+    val nickname: String,
+
+    @Schema(description = "이미지 URL")
+    val imageUrl: String?,
+
+    @Schema(description = "별명 역사/설명")
+    val history: String,
+
+    @Schema(description = "정렬 순서")
+    val sortOrder: Int,
+
+    @Schema(description = "생성 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "수정 시각")
+    val updatedAt: LocalDateTime
+) {
+    companion object {
+        fun from(entity: NicknameExhibit): AdminNicknameExhibitResponse = AdminNicknameExhibitResponse(
+            id = entity.id,
+            nickname = entity.nickname,
+            imageUrl = entity.imageUrl,
+            history = entity.history,
+            sortOrder = entity.sortOrder,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/application/service/NicknameExhibitService.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/application/service/NicknameExhibitService.kt
@@ -1,0 +1,13 @@
+package digdaserver.domain.nickname_exhibit.application.service
+
+import digdaserver.domain.nickname_exhibit.presentation.dto.res.NicknameExhibitResponse
+import java.util.UUID
+
+interface NicknameExhibitService {
+
+    /** 해당 사용자가 전시관에 접근 가능한지. */
+    fun hasAccess(userId: UUID): Boolean
+
+    /** 전시관 카드 목록. 접근 권한 없으면 EXHIBIT_ACCESS_DENIED. */
+    fun list(userId: UUID): List<NicknameExhibitResponse>
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/application/service/impl/NicknameExhibitServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/application/service/impl/NicknameExhibitServiceImpl.kt
@@ -1,0 +1,31 @@
+package digdaserver.domain.nickname_exhibit.application.service.impl
+
+import digdaserver.domain.nickname_exhibit.application.service.NicknameExhibitService
+import digdaserver.domain.nickname_exhibit.domain.repository.NicknameExhibitAccessRepository
+import digdaserver.domain.nickname_exhibit.domain.repository.NicknameExhibitRepository
+import digdaserver.domain.nickname_exhibit.presentation.dto.res.NicknameExhibitResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class NicknameExhibitServiceImpl(
+    private val nicknameExhibitRepository: NicknameExhibitRepository,
+    private val nicknameExhibitAccessRepository: NicknameExhibitAccessRepository
+) : NicknameExhibitService {
+
+    override fun hasAccess(userId: UUID): Boolean =
+        nicknameExhibitAccessRepository.existsByUserId(userId)
+
+    override fun list(userId: UUID): List<NicknameExhibitResponse> {
+        // 버튼이 노출되지 않아도 직접 호출 가능하므로 목록 조회에서 한 번 더 권한을 확인한다.
+        if (!nicknameExhibitAccessRepository.existsByUserId(userId)) {
+            throw DigdaException(ErrorCode.EXHIBIT_ACCESS_DENIED)
+        }
+        return nicknameExhibitRepository.findAllByOrderBySortOrderAscIdAsc()
+            .map(NicknameExhibitResponse::from)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/entity/NicknameExhibit.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/entity/NicknameExhibit.kt
@@ -1,0 +1,48 @@
+package digdaserver.domain.nickname_exhibit.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * 디그다 역대 별명 전시관의 카드 1장. 재미용 콘텐츠라 그룹/유저에 묶이지 않는 전역 데이터.
+ *
+ * 앞면 = [imageUrl] + [nickname], 뒷면 = [history](별명이 생긴 배경·역사·설명).
+ * 목록은 [sortOrder] 오름차순(동률 시 id 오름차순)으로 노출한다.
+ * 등록/수정/삭제는 모두 어드민에서만 일어난다.
+ */
+@Entity
+@Table(name = "nickname_exhibit")
+class NicknameExhibit(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "nickname_exhibit_id")
+    val id: Long = 0L,
+
+    @Column(nullable = false, length = 100)
+    var nickname: String,
+
+    @Column(name = "image_url", length = 512)
+    var imageUrl: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var history: String,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0
+
+) : BaseTimeEntity() {
+
+    /** 어드민 부분 수정 — null 인 필드는 변경하지 않는다. */
+    fun update(nickname: String?, imageUrl: String?, history: String?, sortOrder: Int?) {
+        nickname?.let { this.nickname = it }
+        imageUrl?.let { this.imageUrl = it }
+        history?.let { this.history = it }
+        sortOrder?.let { this.sortOrder = it }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/entity/NicknameExhibitAccess.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/entity/NicknameExhibitAccess.kt
@@ -1,0 +1,38 @@
+package digdaserver.domain.nickname_exhibit.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+/**
+ * 전시관 접근을 허용받은 사용자. 어드민이 등록/해제한다.
+ * 한 사용자당 1행(unique). 행이 존재하면 모찌 화면 하단 전시관 버튼이 노출된다.
+ */
+@Entity
+@Table(
+    name = "nickname_exhibit_access",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_nickname_exhibit_access_user", columnNames = ["user_id"])
+    ]
+)
+class NicknameExhibitAccess(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "nickname_exhibit_access_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/repository/NicknameExhibitAccessRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/repository/NicknameExhibitAccessRepository.kt
@@ -1,0 +1,35 @@
+package digdaserver.domain.nickname_exhibit.domain.repository
+
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibitAccess
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface NicknameExhibitAccessRepository : JpaRepository<NicknameExhibitAccess, Long> {
+
+    fun existsByUserId(userId: UUID): Boolean
+
+    fun findByUserId(userId: UUID): NicknameExhibitAccess?
+
+    fun deleteByUserId(userId: UUID)
+
+    /** 어드민 허용 목록 — 사용자 join 으로 이름/이메일 키워드 검색. */
+    @Query(
+        """
+        SELECT a FROM NicknameExhibitAccess a
+        JOIN a.user u
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<NicknameExhibitAccess>
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/repository/NicknameExhibitRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/domain/repository/NicknameExhibitRepository.kt
@@ -1,0 +1,29 @@
+package digdaserver.domain.nickname_exhibit.domain.repository
+
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibit
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NicknameExhibitRepository : JpaRepository<NicknameExhibit, Long> {
+
+    /** 앱 노출용 — 정렬 순서대로 전체 목록. */
+    fun findAllByOrderBySortOrderAscIdAsc(): List<NicknameExhibit>
+
+    /** 어드민 페이지네이션 검색 — 별명 LIKE (null/빈 = 무필터). */
+    @Query(
+        """
+        SELECT e FROM NicknameExhibit e
+        WHERE (:keyword IS NULL OR :keyword = ''
+            OR LOWER(e.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """
+    )
+    fun searchForAdmin(
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<NicknameExhibit>
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/controller/NicknameExhibitController.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/controller/NicknameExhibitController.kt
@@ -1,0 +1,48 @@
+package digdaserver.domain.nickname_exhibit.presentation.controller
+
+import digdaserver.domain.nickname_exhibit.application.service.NicknameExhibitService
+import digdaserver.domain.nickname_exhibit.presentation.dto.res.NicknameExhibitAccessResponse
+import digdaserver.domain.nickname_exhibit.presentation.dto.res.NicknameExhibitResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/nickname-exhibits")
+@Tag(name = "Nickname Exhibit", description = "디그다 역대 별명 전시관 API (재미용 콘텐츠)")
+class NicknameExhibitController(
+    private val nicknameExhibitService: NicknameExhibitService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(
+        summary = "전시관 접근 권한 조회",
+        description = "현재 사용자가 전시관에 접근 가능한지(어드민이 허용했는지) 반환. 앱은 이 값으로 버튼 노출을 결정."
+    )
+    @GetMapping("/access")
+    fun checkAccess(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<NicknameExhibitAccessResponse> {
+        val allowed = nicknameExhibitService.hasAccess(UUID.fromString(userId))
+        return ResponseEntity.ok(NicknameExhibitAccessResponse(allowed = allowed))
+    }
+
+    @Operation(
+        summary = "전시관 별명 카드 목록 조회",
+        description = "접근 허용 사용자만 조회 가능. 미허용 시 403(EXHIBIT_ACCESS_DENIED)."
+    )
+    @GetMapping
+    fun list(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<List<NicknameExhibitResponse>> {
+        log.info("api=GET /nickname-exhibits, userId={}", userId)
+        return ResponseEntity.ok(nicknameExhibitService.list(UUID.fromString(userId)))
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/dto/res/NicknameExhibitAccessResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/dto/res/NicknameExhibitAccessResponse.kt
@@ -1,0 +1,10 @@
+package digdaserver.domain.nickname_exhibit.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "전시관 접근 권한 여부")
+data class NicknameExhibitAccessResponse(
+
+    @Schema(description = "전시관 접근 허용 여부")
+    val allowed: Boolean
+)

--- a/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/dto/res/NicknameExhibitResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/nickname_exhibit/presentation/dto/res/NicknameExhibitResponse.kt
@@ -1,0 +1,29 @@
+package digdaserver.domain.nickname_exhibit.presentation.dto.res
+
+import digdaserver.domain.nickname_exhibit.domain.entity.NicknameExhibit
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "전시관 별명 카드")
+data class NicknameExhibitResponse(
+
+    @Schema(description = "카드 ID")
+    val id: Long,
+
+    @Schema(description = "별명")
+    val nickname: String,
+
+    @Schema(description = "카드 앞면 이미지 URL")
+    val imageUrl: String?,
+
+    @Schema(description = "별명이 생긴 배경·역사·설명 (카드 뒷면)")
+    val history: String
+) {
+    companion object {
+        fun from(entity: NicknameExhibit): NicknameExhibitResponse = NicknameExhibitResponse(
+            id = entity.id,
+            nickname = entity.nickname,
+            imageUrl = entity.imageUrl,
+            history = entity.history
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/application/service/impl/UploadServiceImpl.kt
@@ -74,6 +74,7 @@ class UploadServiceImpl(
             "group_thumbnail" -> ImagePurpose.GROUP_THUMBNAIL
             "diary" -> ImagePurpose.DIARY
             "quiz" -> ImagePurpose.QUIZ
+            "exhibit" -> ImagePurpose.EXHIBIT
             else -> throw DigdaException(ErrorCode.INVALID_PARAMETER)
         }
     }

--- a/src/main/kotlin/digdaserver/domain/upload/domain/entity/ImagePurpose.kt
+++ b/src/main/kotlin/digdaserver/domain/upload/domain/entity/ImagePurpose.kt
@@ -5,5 +5,6 @@ enum class ImagePurpose {
     PROFILE,
     GROUP_THUMBNAIL,
     DIARY,
-    QUIZ;
+    QUIZ,
+    EXHIBIT;
 }

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -120,6 +120,10 @@ enum class ErrorCode(
     QUIZ_INVALID_MULTIPLIER("QUIZ_INVALID_MULTIPLIER", "EXP 배수는 1-3 사이여야 합니다.", 400),
     QUIZ_IMAGE_REQUIRES_DIKO("QUIZ_IMAGE_REQUIRES_DIKO", "사진 퀴즈는 디코가 등장한 그룹에서만 사용할 수 있어요.", 400),
 
+    // ── Nickname Exhibit (역대 별명 전시관) ──
+    EXHIBIT_NOT_FOUND("EXHIBIT_NOT_FOUND", "존재하지 않는 전시관 카드입니다.", 404),
+    EXHIBIT_ACCESS_DENIED("EXHIBIT_ACCESS_DENIED", "전시관 접근 권한이 없습니다.", 403),
+
     // ── Rate Limit ──
     RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),
 


### PR DESCRIPTION
@
## 개요
역대 별명 전시관 백엔드 구현.

## 변경 사항
- feat(exhibit): 역대 별명 전시관 백엔드 — 엔티티·앱/어드민 API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@