### PR TITLE
fix(exhibit): KDoc 내 /** 로 인한 Unclosed comment 컴파일 오류 수정

### DIFF
--- a/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/controller/AdminNicknameExhibitController.kt
+++ b/src/main/kotlin/digdaserver/admin/nicknameexhibit/presentation/controller/AdminNicknameExhibitController.kt
@@ -29,7 +29,7 @@ import java.util.UUID
  * - 별명 카드(콘텐츠) CRUD
  * - 접근 허용 사용자 등록/조회/해제
  *
- * `/api/admin/**` 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ * 관리자 전용 경로(`/api/admin` 하위)는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
  */
 @RestController
 @RequestMapping("/api/admin/nickname-exhibits")
@@ -56,7 +56,8 @@ class AdminNicknameExhibitController(
     @Operation(summary = "별명 카드 등록")
     @PostMapping
     fun create(
-        @Valid @RequestBody request: CreateNicknameExhibitRequest
+        @Valid @RequestBody
+        request: CreateNicknameExhibitRequest
     ): ResponseEntity<AdminNicknameExhibitResponse> {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(adminNicknameExhibitService.create(request))
@@ -66,7 +67,8 @@ class AdminNicknameExhibitController(
     @PatchMapping("/{id}")
     fun update(
         @PathVariable id: Long,
-        @Valid @RequestBody request: UpdateNicknameExhibitRequest
+        @Valid @RequestBody
+        request: UpdateNicknameExhibitRequest
     ): ResponseEntity<AdminNicknameExhibitResponse> {
         return ResponseEntity.ok(adminNicknameExhibitService.update(id, request))
     }
@@ -93,7 +95,8 @@ class AdminNicknameExhibitController(
     @Operation(summary = "접근 허용 추가", description = "이미 허용된 사용자면 멱등 처리")
     @PostMapping("/access")
     fun addAccess(
-        @Valid @RequestBody request: AddExhibitAccessRequest
+        @Valid @RequestBody
+        request: AddExhibitAccessRequest
     ): ResponseEntity<AdminExhibitAccessResponse> {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(adminNicknameExhibitService.addAccess(request.userId))


### PR DESCRIPTION
@
## 문제
`./gradlew compileKotlin` 실패:
```
AdminNicknameExhibitController.kt:109:1 Unclosed comment
```

## 원인
KDoc(`/** ... */`) 본문에 `` `/api/admin/**` `` 가 들어가, 그 안의 `/**` 가
Kotlin 의 **중첩 블록 주석**을 한 단계 더 열었다. 닫는 `*/` 는 중첩분만 닫고
최상위 주석이 EOF 까지 닫히지 않아 컴파일이 깨졌다.

## 수정
경로 표기를 `` `/api/admin` 하위 `` 로 바꿔 `/**` 시퀀스 제거. `ktlintFormat` + `compileKotlin` 통과 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@