### PR TITLE
fix(upload): 별명전시관 EXHIBIT 업로드 500 — uploaded_image.purpose enum drift 정정

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -35,6 +35,9 @@ class SchemaAutoMigration(
      * - `notification.type`: 초기 MySQL ENUM(8) 으로 생성됐는데 이후 [NotificationType]
      *    에 값이 추가되면서 insert 가 "Data truncated" 로 실패. 새 enum 값 추가 시마다
      *    SQL 을 손대지 않도록 VARCHAR(64) 로 일반화.
+     * - `uploaded_image.purpose`: 초기 MySQL ENUM 으로 생성됐는데 별명전시관 도입으로
+     *    [ImagePurpose] 에 EXHIBIT 가 추가되면서 purpose=exhibit 업로드가 "Data truncated"
+     *    로 500. notification.type 과 동일하게 VARCHAR(64) 로 일반화.
      */
     private val requiredColumns: List<RequiredColumn> = listOf(
         RequiredColumn(
@@ -44,6 +47,14 @@ class SchemaAutoMigration(
             expectedMaxLength = 64,
             nullable = false,
             alterSql = "ALTER TABLE notification MODIFY COLUMN type VARCHAR(64) NOT NULL"
+        ),
+        RequiredColumn(
+            table = "uploaded_image",
+            column = "purpose",
+            expectedDataType = "varchar",
+            expectedMaxLength = 64,
+            nullable = false,
+            alterSql = "ALTER TABLE uploaded_image MODIFY COLUMN purpose VARCHAR(64) NOT NULL"
         ),
         // 작성자 회원탈퇴 시 퀴즈를 보존(author=NULL)하려면 author_id 가 NULL 허용이어야 한다.
         // 기존 prod 컬럼은 BINARY(16) NOT NULL 이라 nullable 로 완화. FK 제약은 그대로 유지된다.


### PR DESCRIPTION
## 증상
별명전시관에서 사진 넣고 저장 시 `POST /uploads/images` 가 500.

## 원인
`uploaded_image.purpose` 는 `@Enumerated(STRING)` 컬럼. prod 는 `ddl-auto=none` 이라 이 컬럼이 구 enum 값(PROFILE/GROUP_THUMBNAIL/DIARY/QUIZ)만 담는 MySQL ENUM 으로 굳어 있어, 별명전시관이 추가한 신규 값 `EXHIBIT` INSERT 시 "Data truncated for column 'purpose'" 로 실패 → 500. (S3 업로드는 성공 후 DB save 에서 터짐)

## 조치
`notification.type` 과 동일 패턴으로 `SchemaAutoMigration.requiredColumns` 에 추가 → 부팅 시 `VARCHAR(64) NOT NULL` 로 멱등 정정. 이미 VARCHAR 면 skip.

ktlintFormat / compileKotlin 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)