### PR TITLE
feat(diary): 시그니처 지도 — 일기 지역 필드 + 지역지도 집계/지역별 일기 API

### DIFF
--- a/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
@@ -8,6 +8,7 @@ import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryRegionMapResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import java.time.YearMonth
 import java.util.UUID
@@ -15,6 +16,18 @@ import java.util.UUID
 interface DiaryService {
 
     fun getDiaries(userId: UUID, groupRoomId: Long, month: YearMonth?, limit: Int, offset: Int): DiaryListResponse
+
+    /** 시그니처 지도 — 그룹의 지역별 일기 수 집계. */
+    fun getDiaryRegionMap(userId: UUID, groupRoomId: Long): DiaryRegionMapResponse
+
+    /** 시그니처 지도 — 특정 지역(regionKey)의 그룹 일기 목록. */
+    fun getDiariesByRegion(
+        userId: UUID,
+        groupRoomId: Long,
+        regionKey: String,
+        limit: Int,
+        offset: Int
+    ): DiaryListResponse
 
     fun getDiaryCalendar(userId: UUID, groupRoomId: Long, month: YearMonth): DiaryCalendarResponse
 

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -23,6 +23,8 @@ import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryReactionSummary
 import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryRegionCount
+import digdaserver.domain.diary.presentation.dto.res.DiaryRegionMapResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import digdaserver.domain.diary.presentation.dto.res.DiarySummaryResponse
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
@@ -101,6 +103,38 @@ class DiaryServiceImpl(
             diaryRepository.findAllByGroupRoomId(groupRoomId, pageable)
         }
 
+        return buildListResponse(page, userId)
+    }
+
+    override fun getDiaryRegionMap(userId: UUID, groupRoomId: Long): DiaryRegionMapResponse {
+        ensureMember(userId, groupRoomId)
+        val rows = diaryRepository.countByRegionKey(groupRoomId)
+        val regions = rows.map { row ->
+            DiaryRegionCount(regionKey = row[0] as String, count = row[1] as Long)
+        }
+        val total = regions.sumOf { it.count }
+        log.info("action=일기 지역지도 집계, groupRoomId={}, regions={}, total={}", groupRoomId, regions.size, total)
+        return DiaryRegionMapResponse(regions = regions, total = total)
+    }
+
+    override fun getDiariesByRegion(
+        userId: UUID,
+        groupRoomId: Long,
+        regionKey: String,
+        limit: Int,
+        offset: Int
+    ): DiaryListResponse {
+        ensureMember(userId, groupRoomId)
+        val pageable = PageRequest.of(offset / limit, limit)
+        val page = diaryRepository.findAllByGroupRoomIdAndRegionKey(groupRoomId, regionKey, pageable)
+        return buildListResponse(page, userId)
+    }
+
+    /** Page<Diary> → 댓글·좋아요 수를 채운 DiaryListResponse 로 변환(목록 응답 공통). */
+    private fun buildListResponse(
+        page: org.springframework.data.domain.Page<Diary>,
+        userId: UUID
+    ): DiaryListResponse {
         val diaries = page.content
         val diaryIds = diaries.map { it.id }
 
@@ -247,6 +281,9 @@ class DiaryServiceImpl(
             weather = request.weather,
             mood = request.mood,
             location = request.location?.takeIf { it.isNotBlank() },
+            regionKey = request.regionKey?.takeIf { it.isNotBlank() },
+            regionSido = request.regionSido?.takeIf { it.isNotBlank() },
+            regionSigungu = request.regionSigungu?.takeIf { it.isNotBlank() },
             createdBy = user
         )
         diary.replaceImages(resolvedUrls)
@@ -313,7 +350,10 @@ class DiaryServiceImpl(
             date = request.date,
             weather = request.weather,
             mood = request.mood,
-            location = request.location?.takeIf { it.isNotBlank() }
+            location = request.location?.takeIf { it.isNotBlank() },
+            regionKey = request.regionKey?.takeIf { it.isNotBlank() },
+            regionSido = request.regionSido?.takeIf { it.isNotBlank() },
+            regionSigungu = request.regionSigungu?.takeIf { it.isNotBlank() }
         )
         request.imageIds?.let { ids ->
             diary.replaceImages(resolveImageUrls(ids))

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
@@ -48,6 +48,21 @@ class Diary(
     @Column(name = "location", length = 100)
     var location: String? = null,
 
+    /**
+     * 시그니처 지도 색칠용 정규 지역 키. 앱이 색칠 분류의 단일 소스이므로 앱에서 산출해 보낸다.
+     * 광역시·세종 = 시도명("인천"), 도 = 시·군명("남원시"; 통합시는 일반구 합산해 母市 "창원시").
+     */
+    @Column(name = "region_key", length = 40)
+    var regionKey: String? = null,
+
+    /** 표시용 시도명 (예: "전북특별자치도"). */
+    @Column(name = "region_sido", length = 30)
+    var regionSido: String? = null,
+
+    /** 표시용 시군구명 (예: "남원시", "창원시 성산구"). */
+    @Column(name = "region_sigungu", length = 60)
+    var regionSigungu: String? = null,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by", nullable = false)
     val createdBy: User,
@@ -64,14 +79,21 @@ class Diary(
         date: LocalDate?,
         weather: Int?,
         mood: Int?,
-        location: String?
+        location: String?,
+        regionKey: String?,
+        regionSido: String?,
+        regionSigungu: String?
     ) {
         title?.let { this.title = it }
         content?.let { this.content = it }
         date?.let { this.date = it }
         weather?.let { this.weather = it }
         mood?.let { this.mood = it }
+        // location 과 지역은 항상 요청값으로 덮어쓴다(빈 값 = 위치 제거 의도).
         this.location = location
+        this.regionKey = regionKey
+        this.regionSido = regionSido
+        this.regionSigungu = regionSigungu
     }
 
     /** 이미지를 전부 재구성. urls 순서대로 sort_order 0..N-1 부여. */

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -53,4 +53,23 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
     @Modifying
     @Query("DELETE FROM Diary d WHERE d.createdBy.id = :userId")
     fun deleteAllByCreatedById(@Param("userId") userId: UUID)
+
+    /**
+     * 시그니처 지도 — 그룹의 region_key 별 일기 수 집계. region_key 가 있는 일기만 대상.
+     * 각 row = [regionKey(String), count(Long)].
+     */
+    @Query(
+        "SELECT d.regionKey, COUNT(d) FROM Diary d " +
+            "WHERE d.groupRoom.id = :groupRoomId AND d.regionKey IS NOT NULL " +
+            "GROUP BY d.regionKey"
+    )
+    fun countByRegionKey(@Param("groupRoomId") groupRoomId: Long): List<Array<Any>>
+
+    /** 시그니처 지도 — 특정 region_key 의 그룹 일기 목록(최신순). */
+    @Query("SELECT d FROM Diary d WHERE d.groupRoom.id = :groupRoomId AND d.regionKey = :regionKey ORDER BY d.date DESC, d.createdAt DESC")
+    fun findAllByGroupRoomIdAndRegionKey(
+        @Param("groupRoomId") groupRoomId: Long,
+        @Param("regionKey") regionKey: String,
+        pageable: Pageable
+    ): Page<Diary>
 }

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
@@ -9,6 +9,7 @@ import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryRegionMapResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -53,6 +54,32 @@ class DiaryController(
         @RequestParam month: YearMonth
     ): ResponseEntity<DiaryCalendarResponse> {
         val response = diaryService.getDiaryCalendar(UUID.fromString(userId), groupRoomId, month)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(
+        summary = "일기 지역지도 집계",
+        description = "시그니처 지도용. 그룹의 region_key 별 일기 수를 집계해 반환합니다. 색칠 임계값 판정은 앱이 수행."
+    )
+    @GetMapping("/group-rooms/{groupRoomId}/diaries/region-map")
+    fun getDiaryRegionMap(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long
+    ): ResponseEntity<DiaryRegionMapResponse> {
+        val response = diaryService.getDiaryRegionMap(UUID.fromString(userId), groupRoomId)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "지역별 일기 목록", description = "시그니처 지도에서 특정 지역(regionKey)을 선택했을 때의 일기 목록.")
+    @GetMapping("/group-rooms/{groupRoomId}/diaries/by-region")
+    fun getDiariesByRegion(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestParam regionKey: String,
+        @RequestParam(defaultValue = "20") limit: Int,
+        @RequestParam(defaultValue = "0") offset: Int
+    ): ResponseEntity<DiaryListResponse> {
+        val response = diaryService.getDiariesByRegion(UUID.fromString(userId), groupRoomId, regionKey, limit, offset)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/CreateDiaryRequest.kt
@@ -9,6 +9,12 @@ data class CreateDiaryRequest(
     val weather: Int,
     val mood: Int,
     val location: String? = null,
+    /** 시그니처 지도 색칠용 정규 지역 키(앱 산출). 광역시=시도명, 도=시·군명. */
+    val regionKey: String? = null,
+    /** 표시용 시도명. */
+    val regionSido: String? = null,
+    /** 표시용 시군구명. */
+    val regionSigungu: String? = null,
     /** UploadedImage.id (Long) 의 문자열 리스트. 0..10 장. 순서대로 sort_order 부여. */
     val imageIds: List<String> = emptyList()
 )

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/req/UpdateDiaryRequest.kt
@@ -15,6 +15,10 @@ data class UpdateDiaryRequest(
     val weather: Int? = null,
     val mood: Int? = null,
     val location: String? = null,
+    /** 시그니처 지도 색칠용 정규 지역 키(앱 산출). location 과 함께 항상 덮어쓴다. */
+    val regionKey: String? = null,
+    val regionSido: String? = null,
+    val regionSigungu: String? = null,
     /** null = 이미지 변경 없음. 빈 리스트 = 이미지 전부 제거. 값 있으면 그 순서대로 교체. */
     val imageIds: List<String>? = null
 )

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryRegionMapResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryRegionMapResponse.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+/**
+ * 시그니처 지도 — 그룹의 지역별 일기 수 집계 응답.
+ *
+ * 색칠 임계값(군·시=1, 광역시=10) 판정은 앱이 로컬 지도 에셋의 metro 플래그로 수행하므로,
+ * 서버는 region_key 별 raw count 만 내려준다.
+ */
+data class DiaryRegionMapResponse(
+    val regions: List<DiaryRegionCount>,
+    /** region_key 가 지정된 전체 일기 수(분류된 기록 총합). */
+    val total: Long
+)
+
+data class DiaryRegionCount(
+    val regionKey: String,
+    val count: Long
+)

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -90,6 +90,23 @@ class SchemaAutoMigration(
             column = "image_url",
             addSql = "ALTER TABLE character_quiz ADD COLUMN image_url VARCHAR(2048) NULL"
         ),
+        // 시그니처 지도 — 일기 지역 색칠용. 앱이 산출한 정규 지역 키/표시명을 저장.
+        // 기존 일기는 NULL(지도 미반영). NULL 허용이라 추가만으로 충분.
+        MissingColumn(
+            table = "diary",
+            column = "region_key",
+            addSql = "ALTER TABLE diary ADD COLUMN region_key VARCHAR(40) NULL"
+        ),
+        MissingColumn(
+            table = "diary",
+            column = "region_sido",
+            addSql = "ALTER TABLE diary ADD COLUMN region_sido VARCHAR(30) NULL"
+        ),
+        MissingColumn(
+            table = "diary",
+            column = "region_sigungu",
+            addSql = "ALTER TABLE diary ADD COLUMN region_sigungu VARCHAR(60) NULL"
+        ),
         // 마스터 진화 시험 통과 여부. 기존에 이미 레벨 20 에 도달해 MASTER 로 보이던 그룹은
         // 컬럼 추가 시 false 로 들어가 GLOW 로 후퇴하는 회귀가 생기므로, level>=20 인 행은
         // 곧바로 true 로 backfill 해 마스터 상태를 보존한다.


### PR DESCRIPTION
디그팟 시그니처 지도 기능의 서버 1차.

## 변경
- Diary 에 `region_key`/`region_sido`/`region_sigungu` 추가. 색칠키 분류의 단일 소스는 앱(시도/통합시 로직 보유)이라 앱이 산출해 전송.
- SchemaAutoMigration: nullable ADD COLUMN 3건. 기존 일기는 NULL(지도 미반영) — 안전.
- Create/Update 요청에 지역 필드 수용.
- `GET /group-rooms/{id}/diaries/region-map`: region_key 별 일기 수 집계(임계값 판정은 앱).
- `GET /group-rooms/{id}/diaries/by-region?regionKey=`: 지역별 일기 목록.

전부 additive. ktlintFormat/compileKotlin 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)