### PR TITLE
feat/fix: 퀴즈 재풀이 모드 + 멀티데이 리마인더 + 시그니처 지도 성능

### DIFF
--- a/src/main/kotlin/digdaserver/domain/character/application/service/CharacterQuizService.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/CharacterQuizService.kt
@@ -22,10 +22,15 @@ interface CharacterQuizService {
     /** 풀기 가능한(자기 작성 X, 미응시) 퀴즈 1건 랜덤. 없으면 4xx. */
     fun pickRandom(userId: UUID, groupRoomId: Long): CharacterQuizResponse
 
-    /** 퀴즈 응시. 보상 자동 적용 후 캐릭터 상태 포함 응답. */
+    /**
+     * 퀴즈 응시. 보상 자동 적용 후 캐릭터 상태 포함 응답.
+     * [practice] 가 true 면 재풀이(연습) 모드 — 이미 푼 문제·본인 출제도 가능하고
+     * 보상(경험치/코인)·기록·알림 없이 정답 여부만 돌려준다.
+     */
     fun submitAttempt(
         userId: UUID,
         quizId: Long,
-        selectedIndex: Int
+        selectedIndex: Int,
+        practice: Boolean = false
     ): QuizAttemptResultResponse
 }

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -163,7 +163,8 @@ class CharacterQuizServiceImpl(
     override fun submitAttempt(
         userId: UUID,
         quizId: Long,
-        selectedIndex: Int
+        selectedIndex: Int,
+        practice: Boolean
     ): QuizAttemptResultResponse {
         if (selectedIndex !in 1..OPTION_COUNT) {
             throw DigdaException(ErrorCode.QUIZ_INVALID_CORRECT_INDEX)
@@ -172,14 +173,37 @@ class CharacterQuizServiceImpl(
         val quiz = quizRepository.findById(quizId)
             .orElseThrow { DigdaException(ErrorCode.QUIZ_NOT_FOUND) }
 
-        // 작성자 탈퇴(author=null)면 본인 출제 제한 대상이 아니므로 누구나 응시 가능.
-        if (quiz.author?.id == userId) throw DigdaException(ErrorCode.QUIZ_CANNOT_ATTEMPT_OWN)
         validateGroupMember(quiz.groupRoom.id, userId)
 
         // 사진 퀴즈는 디코가 풀린 그룹에서만 응시 가능. URL 우회 방어용.
         if (quiz.imageUrl != null && !isDikoUnlocked(quiz.groupRoom.id)) {
             throw DigdaException(ErrorCode.QUIZ_IMAGE_REQUIRES_DIKO)
         }
+
+        // 연습(재풀이) 모드: 본인 출제·이미 푼 문제 제한 없이 정답만 채점하고
+        // 보상/기록/알림 없이 현재 캐릭터 상태를 그대로 돌려준다.
+        if (practice) {
+            val correctPractice = selectedIndex == quiz.correctIndex
+            val character = loadOrCreateGroupCharacter(quiz.groupRoom.id)
+            val equipped = groupCharacterEquippedRepository.findAllByGroupRoomId(quiz.groupRoom.id)
+            return QuizAttemptResultResponse(
+                quizId = quiz.id,
+                correct = correctPractice,
+                correctIndex = quiz.correctIndex,
+                selectedIndex = selectedIndex,
+                earnedExp = 0,
+                earnedCoin = 0,
+                character = CharacterStateResponse.from(character, equipped),
+                levelGained = 0,
+                stageBefore = character.stage,
+                stageAfter = character.stage,
+                stageChanged = false,
+                dikoJustUnlocked = false
+            )
+        }
+
+        // 작성자 탈퇴(author=null)면 본인 출제 제한 대상이 아니므로 누구나 응시 가능.
+        if (quiz.author?.id == userId) throw DigdaException(ErrorCode.QUIZ_CANNOT_ATTEMPT_OWN)
 
         if (attemptRepository.existsByQuizIdAndUserId(quizId, userId)) {
             throw DigdaException(ErrorCode.QUIZ_ALREADY_ATTEMPTED)

--- a/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterQuizController.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/controller/CharacterQuizController.kt
@@ -89,7 +89,8 @@ class CharacterQuizController(
             characterQuizService.submitAttempt(
                 UUID.fromString(userId),
                 quizId,
-                request.selectedIndex
+                request.selectedIndex,
+                request.practice
             )
         )
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/req/SubmitAttemptRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/req/SubmitAttemptRequest.kt
@@ -1,5 +1,7 @@
 package digdaserver.domain.character.presentation.dto.req
 
 data class SubmitAttemptRequest(
-    val selectedIndex: Int
+    val selectedIndex: Int,
+    /** 연습(재풀이) 모드. true 면 이미 푼 문제·본인 출제도 풀 수 있고 보상(경험치/코인)은 없다. */
+    val practice: Boolean = false
 )

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -93,7 +93,9 @@ class DiaryServiceImpl(
     ): DiaryListResponse {
         ensureMember(userId, groupRoomId)
 
-        val pageable = PageRequest.of(offset / limit, limit, Sort.by(Sort.Direction.DESC, "createdAt"))
+        // limit=0 같은 값이 와도 0-나눗셈/IllegalArgument 로 500 나지 않도록 하한 보정.
+        val safeLimit = limit.coerceAtLeast(1)
+        val pageable = PageRequest.of(offset / safeLimit, safeLimit, Sort.by(Sort.Direction.DESC, "createdAt"))
 
         val page = if (month != null) {
             val startDate = month.atDay(1)
@@ -125,7 +127,8 @@ class DiaryServiceImpl(
         offset: Int
     ): DiaryListResponse {
         ensureMember(userId, groupRoomId)
-        val pageable = PageRequest.of(offset / limit, limit)
+        val safeLimit = limit.coerceAtLeast(1)
+        val pageable = PageRequest.of(offset / safeLimit, safeLimit)
         val page = diaryRepository.findAllByGroupRoomIdAndRegionKey(groupRoomId, regionKey, pageable)
         return buildListResponse(page, userId)
     }

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
@@ -18,7 +19,14 @@ import jakarta.persistence.Table
 import java.time.LocalDate
 
 @Entity
-@Table(name = "diary")
+@Table(
+    name = "diary",
+    // 시그니처 지도 집계(GROUP BY region_key)·지역별 일기 목록(WHERE region_key)이
+    // 그룹 단위로 풀스캔되지 않도록 복합 인덱스. prod 는 SchemaAutoMigration 에서 동일 인덱스를 멱등 생성.
+    indexes = [
+        Index(name = "idx_diary_group_region", columnList = "group_room_id, region_key")
+    ]
+)
 class Diary(
 
     @Id

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -280,8 +281,14 @@ class NotificationServiceImpl(
         val uniqueRecipientIds = recipientUserIds.distinct()
         if (uniqueRecipientIds.isEmpty()) return
 
-        // 동일 일정에 같은 종류의 리마인더가 이미 발송된 경우 중복 발송하지 않는다.
-        if (notificationRepository.existsByTypeAndRelatedId(type, scheduleId)) return
+        // 동일 일정·동일 종류의 리마인더가 '최근 시간창 안'에 이미 발송됐으면 건너뛴다.
+        // 전역 1회가 아니라 시간창으로 봐야, 멀티데이 일정의 당일 알림이 날마다 1번씩 간다
+        // (같은 날 09/12/18 슬롯 중복은 막고, 다음 날엔 다시 발송).
+        if (notificationRepository.existsByTypeAndRelatedIdAndCreatedAtAfter(
+                type, scheduleId, LocalDateTime.now().minusHours(REMINDER_DEDUP_WINDOW_HOURS))
+        ) {
+            return
+        }
 
         val groupRoom = findGroupRoom(groupRoomId)
         val recipients = userRepository.findAllById(uniqueRecipientIds).toList()
@@ -564,5 +571,9 @@ class NotificationServiceImpl(
 
     companion object {
         private const val ANNOUNCEMENT_BATCH_SIZE = 500
+
+        // 일정 리마인더 중복 판정 시간창(시간). 같은 날 슬롯(09/12/18시) 사이는 막고,
+        // 다음 날 첫 슬롯(전날 마지막 18시→09시=15h)은 통과하도록 12h 로 둔다.
+        private const val REMINDER_DEDUP_WINDOW_HOURS = 12L
     }
 }

--- a/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/domain/repository/NotificationRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -18,8 +19,16 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
 
     fun countByUserIdAndIsReadFalse(userId: UUID): Int
 
-    /** 특정 일정(relatedId)에 대해 해당 종류의 알림이 이미 발송되었는지 확인 — 리마인더 중복 발송 방지. */
-    fun existsByTypeAndRelatedId(type: NotificationType, relatedId: Long): Boolean
+    /**
+     * 특정 일정에 대해 해당 종류의 리마인더가 [after] 이후에 발송됐는지 확인.
+     * 멀티데이 당일 리마인더를 '날마다 1회'로 보내기 위해, 전역 1회가 아니라 시간창(예: 12h)
+     * 안에서만 중복으로 본다 — 같은 날 여러 슬롯(09/12/18시)은 막고, 다음 날엔 다시 보낸다.
+     */
+    fun existsByTypeAndRelatedIdAndCreatedAtAfter(
+        type: NotificationType,
+        relatedId: Long,
+        after: LocalDateTime
+    ): Boolean
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.user.id = :userId AND n.isRead = false")

--- a/src/main/kotlin/digdaserver/domain/schedule/application/scheduler/ScheduleReminderScheduler.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/scheduler/ScheduleReminderScheduler.kt
@@ -18,11 +18,12 @@ import java.util.UUID
  *
  * - KST 09:00 / 12:00 / 18:00 세 슬롯에서만 실행. 9시 이후 등록된 일정이라도
  *   같은 날 안에 다음 슬롯이 따라잡아 발송한다. 중복 방지는 [NotificationService] 가 담당.
- * - 시작일이 "내일"인 일정 → 하루 전 리마인더(SCHEDULE_DAY_BEFORE).
- * - 시작일이 "오늘"인 일정 → 당일 리마인더(SCHEDULE_TODAY).
+ * - 시작일이 "내일"인 일정 → 하루 전 리마인더(SCHEDULE_DAY_BEFORE), 시작 하루 전 1회.
+ * - "오늘" 진행 중인(시작일 ≤ 오늘 ≤ 종료일) 일정 → 당일 리마인더(SCHEDULE_TODAY).
+ *   멀티데이 일정은 중간 날에도 당일 알림이 간다(예: 6~8일 일정이면 6·7·8일 모두).
  * - 발송 대상: 일정 참가자 전원 + 일정을 생성한 사람(중복은 제거).
- * - 중복 발송 방지는 [NotificationService] 내부에서 처리한다. 동일 일정·동일 종류의
- *   리마인더가 이미 존재하면 건너뛰므로, 잡이 다른 슬롯에서 다시 돌아도 같은 알림이 두 번 가지 않는다.
+ * - 중복 발송 방지는 [NotificationService] 가 시간창(12h) 멱등으로 처리한다. 같은 날
+ *   여러 슬롯의 중복은 막고, 멀티데이의 다음 날 당일 알림은 통과시킨다.
  * - row 단위 격리: 한 일정의 처리가 실패해도 나머지 일정은 계속 처리한다.
  */
 @Component
@@ -42,7 +43,7 @@ class ScheduleReminderScheduler(
      * 부팅 직후 catch-up. cron 슬롯은 09/12/18시 정각에만 발사되므로
      * 그 사이에 재배포/재시작이 끼면 그날치 리마인더가 유실될 수 있다.
      * 첫 슬롯(09:00) 이전엔 너무 이른 발송이라 건너뛰고, 그 외엔 catch-up 실행.
-     * 멱등 가드(`existsByTypeAndRelatedId`)가 있어 cron 이 이미 보냈으면 중복 발송되지 않는다.
+     * 시간창(12h) 멱등 가드가 있어 cron 이 이미 보냈으면 중복 발송되지 않는다.
      */
     @EventListener(ApplicationReadyEvent::class)
     fun catchUpOnStartup() {
@@ -69,7 +70,13 @@ class ScheduleReminderScheduler(
 
     private fun dispatch(targetDate: LocalDate, isToday: Boolean) {
         val label = if (isToday) "당일" else "하루 전"
-        val schedules = scheduleRepository.findAllForReminder(targetDate)
+        // 당일 리마인더는 그날 '진행 중'인 일정 전체(멀티데이 중간 날 포함)를 대상으로 한다.
+        // 하루 전 리마인더는 '시작일이 내일'인 일정만(시작 하루 전 1회).
+        val schedules = if (isToday) {
+            scheduleRepository.findAllActiveOnDate(targetDate)
+        } else {
+            scheduleRepository.findAllForReminder(targetDate)
+        }
         if (schedules.isEmpty()) {
             // 0건도 항상 로그 — 스케줄러가 살아 있는지 / 쿼리 결과가 비는 건지 구분 가능하게.
             log.info(

--- a/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/domain/repository/ScheduleRepository.kt
@@ -30,6 +30,19 @@ interface ScheduleRepository : JpaRepository<Schedule, Long> {
     )
     fun findAllForReminder(@Param("date") date: LocalDate): List<Schedule>
 
+    /**
+     * [date] 에 진행 중인(시작일 ≤ date ≤ 종료일) 삭제되지 않은 그룹방의 일정 — 당일 리마인더 대상.
+     * 멀티데이 일정은 중간 날에도 잡혀, 6~8일 일정이면 7·8일에도 당일 알림이 간다.
+     */
+    @Query(
+        """
+        SELECT DISTINCT s FROM Schedule s
+        LEFT JOIN FETCH s.participants
+        WHERE s.startDate <= :date AND s.endDate >= :date AND s.groupRoom.deletedAt IS NULL
+        """
+    )
+    fun findAllActiveOnDate(@Param("date") date: LocalDate): List<Schedule>
+
     @Query(
         """
         SELECT s FROM Schedule s

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -103,11 +103,27 @@ class SchemaAutoMigration(
         )
     )
 
+    /**
+     * 누락 인덱스 보강용 — 엔티티에는 있지만 prod 테이블에 아직 없는 인덱스를 멱등하게 CREATE.
+     * MySQL 은 `CREATE INDEX IF NOT EXISTS` 를 지원하지 않으므로 STATISTICS 로 존재 확인 후 생성.
+     *
+     * - `idx_diary_group_region`: 시그니처 지도 집계(GROUP BY region_key)·지역별 일기 목록이
+     *    그룹 단위로 풀스캔되지 않도록. data 가 쌓일수록 region-map 조회가 느려지던 원인.
+     */
+    private val missingIndexes: List<MissingIndex> = listOf(
+        MissingIndex(
+            table = "diary",
+            indexName = "idx_diary_group_region",
+            createSql = "CREATE INDEX idx_diary_group_region ON diary (group_room_id, region_key)"
+        )
+    )
+
     override fun run(args: ApplicationArguments?) {
         log.info(
-            "action=startup schema auto-migration 시작, modify={}건, addIfMissing={}건",
+            "action=startup schema auto-migration 시작, modify={}건, addIfMissing={}건, addIndex={}건",
             requiredColumns.size,
-            missingColumns.size
+            missingColumns.size,
+            missingIndexes.size
         )
         for (rc in requiredColumns) {
             try {
@@ -136,7 +152,62 @@ class SchemaAutoMigration(
                 )
             }
         }
+        for (mi in missingIndexes) {
+            try {
+                addIndexIfMissing(mi)
+            } catch (e: Exception) {
+                log.error(
+                    "action=startup schema auto-migration INDEX 실패, table={}, index={}, error={}",
+                    mi.table,
+                    mi.indexName,
+                    e.message,
+                    e
+                )
+            }
+        }
         log.info("action=startup schema auto-migration 완료")
+    }
+
+    private fun addIndexIfMissing(mi: MissingIndex) {
+        val exists = try {
+            val count = jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = ?
+                  AND INDEX_NAME = ?
+                """.trimIndent(),
+                Int::class.java,
+                mi.table,
+                mi.indexName
+            ) ?: 0
+            count > 0
+        } catch (e: DataAccessException) {
+            log.warn(
+                "action=startup schema auto-migration 인덱스 메타 조회 실패, table={}, index={}, error={}",
+                mi.table,
+                mi.indexName,
+                e.message
+            )
+            // 메타 조회 실패 시 중복 생성 위험을 피해 스킵.
+            return
+        }
+        if (exists) {
+            log.info(
+                "action=startup schema auto-migration INDEX 스킵(이미 있음), table={}, index={}",
+                mi.table,
+                mi.indexName
+            )
+            return
+        }
+        log.warn(
+            "action=startup schema auto-migration INDEX 생성, table={}, index={}, sql={}",
+            mi.table,
+            mi.indexName,
+            mi.createSql
+        )
+        jdbcTemplate.execute(mi.createSql)
     }
 
     private fun addIfMissing(mc: MissingColumn) {
@@ -275,5 +346,11 @@ class SchemaAutoMigration(
         val column: String,
         val addSql: String,
         val postSql: List<String> = emptyList()
+    )
+
+    private data class MissingIndex(
+        val table: String,
+        val indexName: String,
+        val createSql: String
     )
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,6 +28,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
+        # 목록 응답에서 LAZY images·createdBy 를 IN(...) 으로 일괄 로드해 N+1 제거.
+        default_batch_fetch_size: 100
     open-in-view: false
 
   redis:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,6 +32,8 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        # 목록 응답에서 LAZY images·createdBy 를 IN(...) 으로 일괄 로드해 N+1 제거.
+        default_batch_fetch_size: 100
     open-in-view: false
 
   redis:


### PR DESCRIPTION
@
## 개요
다른 PC에서 작업한 `fix/schedule-calendar-tetris-packing` 브랜치를 dev 로 머지합니다. (앱 동일 브랜치와 짝)

## 주요 변경
- **feat(quiz):** 재풀이(연습) 모드 — 이미 푼/본인 퀴즈도 보상 없이 채점
- **fix(schedule):** 멀티데이 일정 당일 리마인더를 매일 발송
- **perf(diary):** 시그니처 지도 region-map 조회 인덱스 + 목록 N+1 제거

## 스키마
- prod `ddl-auto=none` 대응으로 `SchemaAutoMigration` 에 ALTER 정의 추가됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@