### PR TITLE
feat: 칭호 시스템 + 앱 설정/대공지 + 일기 압축 연동

### DIFF
--- a/src/main/kotlin/digdaserver/admin/appconfig/presentation/controller/AdminAppConfigController.kt
+++ b/src/main/kotlin/digdaserver/admin/appconfig/presentation/controller/AdminAppConfigController.kt
@@ -1,0 +1,45 @@
+package digdaserver.admin.appconfig.presentation.controller
+
+import digdaserver.domain.appconfig.application.service.AppConfigService
+import digdaserver.domain.appconfig.presentation.dto.req.UpdateAppConfigRequest
+import digdaserver.domain.appconfig.presentation.dto.res.AppConfigResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 어드민 앱 운영 설정 — 대공지(전광판) 노출/메시지, 피드백 노출/URL 관리.
+ * `/api/admin` 하위라 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ */
+@RestController
+@RequestMapping("/api/admin/app-config")
+@Tag(name = "Admin - App Config", description = "관리자 앱 운영 설정(대공지·피드백)")
+class AdminAppConfigController(
+    private val appConfigService: AppConfigService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(summary = "앱 운영 설정 조회")
+    @GetMapping
+    fun get(): ResponseEntity<AppConfigResponse> =
+        ResponseEntity.ok(appConfigService.get())
+
+    @Operation(summary = "앱 운영 설정 수정", description = "대공지 노출/메시지 + 피드백 노출/URL 저장")
+    @PutMapping
+    fun update(
+        @RequestBody request: UpdateAppConfigRequest
+    ): ResponseEntity<AppConfigResponse> {
+        log.info(
+            "api=PUT /api/admin/app-config, notice={}, feedback={}",
+            request.noticeEnabled, request.feedbackEnabled
+        )
+        return ResponseEntity.ok(appConfigService.update(request))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/appconfig/presentation/controller/AdminAppConfigController.kt
+++ b/src/main/kotlin/digdaserver/admin/appconfig/presentation/controller/AdminAppConfigController.kt
@@ -38,7 +38,8 @@ class AdminAppConfigController(
     ): ResponseEntity<AppConfigResponse> {
         log.info(
             "api=PUT /api/admin/app-config, notice={}, feedback={}",
-            request.noticeEnabled, request.feedbackEnabled
+            request.noticeEnabled,
+            request.feedbackEnabled
         )
         return ResponseEntity.ok(appConfigService.update(request))
     }

--- a/src/main/kotlin/digdaserver/admin/region/application/service/AdminRegionService.kt
+++ b/src/main/kotlin/digdaserver/admin/region/application/service/AdminRegionService.kt
@@ -1,0 +1,16 @@
+package digdaserver.admin.region.application.service
+
+interface AdminRegionService {
+
+    /** 그룹에서 어드민이 채워둔 region_key 목록. */
+    fun filled(groupRoomId: Long): List<String>
+
+    /** 지역 채움(멱등). 채움 후 전체 채운 목록 반환. */
+    fun fill(groupRoomId: Long, regionKeys: List<String>): List<String>
+
+    /** 지정 지역 채움 해제. 해제 후 전체 채운 목록 반환. */
+    fun unfill(groupRoomId: Long, regionKeys: List<String>): List<String>
+
+    /** 그룹의 모든 채움 해제. */
+    fun clear(groupRoomId: Long)
+}

--- a/src/main/kotlin/digdaserver/admin/region/application/service/impl/AdminRegionServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/region/application/service/impl/AdminRegionServiceImpl.kt
@@ -1,0 +1,42 @@
+package digdaserver.admin.region.application.service.impl
+
+import digdaserver.admin.region.application.service.AdminRegionService
+import digdaserver.domain.diary.domain.entity.GroupRegionFill
+import digdaserver.domain.diary.domain.repository.GroupRegionFillRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminRegionServiceImpl(
+    private val groupRegionFillRepository: GroupRegionFillRepository
+) : AdminRegionService {
+
+    override fun filled(groupRoomId: Long): List<String> =
+        groupRegionFillRepository.findAllByGroupRoomId(groupRoomId).map { it.regionKey }
+
+    @Transactional
+    override fun fill(groupRoomId: Long, regionKeys: List<String>): List<String> {
+        for (key in regionKeys) {
+            val k = key.trim()
+            if (k.isEmpty()) continue
+            if (!groupRegionFillRepository.existsByGroupRoomIdAndRegionKey(groupRoomId, k)) {
+                groupRegionFillRepository.save(GroupRegionFill(groupRoomId = groupRoomId, regionKey = k))
+            }
+        }
+        return filled(groupRoomId)
+    }
+
+    @Transactional
+    override fun unfill(groupRoomId: Long, regionKeys: List<String>): List<String> {
+        for (key in regionKeys) {
+            groupRegionFillRepository.deleteByGroupRoomIdAndRegionKey(groupRoomId, key.trim())
+        }
+        return filled(groupRoomId)
+    }
+
+    @Transactional
+    override fun clear(groupRoomId: Long) {
+        groupRegionFillRepository.deleteByGroupRoomId(groupRoomId)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/region/presentation/controller/AdminRegionController.kt
+++ b/src/main/kotlin/digdaserver/admin/region/presentation/controller/AdminRegionController.kt
@@ -1,0 +1,56 @@
+package digdaserver.admin.region.presentation.controller
+
+import digdaserver.admin.region.application.service.AdminRegionService
+import digdaserver.admin.region.presentation.dto.req.RegionFillRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 어드민 시그니처 지도 채움 관리 — 그룹의 시·군·구를 임의로 채우거나 해제한다.
+ * 채운 지역은 region-map 응답에 병합되어 앱 지도에서 색칠된다.
+ * `/api/admin` 하위라 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ */
+@RestController
+@RequestMapping("/api/admin/region-map")
+@Tag(name = "Admin - Region Map", description = "관리자 시그니처 지도 채움 관리 API")
+class AdminRegionController(
+    private val adminRegionService: AdminRegionService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(summary = "그룹의 채운 지역 목록")
+    @GetMapping
+    fun filled(@RequestParam groupRoomId: Long): ResponseEntity<List<String>> =
+        ResponseEntity.ok(adminRegionService.filled(groupRoomId))
+
+    @Operation(summary = "지역 채우기", description = "region_key 목록을 채움(멱등). '전체 채우기'는 프론트가 전 지역 키를 보낸다.")
+    @PostMapping("/fill")
+    fun fill(@RequestBody request: RegionFillRequest): ResponseEntity<List<String>> {
+        log.info("api=POST /api/admin/region-map/fill, groupRoomId={}, count={}", request.groupRoomId, request.regionKeys.size)
+        return ResponseEntity.ok(adminRegionService.fill(request.groupRoomId, request.regionKeys))
+    }
+
+    @Operation(summary = "지역 채움 해제", description = "지정 region_key 들의 채움 해제")
+    @PostMapping("/unfill")
+    fun unfill(@RequestBody request: RegionFillRequest): ResponseEntity<List<String>> {
+        log.info("api=POST /api/admin/region-map/unfill, groupRoomId={}, count={}", request.groupRoomId, request.regionKeys.size)
+        return ResponseEntity.ok(adminRegionService.unfill(request.groupRoomId, request.regionKeys))
+    }
+
+    @Operation(summary = "그룹 채움 전체 해제")
+    @DeleteMapping
+    fun clear(@RequestParam groupRoomId: Long): ResponseEntity<Void> {
+        adminRegionService.clear(groupRoomId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/region/presentation/dto/req/RegionFillRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/region/presentation/dto/req/RegionFillRequest.kt
@@ -1,0 +1,13 @@
+package digdaserver.admin.region.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/** 어드민이 그룹의 지역을 임의로 채우거나 해제한다. */
+@Schema(description = "지역 채움/해제 요청")
+data class RegionFillRequest(
+    @field:Schema(description = "대상 그룹방 id")
+    val groupRoomId: Long,
+
+    @field:Schema(description = "채울/해제할 시·군·구 region_key 목록")
+    val regionKeys: List<String> = emptyList()
+)

--- a/src/main/kotlin/digdaserver/admin/title/application/service/AdminTitleService.kt
+++ b/src/main/kotlin/digdaserver/admin/title/application/service/AdminTitleService.kt
@@ -1,0 +1,20 @@
+package digdaserver.admin.title.application.service
+
+import digdaserver.admin.title.presentation.dto.res.AdminUserTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
+import java.util.UUID
+
+interface AdminTitleService {
+
+    /** 칭호 카탈로그 전체(부여 대상 목록). */
+    fun catalog(): List<TitleCatalogResponse>
+
+    /** 특정 사용자가 보유한 칭호 목록. */
+    fun userTitles(userId: UUID): List<AdminUserTitleResponse>
+
+    /** 사용자에게 칭호 부여(멱등). 카탈로그에 없는 코드면 예외. */
+    fun grant(userId: UUID, code: String): List<AdminUserTitleResponse>
+
+    /** 사용자 칭호 회수. */
+    fun revoke(userId: UUID, code: String): List<AdminUserTitleResponse>
+}

--- a/src/main/kotlin/digdaserver/admin/title/application/service/impl/AdminTitleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/title/application/service/impl/AdminTitleServiceImpl.kt
@@ -1,0 +1,56 @@
+package digdaserver.admin.title.application.service.impl
+
+import digdaserver.admin.title.application.service.AdminTitleService
+import digdaserver.admin.title.presentation.dto.res.AdminUserTitleResponse
+import digdaserver.domain.title.domain.entity.TitleCatalogEntry
+import digdaserver.domain.title.domain.entity.UserTitle
+import digdaserver.domain.title.domain.repository.TitleCatalogRepository
+import digdaserver.domain.title.domain.repository.UserTitleRepository
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class AdminTitleServiceImpl(
+    private val userTitleRepository: UserTitleRepository,
+    private val titleCatalogRepository: TitleCatalogRepository
+) : AdminTitleService {
+
+    override fun catalog(): List<TitleCatalogResponse> =
+        titleCatalogRepository.findAllByOrderBySortOrderAscIdAsc()
+            .map(TitleCatalogResponse::from)
+
+    override fun userTitles(userId: UUID): List<AdminUserTitleResponse> {
+        val catalog = titleCatalogRepository.findAll().associateBy { it.code }
+        return userTitleRepository.findAllByUserIdOrderByEarnedAtDesc(userId)
+            .map { toResponse(it, catalog[it.code]) }
+    }
+
+    @Transactional
+    override fun grant(userId: UUID, code: String): List<AdminUserTitleResponse> {
+        val def = titleCatalogRepository.findByCode(code)
+            ?: throw DigdaException(ErrorCode.INVALID_PARAMETER)
+        if (!userTitleRepository.existsByUserIdAndCode(userId, def.code)) {
+            userTitleRepository.save(UserTitle(userId = userId, code = def.code))
+        }
+        return userTitles(userId)
+    }
+
+    @Transactional
+    override fun revoke(userId: UUID, code: String): List<AdminUserTitleResponse> {
+        userTitleRepository.deleteByUserIdAndCode(userId, code)
+        return userTitles(userId)
+    }
+
+    private fun toResponse(t: UserTitle, def: TitleCatalogEntry?): AdminUserTitleResponse =
+        AdminUserTitleResponse.of(
+            t = t,
+            name = def?.name ?: t.code,
+            category = def?.category ?: "unknown",
+            accentColor = def?.accentColor ?: "#999999"
+        )
+}

--- a/src/main/kotlin/digdaserver/admin/title/presentation/controller/AdminTitleController.kt
+++ b/src/main/kotlin/digdaserver/admin/title/presentation/controller/AdminTitleController.kt
@@ -44,7 +44,8 @@ class AdminTitleController(
     @Operation(summary = "칭호 부여", description = "대상 사용자에게 칭호 지급(멱등). 부여 후 보유 목록 반환.")
     @PostMapping("/grant")
     fun grant(
-        @Valid @RequestBody request: GrantTitleRequest
+        @Valid @RequestBody
+        request: GrantTitleRequest
     ): ResponseEntity<List<AdminUserTitleResponse>> {
         log.info("api=POST /api/admin/titles/grant, userId={}, code={}", request.userId, request.code)
         return ResponseEntity.ok(adminTitleService.grant(request.userId, request.code))

--- a/src/main/kotlin/digdaserver/admin/title/presentation/controller/AdminTitleController.kt
+++ b/src/main/kotlin/digdaserver/admin/title/presentation/controller/AdminTitleController.kt
@@ -1,0 +1,62 @@
+package digdaserver.admin.title.presentation.controller
+
+import digdaserver.admin.title.application.service.AdminTitleService
+import digdaserver.admin.title.presentation.dto.req.GrantTitleRequest
+import digdaserver.admin.title.presentation.dto.res.AdminUserTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 어드민 칭호 관리 — 카탈로그 조회 + 특정 사용자에게 칭호 부여/회수.
+ * `/api/admin` 하위라 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ */
+@RestController
+@RequestMapping("/api/admin/titles")
+@Tag(name = "Admin - Title", description = "관리자 칭호 부여/회수 API")
+class AdminTitleController(
+    private val adminTitleService: AdminTitleService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(summary = "칭호 카탈로그 조회", description = "부여 가능한 전체 칭호 목록")
+    @GetMapping("/catalog")
+    fun catalog(): ResponseEntity<List<TitleCatalogResponse>> =
+        ResponseEntity.ok(adminTitleService.catalog())
+
+    @Operation(summary = "사용자 보유 칭호 조회")
+    @GetMapping("/users/{userId}")
+    fun userTitles(@PathVariable userId: UUID): ResponseEntity<List<AdminUserTitleResponse>> =
+        ResponseEntity.ok(adminTitleService.userTitles(userId))
+
+    @Operation(summary = "칭호 부여", description = "대상 사용자에게 칭호 지급(멱등). 부여 후 보유 목록 반환.")
+    @PostMapping("/grant")
+    fun grant(
+        @Valid @RequestBody request: GrantTitleRequest
+    ): ResponseEntity<List<AdminUserTitleResponse>> {
+        log.info("api=POST /api/admin/titles/grant, userId={}, code={}", request.userId, request.code)
+        return ResponseEntity.ok(adminTitleService.grant(request.userId, request.code))
+    }
+
+    @Operation(summary = "칭호 회수")
+    @DeleteMapping("/users/{userId}/{code}")
+    fun revoke(
+        @PathVariable userId: UUID,
+        @PathVariable code: String
+    ): ResponseEntity<List<AdminUserTitleResponse>> {
+        log.info("api=DELETE /api/admin/titles/users/{}/{}", userId, code)
+        return ResponseEntity.ok(adminTitleService.revoke(userId, code))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/title/presentation/dto/req/GrantTitleRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/title/presentation/dto/req/GrantTitleRequest.kt
@@ -1,0 +1,16 @@
+package digdaserver.admin.title.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+/** 어드민이 특정 사용자에게 칭호를 부여한다. */
+@Schema(description = "칭호 부여 요청")
+data class GrantTitleRequest(
+    @field:Schema(description = "대상 사용자 id")
+    val userId: UUID,
+
+    @field:NotBlank
+    @field:Schema(description = "칭호 코드", example = "region_gyeongnam")
+    val code: String
+)

--- a/src/main/kotlin/digdaserver/admin/title/presentation/dto/res/AdminUserTitleResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/title/presentation/dto/res/AdminUserTitleResponse.kt
@@ -1,0 +1,32 @@
+package digdaserver.admin.title.presentation.dto.res
+
+import digdaserver.domain.title.domain.entity.UserTitle
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/** 어드민용 — 사용자가 보유한 칭호 1건(카탈로그 표시명 결합). */
+@Schema(description = "사용자 보유 칭호")
+data class AdminUserTitleResponse(
+    val code: String,
+    val name: String,
+    val category: String,
+    val accentColor: String,
+    val groupRoomName: String?,
+    val earnedAt: LocalDateTime
+) {
+    companion object {
+        fun of(
+            t: UserTitle,
+            name: String,
+            category: String,
+            accentColor: String
+        ): AdminUserTitleResponse = AdminUserTitleResponse(
+            code = t.code,
+            name = name,
+            category = category,
+            accentColor = accentColor,
+            groupRoomName = t.groupRoomName,
+            earnedAt = t.earnedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
@@ -16,9 +16,6 @@ data class AdminUserResponse(
     @Schema(description = "이름")
     val name: String,
 
-    @Schema(description = "상태 메시지")
-    val statusMessage: String?,
-
     @Schema(description = "프로필 이미지 URL")
     val profileImage: String?,
 
@@ -39,7 +36,6 @@ data class AdminUserResponse(
             userId = user.id.toString(),
             email = user.email,
             name = user.name,
-            statusMessage = user.statusMessage,
             profileImage = user.profileImage,
             socialProvider = user.socialProvider.name,
             role = user.role.name,

--- a/src/main/kotlin/digdaserver/domain/appconfig/application/service/AppConfigService.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/application/service/AppConfigService.kt
@@ -1,0 +1,13 @@
+package digdaserver.domain.appconfig.application.service
+
+import digdaserver.domain.appconfig.presentation.dto.req.UpdateAppConfigRequest
+import digdaserver.domain.appconfig.presentation.dto.res.AppConfigResponse
+
+interface AppConfigService {
+
+    /** 현재 앱 운영 설정(없으면 기본값). */
+    fun get(): AppConfigResponse
+
+    /** 앱 운영 설정 갱신(단일 행 upsert). 어드민 전용. */
+    fun update(request: UpdateAppConfigRequest): AppConfigResponse
+}

--- a/src/main/kotlin/digdaserver/domain/appconfig/application/service/impl/AppConfigServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/application/service/impl/AppConfigServiceImpl.kt
@@ -1,0 +1,33 @@
+package digdaserver.domain.appconfig.application.service.impl
+
+import digdaserver.domain.appconfig.application.service.AppConfigService
+import digdaserver.domain.appconfig.domain.entity.AppConfig
+import digdaserver.domain.appconfig.domain.repository.AppConfigRepository
+import digdaserver.domain.appconfig.presentation.dto.req.UpdateAppConfigRequest
+import digdaserver.domain.appconfig.presentation.dto.res.AppConfigResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AppConfigServiceImpl(
+    private val appConfigRepository: AppConfigRepository
+) : AppConfigService {
+
+    override fun get(): AppConfigResponse {
+        val config = appConfigRepository.findFirstByOrderByIdAsc()
+        return config?.let(AppConfigResponse::from) ?: AppConfigResponse.default
+    }
+
+    @Transactional
+    override fun update(request: UpdateAppConfigRequest): AppConfigResponse {
+        val config = appConfigRepository.findFirstByOrderByIdAsc() ?: AppConfig()
+        config.update(
+            noticeEnabled = request.noticeEnabled,
+            noticeMessage = request.noticeMessage.trim(),
+            feedbackEnabled = request.feedbackEnabled,
+            feedbackUrl = request.feedbackUrl.trim()
+        )
+        return AppConfigResponse.from(appConfigRepository.save(config))
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/appconfig/domain/entity/AppConfig.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/domain/entity/AppConfig.kt
@@ -1,0 +1,51 @@
+package digdaserver.domain.appconfig.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * 앱 전역 운영 설정 — 어드민이 토글/입력하는 **단일 행**.
+ *
+ * - 대공지(전광판): [noticeEnabled] && [noticeMessage] 가 있으면 그룹홈 상단에 흐른다.
+ * - 피드백: [feedbackEnabled] 면 마이페이지에 "피드백 받기" 노출, [feedbackUrl] 로 이동.
+ */
+@Entity
+@Table(name = "app_config")
+class AppConfig(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "app_config_id")
+    val id: Long = 0L,
+
+    @Column(name = "notice_enabled", nullable = false)
+    var noticeEnabled: Boolean = false,
+
+    @Column(name = "notice_message", nullable = false, length = 200)
+    var noticeMessage: String = "",
+
+    @Column(name = "feedback_enabled", nullable = false)
+    var feedbackEnabled: Boolean = false,
+
+    @Column(name = "feedback_url", nullable = false, length = 500)
+    var feedbackUrl: String = ""
+
+) : BaseTimeEntity() {
+
+    fun update(
+        noticeEnabled: Boolean,
+        noticeMessage: String,
+        feedbackEnabled: Boolean,
+        feedbackUrl: String
+    ) {
+        this.noticeEnabled = noticeEnabled
+        this.noticeMessage = noticeMessage
+        this.feedbackEnabled = feedbackEnabled
+        this.feedbackUrl = feedbackUrl
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/appconfig/domain/repository/AppConfigRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/domain/repository/AppConfigRepository.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.appconfig.domain.repository
+
+import digdaserver.domain.appconfig.domain.entity.AppConfig
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AppConfigRepository : JpaRepository<AppConfig, Long> {
+
+    /** 단일 행 운영 — 가장 먼저 생성된 1행. */
+    fun findFirstByOrderByIdAsc(): AppConfig?
+}

--- a/src/main/kotlin/digdaserver/domain/appconfig/presentation/controller/AppConfigController.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/presentation/controller/AppConfigController.kt
@@ -1,0 +1,26 @@
+package digdaserver.domain.appconfig.presentation.controller
+
+import digdaserver.domain.appconfig.application.service.AppConfigService
+import digdaserver.domain.appconfig.presentation.dto.res.AppConfigResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/** 앱이 전역 운영 설정(대공지·피드백)을 조회한다. */
+@RestController
+@RequestMapping("/app-config")
+@Tag(name = "App Config", description = "앱 전역 운영 설정 조회(대공지·피드백)")
+class AppConfigController(
+    private val appConfigService: AppConfigService
+) {
+
+    @Operation(summary = "앱 운영 설정 조회", description = "대공지 노출/메시지 + 피드백 노출/URL")
+    @GetMapping
+    fun get(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<AppConfigResponse> = ResponseEntity.ok(appConfigService.get())
+}

--- a/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/req/UpdateAppConfigRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/req/UpdateAppConfigRequest.kt
@@ -1,0 +1,11 @@
+package digdaserver.domain.appconfig.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "앱 전역 운영 설정 수정")
+data class UpdateAppConfigRequest(
+    val noticeEnabled: Boolean = false,
+    val noticeMessage: String = "",
+    val feedbackEnabled: Boolean = false,
+    val feedbackUrl: String = ""
+)

--- a/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/res/AppConfigResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/res/AppConfigResponse.kt
@@ -1,0 +1,35 @@
+package digdaserver.domain.appconfig.presentation.dto.res
+
+import digdaserver.domain.appconfig.domain.entity.AppConfig
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "앱 전역 운영 설정")
+data class AppConfigResponse(
+    @field:Schema(description = "대공지 노출 여부")
+    val noticeEnabled: Boolean,
+
+    @field:Schema(description = "대공지 메시지")
+    val noticeMessage: String,
+
+    @field:Schema(description = "피드백 메뉴 노출 여부")
+    val feedbackEnabled: Boolean,
+
+    @field:Schema(description = "피드백 폼 URL")
+    val feedbackUrl: String
+) {
+    companion object {
+        val default = AppConfigResponse(
+            noticeEnabled = false,
+            noticeMessage = "",
+            feedbackEnabled = false,
+            feedbackUrl = ""
+        )
+
+        fun from(c: AppConfig): AppConfigResponse = AppConfigResponse(
+            noticeEnabled = c.noticeEnabled,
+            noticeMessage = c.noticeMessage,
+            feedbackEnabled = c.feedbackEnabled,
+            feedbackUrl = c.feedbackUrl
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -129,7 +129,11 @@ class DiaryServiceImpl(
         val regions = counts.map { DiaryRegionCount(regionKey = it.key, count = it.value) }
         val total = regions.sumOf { it.count }
         log.info("action=일기 지역지도 집계, groupRoomId={}, regions={}, total={}", groupRoomId, regions.size, total)
-        return DiaryRegionMapResponse(regions = regions, total = total)
+        return DiaryRegionMapResponse(
+            regions = regions,
+            total = total,
+            adminFilledKeys = filled.map { it.regionKey }
+        )
     }
 
     override fun getDiariesByRegion(

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -11,6 +11,7 @@ import digdaserver.domain.diary.domain.entity.DiaryReactionType
 import digdaserver.domain.diary.domain.repository.DiaryLikeRepository
 import digdaserver.domain.diary.domain.repository.DiaryReactionRepository
 import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.diary.domain.repository.GroupRegionFillRepository
 import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
@@ -60,6 +61,7 @@ class DiaryServiceImpl(
     private val uploadedImageRepository: UploadedImageRepository,
     private val diaryLikeRepository: DiaryLikeRepository,
     private val diaryReactionRepository: DiaryReactionRepository,
+    private val groupRegionFillRepository: GroupRegionFillRepository,
     @Lazy private val characterService: CharacterService
 ) : DiaryService {
 
@@ -67,6 +69,9 @@ class DiaryServiceImpl(
 
     companion object {
         private const val MAX_IMAGES_PER_DIARY = 10
+
+        /** 어드민이 임의로 채운 지역의 합성 일기 수 — 최대 색칠 임계(광역시 10) 이상이면 무조건 색칠된다. */
+        private const val ADMIN_FILL_COUNT = 10L
 
         /**
          * 날짜 판정 기준 타임존. 서버 기본 TZ 가 UTC 이면 KST 00~09 시 사이에 한국 사용자의
@@ -111,9 +116,17 @@ class DiaryServiceImpl(
     override fun getDiaryRegionMap(userId: UUID, groupRoomId: Long): DiaryRegionMapResponse {
         ensureMember(userId, groupRoomId)
         val rows = diaryRepository.countByRegionKey(groupRoomId)
-        val regions = rows.map { row ->
-            DiaryRegionCount(regionKey = row[0] as String, count = row[1] as Long)
+        val counts = LinkedHashMap<String, Long>()
+        for (row in rows) {
+            counts[row[0] as String] = row[1] as Long
         }
+        // 어드민이 임의로 채운 지역을 병합 — 색칠 임계(최대 10) 이상으로 끌어올린다.
+        val filled = groupRegionFillRepository.findAllByGroupRoomId(groupRoomId)
+        for (f in filled) {
+            val cur = counts[f.regionKey] ?: 0L
+            if (cur < ADMIN_FILL_COUNT) counts[f.regionKey] = ADMIN_FILL_COUNT
+        }
+        val regions = counts.map { DiaryRegionCount(regionKey = it.key, count = it.value) }
         val total = regions.sumOf { it.count }
         log.info("action=일기 지역지도 집계, groupRoomId={}, regions={}, total={}", groupRoomId, regions.size, total)
         return DiaryRegionMapResponse(regions = regions, total = total)

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/GroupRegionFill.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/GroupRegionFill.kt
@@ -1,0 +1,38 @@
+package digdaserver.domain.diary.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+/**
+ * 어드민이 임의로 "채운" 지역 1칸(그룹×지역키). 실제 일기와 무관하게 시그니처 지도를 칠하기 위한 override.
+ *
+ * 시그니처 지도 응답(region-map)은 일기 집계에 이 override 를 병합해, 해당 region_key 를
+ * 색칠 임계 이상으로 보이게 만든다. 행 삭제 = 채움 해제.
+ */
+@Entity
+@Table(
+    name = "group_region_fill",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_group_region_fill", columnNames = ["group_room_id", "region_key"])
+    ]
+)
+class GroupRegionFill(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_region_fill_id")
+    val id: Long = 0L,
+
+    @Column(name = "group_room_id", nullable = false)
+    val groupRoomId: Long,
+
+    @Column(name = "region_key", nullable = false, length = 40)
+    val regionKey: String
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -54,6 +54,10 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
     @Query("DELETE FROM Diary d WHERE d.createdBy.id = :userId")
     fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 
+    /** 칭호(작성 일기 수) — 사용자가 작성한 전체 일기 수(그룹 무관). */
+    @Query("SELECT COUNT(d) FROM Diary d WHERE d.createdBy.id = :userId")
+    fun countByCreatedById(@Param("userId") userId: UUID): Long
+
     /**
      * 시그니처 지도 — 그룹의 region_key 별 일기 수 집계. region_key 가 있는 일기만 대상.
      * 각 row = [regionKey(String), count(Long)].

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/GroupRegionFillRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/GroupRegionFillRepository.kt
@@ -1,0 +1,17 @@
+package digdaserver.domain.diary.domain.repository
+
+import digdaserver.domain.diary.domain.entity.GroupRegionFill
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface GroupRegionFillRepository : JpaRepository<GroupRegionFill, Long> {
+
+    fun findAllByGroupRoomId(groupRoomId: Long): List<GroupRegionFill>
+
+    fun existsByGroupRoomIdAndRegionKey(groupRoomId: Long, regionKey: String): Boolean
+
+    fun deleteByGroupRoomIdAndRegionKey(groupRoomId: Long, regionKey: String)
+
+    fun deleteByGroupRoomId(groupRoomId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryRegionMapResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryRegionMapResponse.kt
@@ -9,7 +9,9 @@ package digdaserver.domain.diary.presentation.dto.res
 data class DiaryRegionMapResponse(
     val regions: List<DiaryRegionCount>,
     /** region_key 가 지정된 전체 일기 수(분류된 기록 총합). */
-    val total: Long
+    val total: Long,
+    /** 어드민이 임의로 채운 region_key 목록(실제 일기 아님). 앱이 "관리자 채움"으로 구분 표기. */
+    val adminFilledKeys: List<String> = emptyList()
 )
 
 data class DiaryRegionCount(

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -285,7 +285,10 @@ class NotificationServiceImpl(
         // 전역 1회가 아니라 시간창으로 봐야, 멀티데이 일정의 당일 알림이 날마다 1번씩 간다
         // (같은 날 09/12/18 슬롯 중복은 막고, 다음 날엔 다시 발송).
         if (notificationRepository.existsByTypeAndRelatedIdAndCreatedAtAfter(
-                type, scheduleId, LocalDateTime.now().minusHours(REMINDER_DEDUP_WINDOW_HOURS))
+                type,
+                scheduleId,
+                LocalDateTime.now().minusHours(REMINDER_DEDUP_WINDOW_HOURS)
+            )
         ) {
             return
         }

--- a/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/res/UserResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/res/UserResponse.kt
@@ -18,9 +18,6 @@ data class UserResponse(
     @Schema(description = "프로필 이미지 URL")
     val profileImage: String?,
 
-    @Schema(description = "상태 메시지")
-    val statusMessage: String?,
-
     @Schema(description = "소셜 프로바이더", example = "kakao")
     val provider: String,
 
@@ -34,7 +31,6 @@ data class UserResponse(
                 name = user.name,
                 email = user.email,
                 profileImage = user.profileImage,
-                statusMessage = user.statusMessage,
                 provider = user.socialProvider.value,
                 createdAt = user.createdAt.toString()
             )

--- a/src/main/kotlin/digdaserver/domain/title/application/service/TitleService.kt
+++ b/src/main/kotlin/digdaserver/domain/title/application/service/TitleService.kt
@@ -2,10 +2,14 @@ package digdaserver.domain.title.application.service
 
 import digdaserver.domain.title.presentation.dto.req.ClaimTitleItem
 import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
 import digdaserver.domain.title.presentation.dto.res.TitleResponse
 import java.util.UUID
 
 interface TitleService {
+
+    /** 칭호 카탈로그 전체(앱 렌더·획득 판정 메타). */
+    fun catalog(): List<TitleCatalogResponse>
 
     /**
      * 사용자가 획득한 칭호 전체를 반환한다.

--- a/src/main/kotlin/digdaserver/domain/title/application/service/TitleService.kt
+++ b/src/main/kotlin/digdaserver/domain/title/application/service/TitleService.kt
@@ -1,0 +1,31 @@
+package digdaserver.domain.title.application.service
+
+import digdaserver.domain.title.presentation.dto.req.ClaimTitleItem
+import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleResponse
+import java.util.UUID
+
+interface TitleService {
+
+    /**
+     * 사용자가 획득한 칭호 전체를 반환한다.
+     * 조회 시점에 서버가 직접 셀 수 있는 칭호(작성 일기 수 누적)는 멱등하게 자동 적재한 뒤 함께 반환한다.
+     */
+    fun list(userId: UUID): List<TitleResponse>
+
+    /**
+     * 앱이 판정한 획득 칭호들을 멱등 적재한다(지역 정복·캐릭터 등 앱이 소유한 조건).
+     * 이미 보유했거나, 멤버가 아닌 그룹·형식이 잘못된 코드는 조용히 건너뛴다.
+     * 적재 후 사용자의 전체 칭호 목록을 반환한다.
+     */
+    fun claim(userId: UUID, items: List<ClaimTitleItem>): List<TitleResponse>
+
+    /** 그룹 모찌에 장착된 칭호(없으면 code=null). */
+    fun equippedTitle(groupRoomId: Long): EquippedTitleResponse
+
+    /**
+     * 그룹 모찌에 칭호를 장착/해제([code]=null 이면 해제).
+     * 그룹 구성원만 가능하고, 본인이 획득한 칭호만 장착할 수 있다.
+     */
+    fun equipTitle(userId: UUID, groupRoomId: Long, code: String?): EquippedTitleResponse
+}

--- a/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
@@ -48,6 +48,8 @@ class TitleServiceImpl(
         for (item in items) {
             val code = item.code.trim()
             if (!codeFormat.matches(code)) continue
+            // 카탈로그에 없는(임의 조작) 코드는 무시 — 알 수 없는 칭호 자가발급 방지.
+            if (!titleCatalogRepository.existsByCode(code)) continue
             if (userTitleRepository.existsByUserIdAndCode(userId, code)) continue
 
             val groupId = item.groupRoomId

--- a/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
@@ -7,9 +7,11 @@ import digdaserver.domain.title.application.service.TitleService
 import digdaserver.domain.title.domain.entity.GroupEquippedTitle
 import digdaserver.domain.title.domain.entity.UserTitle
 import digdaserver.domain.title.domain.repository.GroupEquippedTitleRepository
+import digdaserver.domain.title.domain.repository.TitleCatalogRepository
 import digdaserver.domain.title.domain.repository.UserTitleRepository
 import digdaserver.domain.title.presentation.dto.req.ClaimTitleItem
 import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
 import digdaserver.domain.title.presentation.dto.res.TitleResponse
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
@@ -22,6 +24,7 @@ import java.util.UUID
 class TitleServiceImpl(
     private val userTitleRepository: UserTitleRepository,
     private val groupEquippedTitleRepository: GroupEquippedTitleRepository,
+    private val titleCatalogRepository: TitleCatalogRepository,
     private val diaryRepository: DiaryRepository,
     private val membershipRepository: MembershipRepository,
     private val groupRoomRepository: GroupRoomRepository
@@ -29,8 +32,9 @@ class TitleServiceImpl(
 
     private val codeFormat = Regex("^[a-z0-9_]{1,40}$")
 
-    /** 작성 일기 수 누적 칭호 임계값 — 앱 카탈로그의 diary_* 코드와 짝이 맞아야 한다. */
-    private val diaryMilestones = listOf(1, 10, 30, 50, 100)
+    override fun catalog(): List<TitleCatalogResponse> =
+        titleCatalogRepository.findAllByOrderBySortOrderAscIdAsc()
+            .map(TitleCatalogResponse::from)
 
     @Transactional
     override fun list(userId: UUID): List<TitleResponse> {
@@ -107,14 +111,19 @@ class TitleServiceImpl(
         return EquippedTitleResponse.from(saved)
     }
 
-    /** 서버가 직접 셀 수 있는 전역 칭호(작성 일기 수)를 멱등 적재. 그룹 맥락 없음(null). */
+    /**
+     * 서버가 직접 셀 수 있는 전역 칭호(작성 일기 수)를 멱등 적재. 그룹 맥락 없음(null).
+     * 임계값은 카탈로그(conditionType=diary 의 conditionValue)에서 읽어 단일 소스로 둔다.
+     */
     private fun grantDiaryCountTitles(userId: UUID) {
+        val diaryDefs = titleCatalogRepository.findAllByConditionType("diary")
+        if (diaryDefs.isEmpty()) return
         val count = diaryRepository.countByCreatedById(userId)
-        for (m in diaryMilestones) {
-            if (count < m) break
-            val code = "diary_$m"
-            if (!userTitleRepository.existsByUserIdAndCode(userId, code)) {
-                userTitleRepository.save(UserTitle(userId = userId, code = code))
+        for (def in diaryDefs) {
+            val threshold = def.conditionValue?.toIntOrNull() ?: continue
+            if (count < threshold) continue
+            if (!userTitleRepository.existsByUserIdAndCode(userId, def.code)) {
+                userTitleRepository.save(UserTitle(userId = userId, code = def.code))
             }
         }
     }

--- a/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/title/application/service/impl/TitleServiceImpl.kt
@@ -1,0 +1,121 @@
+package digdaserver.domain.title.application.service.impl
+
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
+import digdaserver.domain.membership.domain.repository.MembershipRepository
+import digdaserver.domain.title.application.service.TitleService
+import digdaserver.domain.title.domain.entity.GroupEquippedTitle
+import digdaserver.domain.title.domain.entity.UserTitle
+import digdaserver.domain.title.domain.repository.GroupEquippedTitleRepository
+import digdaserver.domain.title.domain.repository.UserTitleRepository
+import digdaserver.domain.title.presentation.dto.req.ClaimTitleItem
+import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleResponse
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class TitleServiceImpl(
+    private val userTitleRepository: UserTitleRepository,
+    private val groupEquippedTitleRepository: GroupEquippedTitleRepository,
+    private val diaryRepository: DiaryRepository,
+    private val membershipRepository: MembershipRepository,
+    private val groupRoomRepository: GroupRoomRepository
+) : TitleService {
+
+    private val codeFormat = Regex("^[a-z0-9_]{1,40}$")
+
+    /** 작성 일기 수 누적 칭호 임계값 — 앱 카탈로그의 diary_* 코드와 짝이 맞아야 한다. */
+    private val diaryMilestones = listOf(1, 10, 30, 50, 100)
+
+    @Transactional
+    override fun list(userId: UUID): List<TitleResponse> {
+        grantDiaryCountTitles(userId)
+        return userTitleRepository.findAllByUserIdOrderByEarnedAtDesc(userId)
+            .map(TitleResponse::from)
+    }
+
+    @Transactional
+    override fun claim(userId: UUID, items: List<ClaimTitleItem>): List<TitleResponse> {
+        for (item in items) {
+            val code = item.code.trim()
+            if (!codeFormat.matches(code)) continue
+            if (userTitleRepository.existsByUserIdAndCode(userId, code)) continue
+
+            val groupId = item.groupRoomId
+            var groupName: String? = null
+            if (groupId != null) {
+                // 멤버가 아닌 그룹으로의 적재는 무시(앱 버그/조작 방지).
+                if (!membershipRepository.existsByGroupRoomIdAndUserId(groupId, userId)) continue
+                groupName = groupRoomRepository.findById(groupId).orElse(null)?.name
+            }
+            userTitleRepository.save(
+                UserTitle(
+                    userId = userId,
+                    code = code,
+                    groupRoomId = groupId,
+                    groupRoomName = groupName
+                )
+            )
+        }
+        return userTitleRepository.findAllByUserIdOrderByEarnedAtDesc(userId)
+            .map(TitleResponse::from)
+    }
+
+    override fun equippedTitle(groupRoomId: Long): EquippedTitleResponse {
+        return groupEquippedTitleRepository.findByGroupRoomId(groupRoomId)
+            .map(EquippedTitleResponse::from)
+            .orElse(EquippedTitleResponse.empty)
+    }
+
+    @Transactional
+    override fun equipTitle(
+        userId: UUID,
+        groupRoomId: Long,
+        code: String?
+    ): EquippedTitleResponse {
+        // 그룹 구성원만 그룹 모찌를 꾸밀 수 있다.
+        if (!membershipRepository.existsByGroupRoomIdAndUserId(groupRoomId, userId)) {
+            throw DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER)
+        }
+        val existing = groupEquippedTitleRepository.findByGroupRoomId(groupRoomId).orElse(null)
+
+        // code 가 null/blank 면 해제.
+        val target = code?.trim()
+        if (target.isNullOrEmpty()) {
+            if (existing != null) groupEquippedTitleRepository.delete(existing)
+            return EquippedTitleResponse.empty
+        }
+
+        // 본인이 획득한 칭호만 장착 가능.
+        if (!userTitleRepository.existsByUserIdAndCode(userId, target)) {
+            throw DigdaException(ErrorCode.TITLE_NOT_OWNED)
+        }
+
+        val saved = if (existing != null) {
+            existing.replaceWith(target, userId)
+            existing
+        } else {
+            groupEquippedTitleRepository.save(
+                GroupEquippedTitle(groupRoomId = groupRoomId, code = target, equippedBy = userId)
+            )
+        }
+        return EquippedTitleResponse.from(saved)
+    }
+
+    /** 서버가 직접 셀 수 있는 전역 칭호(작성 일기 수)를 멱등 적재. 그룹 맥락 없음(null). */
+    private fun grantDiaryCountTitles(userId: UUID) {
+        val count = diaryRepository.countByCreatedById(userId)
+        for (m in diaryMilestones) {
+            if (count < m) break
+            val code = "diary_$m"
+            if (!userTitleRepository.existsByUserIdAndCode(userId, code)) {
+                userTitleRepository.save(UserTitle(userId = userId, code = code))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/domain/entity/GroupEquippedTitle.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/entity/GroupEquippedTitle.kt
@@ -1,0 +1,49 @@
+package digdaserver.domain.title.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.util.UUID
+
+/**
+ * 그룹 모찌에 장착된 칭호(그룹당 1개). 모찌는 그룹 공용 캐릭터라 장착도 그룹 단위다.
+ *
+ * 멤버 누구든 **자신이 획득한** 칭호([UserTitle]) 중 하나를 그룹 모찌에 장착할 수 있고,
+ * 마지막에 장착한 값이 그룹 모찌 화면에 표시된다. 해제는 row 삭제.
+ */
+@Entity
+@Table(
+    name = "group_equipped_title",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_group_equipped_title_group", columnNames = ["group_room_id"])
+    ]
+)
+class GroupEquippedTitle(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_equipped_title_id")
+    val id: Long = 0L,
+
+    @Column(name = "group_room_id", nullable = false)
+    val groupRoomId: Long,
+
+    @Column(nullable = false, length = 40)
+    var code: String,
+
+    /** 장착한 사용자(소유자 검증·표시용). */
+    @Column(name = "equipped_by", nullable = false)
+    var equippedBy: UUID
+
+) : BaseTimeEntity() {
+
+    fun replaceWith(code: String, userId: UUID) {
+        this.code = code
+        this.equippedBy = userId
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/domain/entity/TitleCatalogEntry.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/entity/TitleCatalogEntry.kt
@@ -1,0 +1,82 @@
+package digdaserver.domain.title.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+/**
+ * 칭호 카탈로그 1종(마스터 데이터). 부팅 시 [디그다 TitleCatalogSeeder] 가 idempotent 하게 시드하므로
+ * 데이터를 날려도 `ddl-auto=create` + 시드로 재생성된다(모찌 ShopItem 과 동일 운영).
+ *
+ * 표시 메타(이름/색/아이콘)와 획득 조건을 모두 담아 어드민·앱이 [code] 로 공유한다.
+ * - [category]       : region / diary / character (앱 분류 탭과 일치)
+ * - [conditionType]  : region / diary / mochi_level / manual (획득 판정 종류)
+ * - [conditionValue] : 조건 파라미터(지역 버킷명, 일기 임계값, 모찌 레벨). manual 은 null.
+ * - [iconKey]        : 앱이 IconData 로 매핑하는 키.
+ */
+@Entity
+@Table(
+    name = "title_catalog",
+    uniqueConstraints = [UniqueConstraint(name = "uk_title_catalog_code", columnNames = ["code"])]
+)
+class TitleCatalogEntry(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "title_catalog_id")
+    val id: Long = 0L,
+
+    @Column(nullable = false, length = 40)
+    val code: String,
+
+    @Column(nullable = false, length = 60)
+    var name: String,
+
+    @Column(nullable = false, length = 200)
+    var description: String,
+
+    @Column(nullable = false, length = 20)
+    var category: String,
+
+    @Column(name = "accent_color", nullable = false, length = 16)
+    var accentColor: String,
+
+    @Column(name = "icon_key", nullable = false, length = 40)
+    var iconKey: String,
+
+    @Column(name = "condition_type", nullable = false, length = 20)
+    var conditionType: String,
+
+    @Column(name = "condition_value", length = 40)
+    var conditionValue: String? = null,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0
+
+) : BaseTimeEntity() {
+
+    fun updateMeta(
+        name: String,
+        description: String,
+        category: String,
+        accentColor: String,
+        iconKey: String,
+        conditionType: String,
+        conditionValue: String?,
+        sortOrder: Int
+    ) {
+        this.name = name
+        this.description = description
+        this.category = category
+        this.accentColor = accentColor
+        this.iconKey = iconKey
+        this.conditionType = conditionType
+        this.conditionValue = conditionValue
+        this.sortOrder = sortOrder
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/domain/entity/UserTitle.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/entity/UserTitle.kt
@@ -1,0 +1,57 @@
+package digdaserver.domain.title.domain.entity
+
+import digdaserver.global.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 사용자가 획득한 칭호 1개. **계정(user) 소속**이라 그룹방 탈퇴/삭제와 무관하게 유지된다.
+ *
+ * 칭호의 표시 메타(이름·설명·아이콘·색)와 획득 조건 판정은 모두 **앱이 소유**한다.
+ * 서버는 "누가 / 어떤 코드 / 어느 그룹방에서 / 언제" 땄는지를 저장·조회만 한다.
+ *
+ * - [code]          : 앱 카탈로그의 칭호 식별자(예: "region_gyeongnam", "diary_50", "char_evolved").
+ * - [groupRoomId]   : 획득 당시 그룹방 id(지역/캐릭터 칭호). 전역 칭호(일기 수 등)는 null.
+ * - [groupRoomName] : 획득 당시 그룹방 이름 **스냅샷**. 그룹이 삭제/탈퇴돼도 "OO 그룹방에서 따셨습니다" 가 남도록.
+ */
+@Entity
+@Table(
+    name = "user_title",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_user_title_user_code", columnNames = ["user_id", "code"])
+    ],
+    indexes = [
+        Index(name = "idx_user_title_user", columnList = "user_id")
+    ]
+)
+class UserTitle(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_title_id")
+    val id: Long = 0L,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(nullable = false, length = 40)
+    val code: String,
+
+    @Column(name = "group_room_id")
+    val groupRoomId: Long? = null,
+
+    @Column(name = "group_room_name", length = 100)
+    val groupRoomName: String? = null,
+
+    @Column(name = "earned_at", nullable = false)
+    val earnedAt: LocalDateTime = LocalDateTime.now()
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/digdaserver/domain/title/domain/repository/GroupEquippedTitleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/repository/GroupEquippedTitleRepository.kt
@@ -1,0 +1,14 @@
+package digdaserver.domain.title.domain.repository
+
+import digdaserver.domain.title.domain.entity.GroupEquippedTitle
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface GroupEquippedTitleRepository : JpaRepository<GroupEquippedTitle, Long> {
+
+    fun findByGroupRoomId(groupRoomId: Long): Optional<GroupEquippedTitle>
+
+    fun deleteByGroupRoomId(groupRoomId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/title/domain/repository/TitleCatalogRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/repository/TitleCatalogRepository.kt
@@ -1,0 +1,17 @@
+package digdaserver.domain.title.domain.repository
+
+import digdaserver.domain.title.domain.entity.TitleCatalogEntry
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TitleCatalogRepository : JpaRepository<TitleCatalogEntry, Long> {
+
+    fun findByCode(code: String): TitleCatalogEntry?
+
+    fun findAllByOrderBySortOrderAscIdAsc(): List<TitleCatalogEntry>
+
+    fun findAllByConditionType(conditionType: String): List<TitleCatalogEntry>
+
+    fun existsByCode(code: String): Boolean
+}

--- a/src/main/kotlin/digdaserver/domain/title/domain/repository/UserTitleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/repository/UserTitleRepository.kt
@@ -12,4 +12,7 @@ interface UserTitleRepository : JpaRepository<UserTitle, Long> {
     fun findAllByUserIdOrderByEarnedAtDesc(userId: UUID): List<UserTitle>
 
     fun existsByUserIdAndCode(userId: UUID, code: String): Boolean
+
+    /** 어드민 회수용. */
+    fun deleteByUserIdAndCode(userId: UUID, code: String)
 }

--- a/src/main/kotlin/digdaserver/domain/title/domain/repository/UserTitleRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/title/domain/repository/UserTitleRepository.kt
@@ -1,0 +1,15 @@
+package digdaserver.domain.title.domain.repository
+
+import digdaserver.domain.title.domain.entity.UserTitle
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface UserTitleRepository : JpaRepository<UserTitle, Long> {
+
+    /** 한 사용자가 획득한 모든 칭호 — 최신 획득순. */
+    fun findAllByUserIdOrderByEarnedAtDesc(userId: UUID): List<UserTitle>
+
+    fun existsByUserIdAndCode(userId: UUID, code: String): Boolean
+}

--- a/src/main/kotlin/digdaserver/domain/title/infra/TitleCatalogSeeder.kt
+++ b/src/main/kotlin/digdaserver/domain/title/infra/TitleCatalogSeeder.kt
@@ -1,0 +1,102 @@
+package digdaserver.domain.title.infra
+
+import digdaserver.domain.title.domain.entity.TitleCatalogEntry
+import digdaserver.domain.title.domain.repository.TitleCatalogRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 칭호 카탈로그 마스터 데이터 idempotent 시드(모찌 ShopItemSeeder 와 동일 운영).
+ * 데이터를 날려도 `ddl-auto=create` + 이 시드로 카탈로그가 재생성된다. [code] 가 키.
+ *
+ * **앱의 하드코딩 TitleCatalog(코드/색/아이콘)와 코드가 일치해야 한다.**
+ */
+@Component
+class TitleCatalogSeeder(
+    private val titleCatalogRepository: TitleCatalogRepository
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @EventListener(ApplicationReadyEvent::class)
+    @Transactional
+    fun seed() {
+        var created = 0
+        var updated = 0
+        SeedCatalog.all.forEach { d ->
+            val existing = titleCatalogRepository.findByCode(d.code)
+            if (existing == null) {
+                titleCatalogRepository.save(
+                    TitleCatalogEntry(
+                        code = d.code,
+                        name = d.name,
+                        description = d.description,
+                        category = d.category,
+                        accentColor = d.accentColor,
+                        iconKey = d.iconKey,
+                        conditionType = d.conditionType,
+                        conditionValue = d.conditionValue,
+                        sortOrder = d.sortOrder
+                    )
+                )
+                created += 1
+            } else {
+                existing.updateMeta(
+                    name = d.name,
+                    description = d.description,
+                    category = d.category,
+                    accentColor = d.accentColor,
+                    iconKey = d.iconKey,
+                    conditionType = d.conditionType,
+                    conditionValue = d.conditionValue,
+                    sortOrder = d.sortOrder
+                )
+                updated += 1
+            }
+        }
+        log.info("action=title_catalog_seed_done, created={}, updated={}", created, updated)
+    }
+
+    data class Def(
+        val code: String,
+        val name: String,
+        val description: String,
+        val category: String,
+        val accentColor: String,
+        val iconKey: String,
+        val conditionType: String,
+        val conditionValue: String?,
+        val sortOrder: Int
+    )
+
+    object SeedCatalog {
+        val all: List<Def> = listOf(
+            // ─── 지역 정복(region) — conditionValue = 지도 버킷명 ───
+            Def("region_metro", "광역시 정복자", "전국 광역시를 모두 채웠어요", "region", "#FF8A5B", "location_city", "region", "광역시", 10),
+            Def("region_gyeonggi_north", "경기북부 정복자", "경기 북부의 모든 시·군을 채웠어요", "region", "#FF6B6B", "flag", "region", "경기북부", 20),
+            Def("region_gyeonggi_south", "경기남부 정복자", "경기 남부의 모든 시·군을 채웠어요", "region", "#E8553D", "flag", "region", "경기남부", 30),
+            Def("region_gangwon", "강원 정복자", "강원의 모든 시·군을 채웠어요", "region", "#5B9BF0", "flag", "region", "강원", 40),
+            Def("region_chungbuk", "충북 정복자", "충청북도의 모든 시·군을 채웠어요", "region", "#F4B53C", "flag", "region", "충북", 50),
+            Def("region_chungnam", "충남 정복자", "충청남도의 모든 시·군을 채웠어요", "region", "#E0962B", "flag", "region", "충남", 60),
+            Def("region_jeonbuk", "전북 정복자", "전라북도의 모든 시·군을 채웠어요", "region", "#33C08A", "flag", "region", "전북", 70),
+            Def("region_jeonnam", "전남 정복자", "전라남도의 모든 시·군을 채웠어요", "region", "#1FA876", "flag", "region", "전남", 80),
+            Def("region_gyeongbuk", "경북 정복자", "경상북도의 모든 시·군을 채웠어요", "region", "#A98BF0", "flag", "region", "경북", 90),
+            Def("region_gyeongnam", "경남 정복자", "경상남도의 모든 시·군을 채웠어요", "region", "#8B6BE0", "flag", "region", "경남", 100),
+            Def("region_jeju", "제주 정복자", "제주의 모든 시·군을 채웠어요", "region", "#F47BB4", "flag", "region", "제주", 110),
+            // ─── 기록(diary) — conditionValue = 작성 일기 임계값 ───
+            Def("diary_1", "첫 발자국", "첫 일기를 남겼어요", "diary", "#7DC4A5", "edit_note", "diary", "1", 200),
+            Def("diary_10", "기록의 시작", "일기 10개를 작성했어요", "diary", "#54B98A", "menu_book", "diary", "10", 210),
+            Def("diary_30", "꾸준한 기록가", "일기 30개를 작성했어요", "diary", "#3FA9D6", "auto_stories", "diary", "30", 220),
+            Def("diary_50", "기록 수집가", "일기 50개를 작성했어요", "diary", "#6E8BE0", "collections_bookmark", "diary", "50", 230),
+            Def("diary_100", "기록 마스터", "일기 100개를 작성했어요", "diary", "#C9A23B", "workspace_premium", "diary", "100", 240),
+            // ─── 모찌(character) — conditionValue = 모찌 레벨 ───
+            Def("mochi_lv5", "모찌 새싹", "모찌를 Lv.5까지 키웠어요", "character", "#FFB0C0", "spa", "mochi_level", "5", 300),
+            Def("mochi_lv10", "모찌 단짝", "모찌를 Lv.10까지 키웠어요", "character", "#F583A8", "favorite", "mochi_level", "10", 310),
+            Def("mochi_lv15", "모찌 베테랑", "모찌를 Lv.15까지 키웠어요", "character", "#C78BE0", "military_tech", "mochi_level", "15", 320),
+            Def("mochi_lv20", "모찌 마스터", "모찌를 만렙(Lv.20)까지 키웠어요", "character", "#B07BE0", "workspace_premium", "mochi_level", "20", 330)
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
@@ -87,7 +87,9 @@ class TitleController(
     ): ResponseEntity<EquippedTitleResponse> {
         log.info(
             "api=PUT /titles/equip, userId={}, groupRoomId={}, code={}",
-            userId, request.groupRoomId, request.code
+            userId,
+            request.groupRoomId,
+            request.code
         )
         return ResponseEntity.ok(
             titleService.equipTitle(UUID.fromString(userId), request.groupRoomId, request.code)

--- a/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
@@ -1,0 +1,84 @@
+package digdaserver.domain.title.presentation.controller
+
+import digdaserver.domain.title.application.service.TitleService
+import digdaserver.domain.title.presentation.dto.req.ClaimTitlesRequest
+import digdaserver.domain.title.presentation.dto.req.EquipTitleRequest
+import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/titles")
+@Tag(name = "Title", description = "칭호 API — 계정 단위로 보관되며 그룹방 탈퇴/삭제와 무관하게 유지된다")
+class TitleController(
+    private val titleService: TitleService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(
+        summary = "내 칭호 목록 조회",
+        description = "획득한 칭호 전체를 반환. 작성 일기 수 칭호는 조회 시점에 자동 적재된다. 표시 메타는 앱이 code 로 매핑."
+    )
+    @GetMapping
+    fun list(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<List<TitleResponse>> {
+        return ResponseEntity.ok(titleService.list(UUID.fromString(userId)))
+    }
+
+    @Operation(
+        summary = "칭호 획득 적재(멱등)",
+        description = "앱이 판정한 지역 정복·캐릭터 칭호 등을 적재. 이미 보유/비멤버 그룹/잘못된 코드는 무시. 적재 후 전체 목록 반환."
+    )
+    @PostMapping("/claim")
+    fun claim(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: ClaimTitlesRequest
+    ): ResponseEntity<List<TitleResponse>> {
+        log.info("api=POST /titles/claim, userId={}, count={}", userId, request.titles.size)
+        return ResponseEntity.ok(titleService.claim(UUID.fromString(userId), request.titles))
+    }
+
+    @Operation(
+        summary = "그룹 모찌 장착 칭호 조회",
+        description = "그룹 모찌에 장착된 칭호(code). 미장착이면 code=null."
+    )
+    @GetMapping("/equipped")
+    fun equipped(
+        @AuthenticationPrincipal userId: String,
+        @RequestParam groupRoomId: Long
+    ): ResponseEntity<EquippedTitleResponse> {
+        return ResponseEntity.ok(titleService.equippedTitle(groupRoomId))
+    }
+
+    @Operation(
+        summary = "그룹 모찌에 칭호 장착/해제",
+        description = "본인이 획득한 칭호만 장착 가능. code=null 이면 해제. 그룹 구성원만 호출 가능."
+    )
+    @PutMapping("/equip")
+    fun equip(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: EquipTitleRequest
+    ): ResponseEntity<EquippedTitleResponse> {
+        log.info(
+            "api=PUT /titles/equip, userId={}, groupRoomId={}, code={}",
+            userId, request.groupRoomId, request.code
+        )
+        return ResponseEntity.ok(
+            titleService.equipTitle(UUID.fromString(userId), request.groupRoomId, request.code)
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/controller/TitleController.kt
@@ -4,6 +4,7 @@ import digdaserver.domain.title.application.service.TitleService
 import digdaserver.domain.title.presentation.dto.req.ClaimTitlesRequest
 import digdaserver.domain.title.presentation.dto.req.EquipTitleRequest
 import digdaserver.domain.title.presentation.dto.res.EquippedTitleResponse
+import digdaserver.domain.title.presentation.dto.res.TitleCatalogResponse
 import digdaserver.domain.title.presentation.dto.res.TitleResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -27,6 +28,17 @@ class TitleController(
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
+
+    @Operation(
+        summary = "칭호 카탈로그 조회",
+        description = "전체 칭호 정의(이름/색/아이콘/조건). 앱이 code 로 매핑해 렌더한다."
+    )
+    @GetMapping("/catalog")
+    fun catalog(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<List<TitleCatalogResponse>> {
+        return ResponseEntity.ok(titleService.catalog())
+    }
 
     @Operation(
         summary = "내 칭호 목록 조회",

--- a/src/main/kotlin/digdaserver/domain/title/presentation/dto/req/ClaimTitlesRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/dto/req/ClaimTitlesRequest.kt
@@ -1,0 +1,22 @@
+package digdaserver.domain.title.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 앱이 판정한 "방금 획득한 칭호" 들을 서버에 적재 요청한다(멱등).
+ * 이미 보유한 코드는 무시되고, 멤버가 아닌 그룹/형식이 잘못된 코드도 조용히 건너뛴다.
+ */
+@Schema(description = "칭호 획득 적재 요청")
+data class ClaimTitlesRequest(
+    @field:Schema(description = "획득 칭호 목록")
+    val titles: List<ClaimTitleItem> = emptyList()
+)
+
+@Schema(description = "획득 칭호 1건")
+data class ClaimTitleItem(
+    @field:Schema(description = "앱 카탈로그 칭호 코드", example = "region_gyeongnam")
+    val code: String,
+
+    @field:Schema(description = "획득 그룹방 id(전역 칭호는 null)", example = "12")
+    val groupRoomId: Long? = null
+)

--- a/src/main/kotlin/digdaserver/domain/title/presentation/dto/req/EquipTitleRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/dto/req/EquipTitleRequest.kt
@@ -1,0 +1,16 @@
+package digdaserver.domain.title.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 그룹 모찌에 칭호를 장착/해제한다. [code] 가 null 이면 해제.
+ * 본인이 획득한 칭호만 장착 가능하며, 그룹 구성원만 호출할 수 있다.
+ */
+@Schema(description = "그룹 모찌 칭호 장착 요청")
+data class EquipTitleRequest(
+    @field:Schema(description = "그룹방 id")
+    val groupRoomId: Long,
+
+    @field:Schema(description = "장착할 칭호 코드(null = 해제)", example = "region_gyeongnam")
+    val code: String? = null
+)

--- a/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/EquippedTitleResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/EquippedTitleResponse.kt
@@ -1,0 +1,25 @@
+package digdaserver.domain.title.presentation.dto.res
+
+import digdaserver.domain.title.domain.entity.GroupEquippedTitle
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+/**
+ * 그룹 모찌에 장착된 칭호. [code] 가 null 이면 미장착.
+ * 표시 메타(이름/아이콘/색)는 앱 카탈로그가 code 로 매핑한다.
+ */
+@Schema(description = "그룹 모찌 장착 칭호")
+data class EquippedTitleResponse(
+    @field:Schema(description = "장착 칭호 코드(미장착이면 null)")
+    val code: String?,
+
+    @field:Schema(description = "장착한 사용자 id(미장착이면 null)")
+    val equippedBy: UUID?
+) {
+    companion object {
+        val empty = EquippedTitleResponse(code = null, equippedBy = null)
+
+        fun from(e: GroupEquippedTitle): EquippedTitleResponse =
+            EquippedTitleResponse(code = e.code, equippedBy = e.equippedBy)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/TitleCatalogResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/TitleCatalogResponse.kt
@@ -1,0 +1,32 @@
+package digdaserver.domain.title.presentation.dto.res
+
+import digdaserver.domain.title.domain.entity.TitleCatalogEntry
+import io.swagger.v3.oas.annotations.media.Schema
+
+/** 칭호 카탈로그 1종(표시 메타 + 획득 조건). 앱·어드민이 code 로 공유한다. */
+@Schema(description = "칭호 카탈로그 항목")
+data class TitleCatalogResponse(
+    val code: String,
+    val name: String,
+    val description: String,
+    val category: String,
+    val accentColor: String,
+    val iconKey: String,
+    val conditionType: String,
+    val conditionValue: String?,
+    val sortOrder: Int
+) {
+    companion object {
+        fun from(e: TitleCatalogEntry): TitleCatalogResponse = TitleCatalogResponse(
+            code = e.code,
+            name = e.name,
+            description = e.description,
+            category = e.category,
+            accentColor = e.accentColor,
+            iconKey = e.iconKey,
+            conditionType = e.conditionType,
+            conditionValue = e.conditionValue,
+            sortOrder = e.sortOrder
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/TitleResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/title/presentation/dto/res/TitleResponse.kt
@@ -1,0 +1,32 @@
+package digdaserver.domain.title.presentation.dto.res
+
+import digdaserver.domain.title.domain.entity.UserTitle
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 획득한 칭호 1건. 표시 메타(이름/아이콘/색)는 앱 카탈로그가 [code] 로 매핑한다.
+ */
+@Schema(description = "획득 칭호")
+data class TitleResponse(
+    @field:Schema(description = "칭호 코드", example = "region_gyeongnam")
+    val code: String,
+
+    @field:Schema(description = "획득 그룹방 id(전역 칭호는 null)")
+    val groupRoomId: Long?,
+
+    @field:Schema(description = "획득 당시 그룹방 이름 스냅샷(전역 칭호는 null)")
+    val groupRoomName: String?,
+
+    @field:Schema(description = "획득 시각")
+    val earnedAt: LocalDateTime
+) {
+    companion object {
+        fun from(e: UserTitle): TitleResponse = TitleResponse(
+            code = e.code,
+            groupRoomId = e.groupRoomId,
+            groupRoomName = e.groupRoomName,
+            earnedAt = e.earnedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
@@ -47,10 +47,9 @@ class UserProfileServiceImpl(
     @Transactional
     override fun updateProfile(userId: UUID, request: UpdateProfileRequest): MyProfileResponse {
         log.info(
-            "userId={}, action=프로필 수정 요청, fields=[name={}, statusMessage={}, profileImageId={}]",
+            "userId={}, action=프로필 수정 요청, fields=[name={}, profileImageId={}]",
             userId,
             request.name,
-            request.statusMessage,
             request.profileImageId
         )
 
@@ -61,15 +60,6 @@ class UserProfileServiceImpl(
             if (name.length < 2) throw DigdaException(ErrorCode.NAME_TOO_SHORT)
             if (name.length > 20) throw DigdaException(ErrorCode.NAME_TOO_LONG)
             user.name = name
-        }
-
-        request.statusMessage?.let { msg ->
-            if (msg.isEmpty()) {
-                user.clearStatusMessage()
-            } else {
-                if (msg.length > 100) throw DigdaException(ErrorCode.STATUS_MESSAGE_TOO_LONG)
-                user.statusMessage = msg
-            }
         }
 
         // profileImageId: null(미전송)=변경없음, Optional.empty=초기화, Optional(값)=변경.

--- a/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
@@ -40,9 +40,6 @@ class User(
     @Column(name = "profile_image")
     var profileImage: String? = null,
 
-    @Column(name = "status_message", length = 100)
-    var statusMessage: String? = null,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "social_provider", nullable = false)
     val socialProvider: SocialProvider,
@@ -80,18 +77,13 @@ class User(
     var privacySetting: UserPrivacySetting? = null
         protected set
 
-    fun updateProfile(name: String?, statusMessage: String?, profileImage: String?) {
+    fun updateProfile(name: String?, profileImage: String?) {
         name?.let { this.name = it }
-        statusMessage?.let { this.statusMessage = it }
         profileImage?.let { this.profileImage = it }
     }
 
     fun resetProfileImage() {
         this.profileImage = null
-    }
-
-    fun clearStatusMessage() {
-        this.statusMessage = null
     }
 
     fun agreeToTerms(terms: UserTerms) {

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateProfileRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/req/UpdateProfileRequest.kt
@@ -4,6 +4,5 @@ import java.util.Optional
 
 data class UpdateProfileRequest(
     val name: String? = null,
-    val statusMessage: String? = null,
     val profileImageId: Optional<String>? = null
 )

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
@@ -8,7 +8,6 @@ data class MyProfileResponse(
     val name: String,
     val email: String?,
     val profileImage: String?,
-    val statusMessage: String?,
     val provider: String,
     val createdAt: LocalDateTime
 ) {
@@ -18,7 +17,6 @@ data class MyProfileResponse(
             name = user.name,
             email = user.email,
             profileImage = user.profileImage,
-            statusMessage = user.statusMessage,
             provider = user.socialProvider.name.lowercase(),
             createdAt = user.createdAt
         )

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -124,6 +124,9 @@ enum class ErrorCode(
     EXHIBIT_NOT_FOUND("EXHIBIT_NOT_FOUND", "존재하지 않는 전시관 카드입니다.", 404),
     EXHIBIT_ACCESS_DENIED("EXHIBIT_ACCESS_DENIED", "전시관 접근 권한이 없습니다.", 403),
 
+    // ── Title (칭호) ──
+    TITLE_NOT_OWNED("TITLE_NOT_OWNED", "획득하지 않은 칭호는 장착할 수 없습니다.", 400),
+
     // ── Rate Limit ──
     RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),
 

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -38,7 +38,6 @@ enum class ErrorCode(
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", 409),
     NAME_TOO_SHORT("NAME_TOO_SHORT", "닉네임은 2자 이상이어야 합니다.", 400),
     NAME_TOO_LONG("NAME_TOO_LONG", "닉네임은 20자 이하여야 합니다.", 400),
-    STATUS_MESSAGE_TOO_LONG("STATUS_MESSAGE_TOO_LONG", "상태 메시지는 100자 이하여야 합니다.", 400),
     INVALID_ROLE("INVALID_ROLE", "유효하지 않은 역할입니다.", 400),
 
     // ── GroupRoom ──


### PR DESCRIPTION
다른 PC 작업분 통합. dev 로 머지.

- 칭호(Title) 도메인 — 카탈로그/획득/장착, 어드민 제어
- 앱 설정/대공지 컨트롤러
- ktlintFormat 적용 (인자 줄바꿈 정렬)

🤖 Generated with [Claude Code](https://claude.com/claude-code)