### PR TITLE
fix(auth): 약관 동의에서 만 14세 확인 필수 검증 제거

### DIFF
--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/TermsServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/auth/TermsServiceImpl.kt
@@ -17,7 +17,8 @@ class TermsServiceImpl(
 ) : TermsService {
 
     override fun agreeToTerms(userId: UUID, request: TermsAgreeRequest) {
-        if (!request.termsOfService || !request.privacyPolicy || !request.ageConfirmation) {
+        // 만 14세 확인 항목 제거 — 이용약관/개인정보처리방침 동의만 필수로 검증한다.
+        if (!request.termsOfService || !request.privacyPolicy) {
             throw DigdaException(ErrorCode.REQUIRED_TERMS_NOT_AGREED)
         }
 

--- a/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/req/TermsAgreeRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/req/TermsAgreeRequest.kt
@@ -11,8 +11,8 @@ data class TermsAgreeRequest(
     @Schema(description = "개인정보처리방침 동의 (필수)", example = "true")
     val privacyPolicy: Boolean,
 
-    @Schema(description = "만 14세 이상 확인 (필수)", example = "true")
-    val ageConfirmation: Boolean,
+    @Schema(description = "연령 확인 (레거시 호환용, 미전송 시 true)", example = "true")
+    val ageConfirmation: Boolean = true,
 
     @Schema(description = "마케팅 수신 동의 (선택)", example = "false")
     val marketingConsent: Boolean = false,


### PR DESCRIPTION
## 변경 사항
회원가입 약관 동의에서 **만 14세 이상 확인** 항목을 필수 검증에서 제거합니다. (앱 동의 화면·개인정보처리방침의 만 14세 제거와 동기화)

- `TermsServiceImpl`: 필수 동의 검증을 이용약관·개인정보처리방침으로 한정 (`ageConfirmation` 강제 제외)
- `TermsAgreeRequest.ageConfirmation` 기본값 `true` — 앱이 미전송해도 `user_terms` NOT NULL 컬럼 호환

## 호환성
- `user_terms.age_confirmation` 컬럼/엔티티는 **유지** → DB 마이그레이션 불필요
- 레거시 앱(ageConfirmation 전송)도 그대로 동작

## 검증
- `./gradlew ktlintFormat ktlintCheck` — 통과
- `./gradlew compileKotlin` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)