### PR TITLE
feat(user/auth): 이메일 중복 가입 차단 + 표시 이름 분리

### DIFF
--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CommentUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CommentUserSummary.kt
@@ -11,7 +11,7 @@ data class CommentUserSummary(
     companion object {
         fun from(user: User): CommentUserSummary = CommentUserSummary(
             userId = user.id,
-            name = user.name,
+            name = user.displayedName(),
             profileImage = user.profileImage
         )
     }

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryUserSummary.kt
@@ -11,7 +11,7 @@ data class DiaryUserSummary(
     companion object {
         fun from(user: User): DiaryUserSummary = DiaryUserSummary(
             userId = user.id,
-            name = user.name,
+            name = user.displayedName(),
             profileImage = user.profileImage
         )
     }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
@@ -10,7 +10,7 @@ data class MembershipSummary(
 ) {
     companion object {
         fun from(membership: Membership): MembershipSummary = MembershipSummary(
-            name = membership.user.name,
+            name = membership.user.displayedName(),
             profileImage = membership.user.profileImage,
             role = membership.role.name.lowercase(),
             color = membership.color

--- a/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.kt
@@ -169,6 +169,13 @@ class SocialLoginServiceImpl(
             return Pair(existingUser, isNewUser)
         }
 
+        // 신규 가입: 같은 이메일을 쓰는 다른 계정이 이미 있으면 가입을 막는다(이메일 중복 방지).
+        val email = userResponse.getEmail()
+        if (!email.isNullOrBlank() && userRepository.existsByEmail(email)) {
+            log.info("회원가입 차단: 이메일 중복, provider={}", provider)
+            throw DigdaException(ErrorCode.DUPLICATE_EMAIL)
+        }
+
         val profileImage = if (provider == SocialProvider.APPLE) appleProfile else userResponse.getProfile()
 
         val newUser = User(

--- a/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/res/UserResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/oauth2/presentation/dto/res/UserResponse.kt
@@ -28,7 +28,7 @@ data class UserResponse(
         fun from(user: User): UserResponse {
             return UserResponse(
                 id = user.id.toString(),
-                name = user.name,
+                name = user.displayedName(),
                 email = user.email,
                 profileImage = user.profileImage,
                 provider = user.socialProvider.value,

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/UserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/UserSummary.kt
@@ -11,7 +11,7 @@ data class UserSummary(
     companion object {
         fun from(user: User): UserSummary = UserSummary(
             userId = user.id,
-            name = user.name,
+            name = user.displayedName(),
             profileImage = user.profileImage
         )
     }

--- a/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoUserSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/todo/presentation/dto/res/TodoUserSummary.kt
@@ -11,7 +11,7 @@ data class TodoUserSummary(
     companion object {
         fun from(user: User): TodoUserSummary = TodoUserSummary(
             userId = user.id,
-            name = user.name,
+            name = user.displayedName(),
             profileImage = user.profileImage
         )
     }

--- a/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/user/application/service/impl/UserProfileServiceImpl.kt
@@ -59,7 +59,8 @@ class UserProfileServiceImpl(
         request.name?.let { name ->
             if (name.length < 2) throw DigdaException(ErrorCode.NAME_TOO_SHORT)
             if (name.length > 20) throw DigdaException(ErrorCode.NAME_TOO_LONG)
-            user.name = name
+            // 소셜 원본 name 은 보존하고 표시 이름(displayName)만 갱신한다.
+            user.displayName = name
         }
 
         // profileImageId: null(미전송)=변경없음, Optional.empty=초기화, Optional(값)=변경.

--- a/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
@@ -34,8 +34,13 @@ class User(
 
     var email: String?,
 
+    // 소셜 로그인에서 받아온 원본 이름. 가입 시 1회 설정되며 프로필 편집으로는 바뀌지 않는다.
     @Column(nullable = false, length = 20)
     var name: String,
+
+    // 사용자가 프로필 편집에서 직접 지정한 표시 이름. null 이면 소셜 원본(name)을 그대로 노출.
+    @Column(name = "display_name", length = 20)
+    var displayName: String? = null,
 
     @Column(name = "profile_image")
     var profileImage: String? = null,
@@ -77,8 +82,12 @@ class User(
     var privacySetting: UserPrivacySetting? = null
         protected set
 
+    /** 화면에 노출할 이름 — 사용자가 지정한 표시 이름이 있으면 그것을, 없으면 소셜 원본 이름을 쓴다. */
+    fun displayedName(): String = displayName ?: name
+
     fun updateProfile(name: String?, profileImage: String?) {
-        name?.let { this.name = it }
+        // 프로필 편집은 원본 name 을 건드리지 않고 표시 이름(displayName)만 갱신한다.
+        name?.let { this.displayName = it }
         profileImage?.let { this.profileImage = it }
     }
 

--- a/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/repository/UserRepository.kt
@@ -17,6 +17,8 @@ interface UserRepository : JpaRepository<User, UUID> {
 
     fun findBySocialIdAndSocialProvider(socialId: String, socialProvider: SocialProvider): Optional<User>
 
+    fun existsByEmail(email: String): Boolean
+
     fun countByRole(role: Role): Long
 
     fun findAllByRole(role: Role): List<User>

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
@@ -14,7 +14,7 @@ data class MyProfileResponse(
     companion object {
         fun from(user: User): MyProfileResponse = MyProfileResponse(
             id = user.id.toString(),
-            name = user.name,
+            name = user.displayedName(),
             email = user.email,
             profileImage = user.profileImage,
             provider = user.socialProvider.name.lowercase(),


### PR DESCRIPTION
## 변경 사항

### 1. 이메일 중복 가입 차단
- 소셜 **신규 가입** 시 동일 이메일을 쓰는 계정이 이미 있으면 `DUPLICATE_EMAIL`(409) 로 차단
- 기존 동일 소셜 계정 재로그인(socialId 일치)은 영향 없음
- 이메일이 null/blank 인 경우는 검사 생략

### 2. 표시 이름(displayName) 분리
- `User.display_name` 컬럼 추가
  - `name` = 소셜 로그인 원본 이름(가입 시 1회 설정, 편집해도 불변)
  - `displayName` = 프로필 편집에서 사용자가 지정한 이름
- `displayedName() = displayName ?: name` 으로 사용자 노출 이름 일원화
- 프로필 편집(`updateProfile`)은 `displayName` 만 갱신
- 응답 DTO 반영: MyProfile / 로그인 user / 일기·댓글·일정·할일 작성자 / 멤버 요약

> ⚠️ `display_name` 컬럼 DDL 은 운영 DB 에 수동 추가 예정입니다 (prod `ddl-auto=none`). 마이그레이션 스크립트는 포함하지 않았습니다.

빌드: `./gradlew ktlintFormat` ✅, `compileKotlin` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)