### PR TITLE
feat(report/block): 신고·차단 시스템 + 조회 숨김 필터

### DIFF
--- a/src/main/kotlin/digdaserver/admin/report/application/service/AdminReportService.kt
+++ b/src/main/kotlin/digdaserver/admin/report/application/service/AdminReportService.kt
@@ -1,0 +1,19 @@
+package digdaserver.admin.report.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.report.presentation.dto.res.AdminReportResponse
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+
+interface AdminReportService {
+
+    fun search(
+        status: ReportStatus?,
+        targetType: ReportTargetType?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminReportResponse>
+
+    /** 신고 처리 상태 전이(RESOLVED/DISMISSED). reviewedAt 을 기록한다. */
+    fun updateStatus(reportId: Long, status: ReportStatus): AdminReportResponse
+}

--- a/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
@@ -1,0 +1,40 @@
+package digdaserver.admin.report.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.report.application.service.AdminReportService
+import digdaserver.admin.report.presentation.dto.res.AdminReportResponse
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import digdaserver.domain.report.domain.repository.ReportRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminReportServiceImpl(
+    private val reportRepository: ReportRepository
+) : AdminReportService {
+
+    override fun search(
+        status: ReportStatus?,
+        targetType: ReportTargetType?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminReportResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val result = reportRepository.searchForAdmin(status, targetType, pageable)
+        return AdminPageResponse.of(result, AdminReportResponse::from)
+    }
+
+    @Transactional
+    override fun updateStatus(reportId: Long, status: ReportStatus): AdminReportResponse {
+        val report = reportRepository.findById(reportId)
+            .orElseThrow { DigdaException(ErrorCode.RESOURCE_NOT_FOUND) }
+        report.markReviewed(status)
+        return AdminReportResponse.from(report)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/report/presentation/controller/AdminReportController.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/controller/AdminReportController.kt
@@ -1,0 +1,46 @@
+package digdaserver.admin.report.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.report.application.service.AdminReportService
+import digdaserver.admin.report.presentation.dto.req.AdminUpdateReportStatusRequest
+import digdaserver.admin.report.presentation.dto.res.AdminReportResponse
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/reports")
+@Tag(name = "Admin - Report", description = "관리자 신고 관리 API")
+class AdminReportController(
+    private val adminReportService: AdminReportService
+) {
+
+    @Operation(summary = "신고 목록 조회", description = "상태/대상종류 필터 + 페이징. 최신순.")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) status: ReportStatus?,
+        @RequestParam(required = false) targetType: ReportTargetType?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminReportResponse>> {
+        return ResponseEntity.ok(adminReportService.search(status, targetType, page, size))
+    }
+
+    @Operation(summary = "신고 처리", description = "신고를 RESOLVED(조치 완료) 또는 DISMISSED(반려)로 전이합니다.")
+    @PatchMapping("/{reportId}/status")
+    fun updateStatus(
+        @PathVariable reportId: Long,
+        @RequestBody request: AdminUpdateReportStatusRequest
+    ): ResponseEntity<AdminReportResponse> {
+        return ResponseEntity.ok(adminReportService.updateStatus(reportId, request.status))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/report/presentation/dto/req/AdminUpdateReportStatusRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/dto/req/AdminUpdateReportStatusRequest.kt
@@ -1,0 +1,8 @@
+package digdaserver.admin.report.presentation.dto.req
+
+import digdaserver.domain.report.domain.entity.ReportStatus
+
+/** 신고 처리 상태 전이 요청(RESOLVED/DISMISSED). */
+data class AdminUpdateReportStatusRequest(
+    val status: ReportStatus
+)

--- a/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
@@ -1,0 +1,61 @@
+package digdaserver.admin.report.presentation.dto.res
+
+import digdaserver.domain.report.domain.entity.Report
+import digdaserver.domain.report.domain.entity.ReportReason
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 신고 정보")
+data class AdminReportResponse(
+
+    @Schema(description = "신고 ID")
+    val reportId: Long,
+
+    @Schema(description = "신고자 ID(UUID)")
+    val reporterId: String,
+
+    @Schema(description = "신고자 이름")
+    val reporterName: String,
+
+    @Schema(description = "대상 종류")
+    val targetType: ReportTargetType,
+
+    @Schema(description = "대상 ID(콘텐츠는 PK, USER 는 UUID)")
+    val targetId: String,
+
+    @Schema(description = "대상이 속한 그룹방 ID")
+    val groupRoomId: Long?,
+
+    @Schema(description = "신고 사유")
+    val reason: ReportReason,
+
+    @Schema(description = "상세 사유")
+    val detail: String?,
+
+    @Schema(description = "처리 상태")
+    val status: ReportStatus,
+
+    @Schema(description = "접수 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "검토 시각")
+    val reviewedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(report: Report): AdminReportResponse = AdminReportResponse(
+            reportId = report.id,
+            reporterId = report.reporter.id.toString(),
+            reporterName = report.reporter.displayedName(),
+            targetType = report.targetType,
+            targetId = report.targetId,
+            groupRoomId = report.groupRoomId,
+            reason = report.reason,
+            detail = report.detail,
+            status = report.status,
+            createdAt = report.createdAt,
+            reviewedAt = report.reviewedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/block/application/service/BlockService.kt
+++ b/src/main/kotlin/digdaserver/domain/block/application/service/BlockService.kt
@@ -1,0 +1,24 @@
+package digdaserver.domain.block.application.service
+
+import digdaserver.domain.block.domain.entity.HideReason
+import digdaserver.domain.block.domain.entity.HideTargetType
+import digdaserver.domain.block.presentation.dto.res.BlockedUserResponse
+import java.util.UUID
+
+interface BlockService {
+
+    /** 사용자 단위 차단(전역·단방향). 멱등 — 이미 차단 중이면 무시. */
+    fun blockUser(blockerId: UUID, blockedUserId: UUID)
+
+    /** 차단 해제. 멱등 — 차단 중이 아니면 무시. */
+    fun unblockUser(blockerId: UUID, blockedUserId: UUID)
+
+    /** 마이페이지 차단 목록(최신순). */
+    fun listBlockedUsers(blockerId: UUID): List<BlockedUserResponse>
+
+    /** 개별 콘텐츠 숨김(본인에게서만). 신고 자동 숨김도 이걸 [HideReason.REPORTED] 로 호출. 멱등. */
+    fun hideContent(userId: UUID, targetType: HideTargetType, targetId: Long, reason: HideReason)
+
+    /** 개별 콘텐츠 숨김 해제. 멱등. */
+    fun unhideContent(userId: UUID, targetType: HideTargetType, targetId: Long)
+}

--- a/src/main/kotlin/digdaserver/domain/block/application/service/ContentVisibilityService.kt
+++ b/src/main/kotlin/digdaserver/domain/block/application/service/ContentVisibilityService.kt
@@ -1,0 +1,82 @@
+package digdaserver.domain.block.application.service
+
+import digdaserver.domain.block.domain.entity.HideReason
+import digdaserver.domain.block.domain.entity.HideTargetType
+import digdaserver.domain.block.domain.repository.ContentHideRepository
+import digdaserver.domain.block.domain.repository.UserBlockRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * 조회 시 "이 뷰어에게 숨겨야 하는가"를 한곳에서 판정한다.
+ *
+ * 핵심 원칙: 숨김 ≠ 삭제. 콘텐츠는 DB 와 집계(하루 1편 슬롯·시그니처 지도 색칠)에 그대로 남고,
+ * 조회 시점에만 본문을 비우고 [VisibilityReason] 플래그를 내려보낸다. 그래서 차단/신고가
+ * 그룹 공용 규칙(하루 1편)이나 지도 색칠을 깨뜨리지 않는다.
+ *
+ * 일기/댓글/일정 서비스는 목록을 만들 때 [forViewer] 를 한 번 호출해 컨텍스트를 받고,
+ * 각 항목마다 `*HiddenReason(...)` 으로 숨김 사유 코드(없으면 null)를 구한다.
+ */
+@Service
+@Transactional(readOnly = true)
+class ContentVisibilityService(
+    private val userBlockRepository: UserBlockRepository,
+    private val contentHideRepository: ContentHideRepository
+) {
+
+    fun forViewer(viewerId: UUID): ViewerVisibility {
+        val blockedUserIds = userBlockRepository.findBlockedIdsByBlockerId(viewerId).toHashSet()
+        val hiddenDiary = contentHideRepository
+            .findAllByUserIdAndTargetType(viewerId, HideTargetType.DIARY)
+            .associate { it.targetId to it.reason }
+        val hiddenComment = contentHideRepository
+            .findAllByUserIdAndTargetType(viewerId, HideTargetType.COMMENT)
+            .associate { it.targetId to it.reason }
+        val hiddenSchedule = contentHideRepository
+            .findAllByUserIdAndTargetType(viewerId, HideTargetType.SCHEDULE)
+            .associate { it.targetId to it.reason }
+        return ViewerVisibility(blockedUserIds, hiddenDiary, hiddenComment, hiddenSchedule)
+    }
+}
+
+/** 숨김 사유 코드 — 앱이 플레이스홀더 문구를 분기하는 데 쓴다. */
+object VisibilityReason {
+    /** 작성자를 사용자 단위로 차단함. */
+    const val BLOCKED_USER = "BLOCKED_USER"
+
+    /** 신고하면서 자동 숨김됨. */
+    const val REPORTED = "REPORTED"
+
+    /** 이 게시물만 직접 숨김. */
+    const val HIDDEN = "HIDDEN"
+}
+
+/**
+ * 한 뷰어의 차단/숨김 스냅샷. 목록 1건 조회마다 재사용해 N+1 을 피한다.
+ * 사용자 단위 차단이 개별 숨김보다 우선한다.
+ */
+class ViewerVisibility(
+    val blockedUserIds: Set<UUID>,
+    private val hiddenDiary: Map<Long, HideReason>,
+    private val hiddenComment: Map<Long, HideReason>,
+    private val hiddenSchedule: Map<Long, HideReason>
+) {
+    fun diaryHiddenReason(diaryId: Long, authorId: UUID): String? =
+        resolve(authorId, hiddenDiary[diaryId])
+
+    fun commentHiddenReason(commentId: Long, authorId: UUID): String? =
+        resolve(authorId, hiddenComment[commentId])
+
+    fun scheduleHiddenReason(scheduleId: Long, authorId: UUID): String? =
+        resolve(authorId, hiddenSchedule[scheduleId])
+
+    private fun resolve(authorId: UUID, itemHide: HideReason?): String? {
+        if (authorId in blockedUserIds) return VisibilityReason.BLOCKED_USER
+        return when (itemHide) {
+            HideReason.REPORTED -> VisibilityReason.REPORTED
+            HideReason.HIDDEN -> VisibilityReason.HIDDEN
+            null -> null
+        }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/block/application/service/impl/BlockServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/block/application/service/impl/BlockServiceImpl.kt
@@ -1,0 +1,118 @@
+package digdaserver.domain.block.application.service.impl
+
+import digdaserver.domain.block.application.service.BlockService
+import digdaserver.domain.block.domain.entity.ContentHide
+import digdaserver.domain.block.domain.entity.HideReason
+import digdaserver.domain.block.domain.entity.HideTargetType
+import digdaserver.domain.block.domain.entity.UserBlock
+import digdaserver.domain.block.domain.repository.ContentHideRepository
+import digdaserver.domain.block.domain.repository.UserBlockRepository
+import digdaserver.domain.block.presentation.dto.res.BlockedUserResponse
+import digdaserver.domain.log.application.service.UserActionLogService
+import digdaserver.domain.log.domain.entity.UserAction
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class BlockServiceImpl(
+    private val userBlockRepository: UserBlockRepository,
+    private val contentHideRepository: ContentHideRepository,
+    private val userRepository: UserRepository,
+    private val userActionLogService: UserActionLogService
+) : BlockService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun blockUser(blockerId: UUID, blockedUserId: UUID) {
+        if (blockerId == blockedUserId) throw DigdaException(ErrorCode.CANNOT_BLOCK_SELF)
+
+        val blocker = userRepository.findById(blockerId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        val blocked = userRepository.findById(blockedUserId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedUserId)) {
+            log.info("action=사용자 차단 멱등 스킵(이미 차단됨), blockerId={}, blockedId={}", blockerId, blockedUserId)
+            return
+        }
+        userBlockRepository.save(UserBlock(blocker = blocker, blocked = blocked))
+        userActionLogService.record(
+            actorId = blockerId,
+            action = UserAction.BLOCK_USER,
+            targetType = "USER",
+            targetId = blockedUserId.toString(),
+            detail = null
+        )
+        log.info("action=사용자 차단, blockerId={}, blockedId={}", blockerId, blockedUserId)
+    }
+
+    @Transactional
+    override fun unblockUser(blockerId: UUID, blockedUserId: UUID) {
+        val block = userBlockRepository.findByBlockerIdAndBlockedId(blockerId, blockedUserId)
+        if (block == null) {
+            log.info("action=차단 해제 멱등 스킵(차단 아님), blockerId={}, blockedId={}", blockerId, blockedUserId)
+            return
+        }
+        userBlockRepository.delete(block)
+        userActionLogService.record(
+            actorId = blockerId,
+            action = UserAction.UNBLOCK_USER,
+            targetType = "USER",
+            targetId = blockedUserId.toString(),
+            detail = null
+        )
+        log.info("action=차단 해제, blockerId={}, blockedId={}", blockerId, blockedUserId)
+    }
+
+    override fun listBlockedUsers(blockerId: UUID): List<BlockedUserResponse> {
+        return userBlockRepository.findAllByBlockerIdWithBlocked(blockerId)
+            .map { BlockedUserResponse.from(it) }
+    }
+
+    @Transactional
+    override fun hideContent(userId: UUID, targetType: HideTargetType, targetId: Long, reason: HideReason) {
+        if (contentHideRepository.existsByUserIdAndTargetTypeAndTargetId(userId, targetType, targetId)) {
+            log.info(
+                "action=콘텐츠 숨김 멱등 스킵(이미 숨김), userId={}, type={}, targetId={}",
+                userId,
+                targetType,
+                targetId
+            )
+            return
+        }
+        contentHideRepository.save(
+            ContentHide(userId = userId, targetType = targetType, targetId = targetId, reason = reason)
+        )
+        userActionLogService.record(
+            actorId = userId,
+            action = UserAction.HIDE_CONTENT,
+            targetType = targetType.name,
+            targetId = targetId.toString(),
+            detail = "reason=$reason"
+        )
+        log.info("action=콘텐츠 숨김, userId={}, type={}, targetId={}, reason={}", userId, targetType, targetId, reason)
+    }
+
+    @Transactional
+    override fun unhideContent(userId: UUID, targetType: HideTargetType, targetId: Long) {
+        val hide = contentHideRepository.findByUserIdAndTargetTypeAndTargetId(userId, targetType, targetId)
+        if (hide == null) {
+            log.info(
+                "action=콘텐츠 숨김 해제 멱등 스킵(숨김 아님), userId={}, type={}, targetId={}",
+                userId,
+                targetType,
+                targetId
+            )
+            return
+        }
+        contentHideRepository.delete(hide)
+        log.info("action=콘텐츠 숨김 해제, userId={}, type={}, targetId={}", userId, targetType, targetId)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/block/domain/entity/ContentHide.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/entity/ContentHide.kt
@@ -1,0 +1,56 @@
+package digdaserver.domain.block.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 개별 콘텐츠 숨김(특정 사용자에게서만). "이 게시물 숨기기" 또는 신고 시 자동으로 생성된다.
+ * 사용자 단위 차단은 [UserBlock] 로 따로 둔다.
+ *
+ * 숨김은 콘텐츠를 삭제하지 않는다 — 하루 1편 슬롯/지도 집계는 유지하고 조회 시 숨김만 한다.
+ */
+@Entity
+@Table(
+    name = "content_hide",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_content_hide", columnNames = ["user_id", "target_type", "target_id"])
+    ],
+    indexes = [
+        Index(name = "idx_content_hide_user", columnList = "user_id, target_type")
+    ]
+)
+class ContentHide(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "content_hide_id")
+    val id: Long = 0L,
+
+    /** 숨긴 주체(이 사용자에게서만 안 보인다). */
+    @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+    val userId: UUID,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 32)
+    val targetType: HideTargetType,
+
+    @Column(name = "target_id", nullable = false)
+    val targetId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    val reason: HideReason,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/digdaserver/domain/block/domain/entity/HideReason.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/entity/HideReason.kt
@@ -1,0 +1,12 @@
+package digdaserver.domain.block.domain.entity
+
+/**
+ * 개별 콘텐츠가 숨겨진 이유. 앱에서 플레이스홀더 문구를 분기하는 데 쓴다.
+ *
+ * - [REPORTED] : 신고하면서 본인에게서 자동 숨김된 경우.
+ * - [HIDDEN]   : 신고 없이 "이 게시물 숨기기"로 직접 숨긴 경우.
+ */
+enum class HideReason {
+    REPORTED,
+    HIDDEN
+}

--- a/src/main/kotlin/digdaserver/domain/block/domain/entity/HideTargetType.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/entity/HideTargetType.kt
@@ -1,0 +1,8 @@
+package digdaserver.domain.block.domain.entity
+
+/** 개별 콘텐츠 숨김 대상 종류. 사용자 단위 차단은 [UserBlock] 로 별도 관리한다. */
+enum class HideTargetType {
+    DIARY,
+    COMMENT,
+    SCHEDULE
+}

--- a/src/main/kotlin/digdaserver/domain/block/domain/entity/UserBlock.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/entity/UserBlock.kt
@@ -1,0 +1,47 @@
+package digdaserver.domain.block.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+/**
+ * 사용자 단위 차단(단방향·전역). [blocker] 의 화면에서 [blocked] 의 모든 일기·댓글·일정이
+ * 숨겨진다. 양방향이 아니므로 차단당한 쪽은 영향을 받지 않는다.
+ *
+ * 차단은 콘텐츠를 삭제하지 않는다 — 집계(시그니처 지도 색칠)·하루 1편 슬롯은 그대로 유지되고,
+ * 조회 시점에 숨김 처리만 한다.
+ */
+@Entity
+@Table(
+    name = "user_block",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_user_block", columnNames = ["blocker_id", "blocked_id"])
+    ]
+)
+class UserBlock(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_block_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    val blocker: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    val blocked: User,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/digdaserver/domain/block/domain/repository/ContentHideRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/repository/ContentHideRepository.kt
@@ -1,0 +1,26 @@
+package digdaserver.domain.block.domain.repository
+
+import digdaserver.domain.block.domain.entity.ContentHide
+import digdaserver.domain.block.domain.entity.HideTargetType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface ContentHideRepository : JpaRepository<ContentHide, Long> {
+
+    fun existsByUserIdAndTargetTypeAndTargetId(
+        userId: UUID,
+        targetType: HideTargetType,
+        targetId: Long
+    ): Boolean
+
+    fun findByUserIdAndTargetTypeAndTargetId(
+        userId: UUID,
+        targetType: HideTargetType,
+        targetId: Long
+    ): ContentHide?
+
+    /** 조회 필터용 — 특정 사용자가 특정 종류에서 숨긴 콘텐츠 목록(id→reason 매핑에 사용). */
+    fun findAllByUserIdAndTargetType(userId: UUID, targetType: HideTargetType): List<ContentHide>
+}

--- a/src/main/kotlin/digdaserver/domain/block/domain/repository/UserBlockRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/repository/UserBlockRepository.kt
@@ -1,0 +1,26 @@
+package digdaserver.domain.block.domain.repository
+
+import digdaserver.domain.block.domain.entity.UserBlock
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface UserBlockRepository : JpaRepository<UserBlock, Long> {
+
+    fun existsByBlockerIdAndBlockedId(blockerId: UUID, blockedId: UUID): Boolean
+
+    fun findByBlockerIdAndBlockedId(blockerId: UUID, blockedId: UUID): UserBlock?
+
+    /** 차단 목록(마이페이지) — 최신순. blocked 를 fetch 해 이름/프로필을 한 번에 로드. */
+    @Query(
+        "SELECT b FROM UserBlock b JOIN FETCH b.blocked WHERE b.blocker.id = :blockerId ORDER BY b.createdAt DESC"
+    )
+    fun findAllByBlockerIdWithBlocked(@Param("blockerId") blockerId: UUID): List<UserBlock>
+
+    /** 조회 필터용 — 내가 차단한 사용자 ID 집합. */
+    @Query("SELECT b.blocked.id FROM UserBlock b WHERE b.blocker.id = :blockerId")
+    fun findBlockedIdsByBlockerId(@Param("blockerId") blockerId: UUID): List<UUID>
+}

--- a/src/main/kotlin/digdaserver/domain/block/presentation/controller/BlockController.kt
+++ b/src/main/kotlin/digdaserver/domain/block/presentation/controller/BlockController.kt
@@ -1,0 +1,72 @@
+package digdaserver.domain.block.presentation.controller
+
+import digdaserver.domain.block.application.service.BlockService
+import digdaserver.domain.block.domain.entity.HideReason
+import digdaserver.domain.block.presentation.dto.req.HideContentRequest
+import digdaserver.domain.block.presentation.dto.res.BlockedUserResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Block", description = "차단/숨김 API")
+class BlockController(
+    private val blockService: BlockService
+) {
+
+    @Operation(summary = "사용자 차단", description = "해당 사용자의 모든 일기·댓글·일정을 내 화면에서 숨깁니다(전역·단방향).")
+    @PostMapping("/blocks/users/{userId}")
+    fun blockUser(
+        @AuthenticationPrincipal myId: String,
+        @PathVariable userId: String
+    ): ResponseEntity<Void> {
+        blockService.blockUser(UUID.fromString(myId), UUID.fromString(userId))
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "사용자 차단 해제")
+    @DeleteMapping("/blocks/users/{userId}")
+    fun unblockUser(
+        @AuthenticationPrincipal myId: String,
+        @PathVariable userId: String
+    ): ResponseEntity<Void> {
+        blockService.unblockUser(UUID.fromString(myId), UUID.fromString(userId))
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "차단 목록 조회", description = "마이페이지 — 내가 차단한 사용자 목록(최신순).")
+    @GetMapping("/blocks/users")
+    fun listBlockedUsers(
+        @AuthenticationPrincipal myId: String
+    ): ResponseEntity<List<BlockedUserResponse>> {
+        return ResponseEntity.ok(blockService.listBlockedUsers(UUID.fromString(myId)))
+    }
+
+    @Operation(summary = "게시물 숨기기", description = "신고 없이 개별 일기/댓글/일정을 내 화면에서만 숨깁니다.")
+    @PostMapping("/blocks/content")
+    fun hideContent(
+        @AuthenticationPrincipal myId: String,
+        @RequestBody request: HideContentRequest
+    ): ResponseEntity<Void> {
+        blockService.hideContent(UUID.fromString(myId), request.targetType, request.targetId, HideReason.HIDDEN)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "게시물 숨김 해제")
+    @DeleteMapping("/blocks/content")
+    fun unhideContent(
+        @AuthenticationPrincipal myId: String,
+        @RequestBody request: HideContentRequest
+    ): ResponseEntity<Void> {
+        blockService.unhideContent(UUID.fromString(myId), request.targetType, request.targetId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/block/presentation/dto/req/HideContentRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/block/presentation/dto/req/HideContentRequest.kt
@@ -1,0 +1,9 @@
+package digdaserver.domain.block.presentation.dto.req
+
+import digdaserver.domain.block.domain.entity.HideTargetType
+
+/** "이 게시물 숨기기" 요청. 신고 없이 개별 콘텐츠를 본인에게서만 숨긴다. */
+data class HideContentRequest(
+    val targetType: HideTargetType,
+    val targetId: Long
+)

--- a/src/main/kotlin/digdaserver/domain/block/presentation/dto/res/BlockedUserResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/block/presentation/dto/res/BlockedUserResponse.kt
@@ -1,0 +1,22 @@
+package digdaserver.domain.block.presentation.dto.res
+
+import digdaserver.domain.block.domain.entity.UserBlock
+import java.time.LocalDateTime
+import java.util.UUID
+
+/** 마이페이지 차단 목록 한 줄. */
+data class BlockedUserResponse(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?,
+    val blockedAt: LocalDateTime
+) {
+    companion object {
+        fun from(block: UserBlock): BlockedUserResponse = BlockedUserResponse(
+            userId = block.blocked.id,
+            name = block.blocked.displayedName(),
+            profileImage = block.blocked.profileImage,
+            blockedAt = block.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -1,5 +1,7 @@
 package digdaserver.domain.diary.application.service.impl
 
+import digdaserver.domain.block.application.service.ContentVisibilityService
+import digdaserver.domain.block.application.service.VisibilityReason
 import digdaserver.domain.character.application.service.CharacterService
 import digdaserver.domain.comment.domain.entity.CommentTargetType
 import digdaserver.domain.comment.domain.repository.CommentRepository
@@ -62,6 +64,7 @@ class DiaryServiceImpl(
     private val diaryLikeRepository: DiaryLikeRepository,
     private val diaryReactionRepository: DiaryReactionRepository,
     private val groupRegionFillRepository: GroupRegionFillRepository,
+    private val contentVisibilityService: ContentVisibilityService,
     @Lazy private val characterService: CharacterService
 ) : DiaryService {
 
@@ -203,14 +206,19 @@ class DiaryServiceImpl(
             emptySet()
         }
 
+        // 차단/신고 숨김 — 항목을 삭제하지 않고 본문만 비워 플래그를 단다(목록 자리·총개수 유지).
+        val visibility = contentVisibilityService.forViewer(userId)
+
         return DiaryListResponse(
             diaries = diaries.map { diary ->
-                DiarySummaryResponse.from(
+                val summary = DiarySummaryResponse.from(
                     diary = diary,
                     commentCount = commentCountMap[diary.id] ?: 0,
                     likeCount = likeCountMap[diary.id] ?: 0L,
                     likedByMe = diary.id in likedByMeSet
                 )
+                val reason = visibility.diaryHiddenReason(diary.id, diary.createdBy.id)
+                if (reason != null) summary.asHidden(reason) else summary
             },
             total = page.totalElements
         )
@@ -224,19 +232,33 @@ class DiaryServiceImpl(
         // 사진 그리드용: 해당 월의 모든 일기를 이미지까지 한 번에 로드.
         val monthDiaries = diaryRepository.findAllWithImagesByGroupRoomIdAndDateBetween(groupRoomId, startDate, endDate)
 
+        // 차단/신고 숨김 — 일기를 지우지 않고 대표 칸만 숨김 표시. "하루 1편" 슬롯이 빈 날로 보이지 않게.
+        val visibility = contentVisibilityService.forViewer(userId)
+
         // 날짜별 그룹핑. 같은 날 여러 편이면 최신(createdAt DESC, 쿼리에서 이미 정렬)을 대표로 사용.
         val byDate = monthDiaries.groupBy { it.date }
         val entries = byDate.entries
             .sortedBy { it.key }
             .map { (date, diaries) ->
-                val representative = diaries.first()
-                DiaryCalendarEntry(
+                // 대표는 보이는 일기 우선. 전부 숨김이면 첫 일기를 대표로 두되 숨김 표시(슬롯·count 유지).
+                val visible = diaries.firstOrNull {
+                    visibility.diaryHiddenReason(it.id, it.createdBy.id) == null
+                }
+                val representative = visible ?: diaries.first()
+                val entry = DiaryCalendarEntry(
                     date = date,
                     diaryId = representative.id,
                     thumbnailUrl = representative.images.minByOrNull { it.sortOrder }?.url,
                     mood = representative.mood,
                     count = diaries.size
                 )
+                if (visible != null) {
+                    entry
+                } else {
+                    val reason = visibility.diaryHiddenReason(representative.id, representative.createdBy.id)
+                        ?: VisibilityReason.HIDDEN
+                    entry.asHidden(reason)
+                }
             }
         val dates = entries.map { it.date }
 
@@ -292,9 +314,20 @@ class DiaryServiceImpl(
         val likedByMe = diaryLikeRepository.existsByDiaryIdAndUserId(diaryId, userId)
         val reactions = buildReactionSummariesForOneDiary(diaryId, userId)
 
+        // 차단/신고 숨김 — 본문/댓글을 비워 내려보낸다(상세 직접 접근 방어 + 차단 사용자 댓글 숨김).
+        val visibility = contentVisibilityService.forViewer(userId)
+        val diaryResponse = DiaryResponse.from(diary, likeCount, likedByMe, reactions).let { resp ->
+            val reason = visibility.diaryHiddenReason(diary.id, diary.createdBy.id)
+            if (reason != null) resp.asHidden(reason) else resp
+        }
+
         return DiaryDetailResponse(
-            diary = DiaryResponse.from(diary, likeCount, likedByMe, reactions),
-            comments = comments.map { DiaryCommentResponse.from(it) }
+            diary = diaryResponse,
+            comments = comments.map { comment ->
+                val resp = DiaryCommentResponse.from(comment)
+                val reason = visibility.commentHiddenReason(comment.id, comment.createdBy.id)
+                if (reason != null) resp.asHidden(reason) else resp
+            }
         )
     }
 

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
@@ -15,14 +15,27 @@ data class DiaryCalendarResponse(
     val stats: DiaryCalendarStats = DiaryCalendarStats()
 )
 
-/** 캘린더 한 칸(날짜)에 대응하는 대표 일기. 하루 여러 편이면 [count] 로 표시하고 대표 1건을 노출. */
+/**
+ * 캘린더 한 칸(날짜)에 대응하는 대표 일기. 하루 여러 편이면 [count] 로 표시하고 대표 1건을 노출.
+ *
+ * 차단/신고로 숨겨진 일기여도 [count] 는 유지된다 — "하루 1편" 슬롯이 빈 날로 보이지 않게 하기 위함.
+ * 이때 [hidden] 만 true 가 되고 [thumbnailUrl] 은 비워진다.
+ */
 data class DiaryCalendarEntry(
     val date: LocalDate,
     val diaryId: Long,
     val thumbnailUrl: String?,
     val mood: Int,
-    val count: Int
-)
+    val count: Int,
+    val hidden: Boolean = false,
+    val hiddenReason: String? = null
+) {
+    fun asHidden(reason: String): DiaryCalendarEntry = copy(
+        thumbnailUrl = null,
+        hidden = true,
+        hiddenReason = reason
+    )
+}
 
 /**
  * 통계 스트립 값.

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
@@ -7,8 +7,18 @@ data class DiaryCommentResponse(
     val id: Long,
     val text: String,
     val createdBy: DiaryUserSummary,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    /** 차단/신고로 숨겨진 댓글인지. true 면 text 는 비워진 상태. */
+    val hidden: Boolean = false,
+    val hiddenReason: String? = null
 ) {
+    /** 차단/신고로 숨겨야 할 때 — 텍스트를 비운 사본. */
+    fun asHidden(reason: String): DiaryCommentResponse = copy(
+        text = "",
+        hidden = true,
+        hiddenReason = reason
+    )
+
     companion object {
         fun from(comment: Comment): DiaryCommentResponse = DiaryCommentResponse(
             id = comment.id,

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryResponse.kt
@@ -21,8 +21,22 @@ data class DiaryResponse(
     val updatedAt: LocalDateTime,
     val likeCount: Long,
     val likedByMe: Boolean,
-    val reactions: List<DiaryReactionSummary>
+    val reactions: List<DiaryReactionSummary>,
+    /** 이 뷰어에게 숨겨진 일기(차단/신고)인지. true 면 title/content/imageUrls 는 비워진 상태. */
+    val hidden: Boolean = false,
+    /** 숨김 사유 코드(BLOCKED_USER / REPORTED / HIDDEN). 보일 때는 null. */
+    val hiddenReason: String? = null
 ) {
+    /** 차단/신고로 숨겨야 할 때 — 본문을 비운 사본. */
+    fun asHidden(reason: String): DiaryResponse = copy(
+        title = "",
+        content = "",
+        location = null,
+        imageUrls = emptyList(),
+        hidden = true,
+        hiddenReason = reason
+    )
+
     companion object {
         fun from(
             diary: Diary,

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiarySummaryResponse.kt
@@ -20,8 +20,22 @@ data class DiarySummaryResponse(
     val commentCount: Int,
     val likeCount: Long,
     val likedByMe: Boolean,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    /** 이 뷰어에게 숨겨진 일기(차단/신고)인지. true 면 본문 필드는 비워진 상태로 내려간다. */
+    val hidden: Boolean = false,
+    /** 숨김 사유 코드(BLOCKED_USER / REPORTED / HIDDEN). 보일 때는 null. */
+    val hiddenReason: String? = null
 ) {
+    /** 차단/신고로 숨겨야 할 때 — 본문을 비우고 플래그만 남긴 사본. 날짜·기분·작성자는 슬롯/표시용으로 유지. */
+    fun asHidden(reason: String): DiarySummaryResponse = copy(
+        title = "",
+        location = null,
+        thumbnailUrl = null,
+        imageCount = 0,
+        hidden = true,
+        hiddenReason = reason
+    )
+
     companion object {
         fun from(
             diary: Diary,

--- a/src/main/kotlin/digdaserver/domain/log/domain/entity/UserAction.kt
+++ b/src/main/kotlin/digdaserver/domain/log/domain/entity/UserAction.kt
@@ -15,5 +15,9 @@ enum class UserAction {
     REMOVE_MEMBER,
     TRANSFER_OWNER,
     CREATE_TODO,
+    REPORT,
+    BLOCK_USER,
+    UNBLOCK_USER,
+    HIDE_CONTENT,
     OTHER
 }

--- a/src/main/kotlin/digdaserver/domain/report/application/service/ReportService.kt
+++ b/src/main/kotlin/digdaserver/domain/report/application/service/ReportService.kt
@@ -1,0 +1,14 @@
+package digdaserver.domain.report.application.service
+
+import digdaserver.domain.report.presentation.dto.req.CreateReportRequest
+import digdaserver.domain.report.presentation.dto.res.ReportResponse
+import java.util.UUID
+
+interface ReportService {
+
+    /**
+     * 신고 접수. 어드민 검토용 기록을 남기고, 콘텐츠형(일기/댓글/일정) 신고는 신고자 본인에게서
+     * 자동 숨김(REPORTED)까지 처리한다. 같은 대상 중복 신고는 멱등 처리.
+     */
+    fun createReport(reporterId: UUID, request: CreateReportRequest): ReportResponse
+}

--- a/src/main/kotlin/digdaserver/domain/report/application/service/impl/ReportServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/report/application/service/impl/ReportServiceImpl.kt
@@ -1,0 +1,116 @@
+package digdaserver.domain.report.application.service.impl
+
+import digdaserver.domain.block.application.service.BlockService
+import digdaserver.domain.block.domain.entity.HideReason
+import digdaserver.domain.block.domain.entity.HideTargetType
+import digdaserver.domain.log.application.service.UserActionLogService
+import digdaserver.domain.log.domain.entity.UserAction
+import digdaserver.domain.report.application.service.ReportService
+import digdaserver.domain.report.domain.entity.Report
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import digdaserver.domain.report.domain.repository.ReportRepository
+import digdaserver.domain.report.presentation.dto.req.CreateReportRequest
+import digdaserver.domain.report.presentation.dto.res.ReportResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class ReportServiceImpl(
+    private val reportRepository: ReportRepository,
+    private val userRepository: UserRepository,
+    private val blockService: BlockService,
+    private val userActionLogService: UserActionLogService
+) : ReportService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun createReport(reporterId: UUID, request: CreateReportRequest): ReportResponse {
+        val reporter = userRepository.findById(reporterId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        // targetId 형식 검증 — 콘텐츠형은 Long, USER 는 UUID 여야 한다.
+        val contentTargetId: Long? = when (request.targetType) {
+            ReportTargetType.USER -> {
+                val targetUuid = runCatching { UUID.fromString(request.targetId) }.getOrNull()
+                    ?: throw DigdaException(ErrorCode.REPORT_INVALID_TARGET)
+                if (targetUuid == reporterId) throw DigdaException(ErrorCode.CANNOT_REPORT_SELF)
+                null
+            }
+            else -> request.targetId.toLongOrNull()
+                ?: throw DigdaException(ErrorCode.REPORT_INVALID_TARGET)
+        }
+
+        // 중복 신고는 멱등 — 새 기록을 만들지 않되, 자동 숨김은 보장한다.
+        val alreadyReported = reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+            reporterId,
+            request.targetType,
+            request.targetId
+        )
+
+        val report = if (alreadyReported) {
+            log.info(
+                "action=신고 멱등 스킵(이미 신고함), reporterId={}, type={}, targetId={}",
+                reporterId,
+                request.targetType,
+                request.targetId
+            )
+            null
+        } else {
+            reportRepository.save(
+                Report(
+                    reporter = reporter,
+                    targetType = request.targetType,
+                    targetId = request.targetId,
+                    groupRoomId = request.groupRoomId,
+                    reason = request.reason,
+                    detail = request.detail?.takeIf { it.isNotBlank() }
+                )
+            )
+        }
+
+        // 콘텐츠형 신고는 신고자 본인에게서 자동 숨김(REPORTED). USER 신고는 차단을 별도 액션으로 둔다.
+        contentTargetId?.let { id ->
+            val hideType = when (request.targetType) {
+                ReportTargetType.DIARY -> HideTargetType.DIARY
+                ReportTargetType.COMMENT -> HideTargetType.COMMENT
+                ReportTargetType.SCHEDULE -> HideTargetType.SCHEDULE
+                ReportTargetType.USER -> null
+            }
+            hideType?.let { blockService.hideContent(reporterId, it, id, HideReason.REPORTED) }
+        }
+
+        userActionLogService.record(
+            actorId = reporterId,
+            action = UserAction.REPORT,
+            targetType = request.targetType.name,
+            targetId = request.targetId,
+            detail = "reason=${request.reason}, groupRoomId=${request.groupRoomId}"
+        )
+        log.info(
+            "action=신고 접수, reporterId={}, type={}, targetId={}, reason={}",
+            reporterId,
+            request.targetType,
+            request.targetId,
+            request.reason
+        )
+
+        // 멱등 스킵이면 기존 기록 응답을 만들 필요까진 없어 합성 응답을 돌려준다(상태는 PENDING 가정).
+        return report?.let { ReportResponse.from(it) } ?: ReportResponse(
+            id = 0L,
+            targetType = request.targetType,
+            targetId = request.targetId,
+            reason = request.reason,
+            status = ReportStatus.PENDING,
+            createdAt = LocalDateTime.now()
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/report/domain/entity/Report.kt
+++ b/src/main/kotlin/digdaserver/domain/report/domain/entity/Report.kt
@@ -1,0 +1,75 @@
+package digdaserver.domain.report.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * 사용자 신고 기록. 어드민 검토용으로만 쌓이며, 신고 자체가 콘텐츠를 지우지는 않는다.
+ * (신고하면 신고자 본인에게서만 자동 숨김 처리 — ContentHide 가 별도로 생성된다.)
+ *
+ * targetId 는 종류에 따라 Long PK 또는 UUID 문자열이라 String 으로 보관한다.
+ */
+@Entity
+@Table(
+    name = "report",
+    indexes = [
+        Index(name = "idx_report_status", columnList = "status"),
+        Index(name = "idx_report_target", columnList = "target_type, target_id")
+    ]
+)
+class Report(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    val reporter: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 32)
+    val targetType: ReportTargetType,
+
+    @Column(name = "target_id", nullable = false, length = 64)
+    val targetId: String,
+
+    /** 신고 대상이 속한 그룹방(있으면). USER 신고나 그룹 외 대상은 null. 어드민 추적용. */
+    @Column(name = "group_room_id")
+    val groupRoomId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    val reason: ReportReason,
+
+    @Column(name = "detail", length = 500)
+    val detail: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    var status: ReportStatus = ReportStatus.PENDING,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "reviewed_at")
+    var reviewedAt: LocalDateTime? = null
+) {
+    fun markReviewed(status: ReportStatus) {
+        this.status = status
+        this.reviewedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportReason.kt
+++ b/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportReason.kt
@@ -1,0 +1,22 @@
+package digdaserver.domain.report.domain.entity
+
+/** 신고 사유. 앱/어드민에서 같은 키를 공유한다. */
+enum class ReportReason {
+    /** 스팸·광고·도배 */
+    SPAM,
+
+    /** 욕설·비방·괴롭힘 */
+    ABUSE,
+
+    /** 음란물·선정성 */
+    SEXUAL,
+
+    /** 폭력·혐오 */
+    VIOLENCE,
+
+    /** 개인정보 노출 */
+    PRIVACY,
+
+    /** 기타(상세 사유 동봉) */
+    ETC
+}

--- a/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportStatus.kt
+++ b/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportStatus.kt
@@ -1,0 +1,13 @@
+package digdaserver.domain.report.domain.entity
+
+/** 신고 처리 상태. 어드민(digda-admin)에서 전이시킨다. */
+enum class ReportStatus {
+    /** 접수됨(미처리) */
+    PENDING,
+
+    /** 검토 후 조치 완료(콘텐츠 삭제 등) */
+    RESOLVED,
+
+    /** 검토 후 반려(문제 없음) */
+    DISMISSED
+}

--- a/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportTargetType.kt
+++ b/src/main/kotlin/digdaserver/domain/report/domain/entity/ReportTargetType.kt
@@ -1,0 +1,14 @@
+package digdaserver.domain.report.domain.entity
+
+/**
+ * 신고 대상 종류.
+ *
+ * - [DIARY] / [COMMENT] / [SCHEDULE] : targetId 는 해당 엔티티의 Long PK 문자열.
+ * - [USER] : targetId 는 사용자 UUID 문자열(프로필 신고).
+ */
+enum class ReportTargetType {
+    DIARY,
+    COMMENT,
+    SCHEDULE,
+    USER
+}

--- a/src/main/kotlin/digdaserver/domain/report/domain/repository/ReportRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/report/domain/repository/ReportRepository.kt
@@ -1,0 +1,39 @@
+package digdaserver.domain.report.domain.repository
+
+import digdaserver.domain.report.domain.entity.Report
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface ReportRepository : JpaRepository<Report, Long> {
+
+    /** 같은 신고자가 같은 대상을 중복 신고하지 못하도록 확인. */
+    fun existsByReporterIdAndTargetTypeAndTargetId(
+        reporterId: UUID,
+        targetType: ReportTargetType,
+        targetId: String
+    ): Boolean
+
+    /** 어드민 목록 — 상태/타입 선택 필터(둘 다 null 이면 전체). 최신순은 Pageable 로 지정. */
+    @Query(
+        """
+        SELECT r FROM Report r
+        WHERE (:status IS NULL OR r.status = :status)
+          AND (:targetType IS NULL OR r.targetType = :targetType)
+        """
+    )
+    fun searchForAdmin(
+        @Param("status") status: ReportStatus?,
+        @Param("targetType") targetType: ReportTargetType?,
+        pageable: Pageable
+    ): Page<Report>
+
+    fun countByStatus(status: ReportStatus): Long
+}

--- a/src/main/kotlin/digdaserver/domain/report/presentation/controller/ReportController.kt
+++ b/src/main/kotlin/digdaserver/domain/report/presentation/controller/ReportController.kt
@@ -1,0 +1,34 @@
+package digdaserver.domain.report.presentation.controller
+
+import digdaserver.domain.report.application.service.ReportService
+import digdaserver.domain.report.presentation.dto.req.CreateReportRequest
+import digdaserver.domain.report.presentation.dto.res.ReportResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Report", description = "신고 API")
+class ReportController(
+    private val reportService: ReportService
+) {
+
+    @Operation(
+        summary = "신고하기",
+        description = "일기/댓글/일정/사용자를 신고합니다. 콘텐츠 신고는 신고자 본인에게서 자동 숨김됩니다."
+    )
+    @PostMapping("/reports")
+    fun createReport(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody request: CreateReportRequest
+    ): ResponseEntity<ReportResponse> {
+        val response = reportService.createReport(UUID.fromString(userId), request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/report/presentation/dto/req/CreateReportRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/report/presentation/dto/req/CreateReportRequest.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.report.presentation.dto.req
+
+import digdaserver.domain.report.domain.entity.ReportReason
+import digdaserver.domain.report.domain.entity.ReportTargetType
+
+/**
+ * 신고 요청.
+ *
+ * - [targetId] : DIARY/COMMENT/SCHEDULE 는 Long PK 문자열, USER 는 UUID 문자열.
+ * - [groupRoomId] : 대상이 속한 그룹방(있으면). 어드민 추적용으로만 쓰여 선택값.
+ */
+data class CreateReportRequest(
+    val targetType: ReportTargetType,
+    val targetId: String,
+    val reason: ReportReason,
+    val detail: String? = null,
+    val groupRoomId: Long? = null
+)

--- a/src/main/kotlin/digdaserver/domain/report/presentation/dto/res/ReportResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/report/presentation/dto/res/ReportResponse.kt
@@ -1,0 +1,27 @@
+package digdaserver.domain.report.presentation.dto.res
+
+import digdaserver.domain.report.domain.entity.Report
+import digdaserver.domain.report.domain.entity.ReportReason
+import digdaserver.domain.report.domain.entity.ReportStatus
+import digdaserver.domain.report.domain.entity.ReportTargetType
+import java.time.LocalDateTime
+
+data class ReportResponse(
+    val id: Long,
+    val targetType: ReportTargetType,
+    val targetId: String,
+    val reason: ReportReason,
+    val status: ReportStatus,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(report: Report): ReportResponse = ReportResponse(
+            id = report.id,
+            targetType = report.targetType,
+            targetId = report.targetId,
+            reason = report.reason,
+            status = report.status,
+            createdAt = report.createdAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
@@ -1,5 +1,6 @@
 package digdaserver.domain.schedule.application.service.impl
 
+import digdaserver.domain.block.application.service.ContentVisibilityService
 import digdaserver.domain.comment.domain.entity.CommentTargetType
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
@@ -34,7 +35,8 @@ class ScheduleServiceImpl(
     private val commentRepository: CommentRepository,
     private val userRepository: UserRepository,
     private val notificationService: NotificationService,
-    private val userActionLogService: UserActionLogService
+    private val userActionLogService: UserActionLogService,
+    private val contentVisibilityService: ContentVisibilityService
 ) : ScheduleService {
 
     override fun getSchedules(userId: UUID, groupRoomId: Long, startDate: LocalDate, endDate: LocalDate): ScheduleListResponse {
@@ -46,7 +48,13 @@ class ScheduleServiceImpl(
         membershipRepository.findByGroupRoomIdAndUserId(groupRoomId, userId)
             .orElseThrow { DigdaException(ErrorCode.NOT_GROUP_ROOM_MEMBER) }
 
-        val schedules = scheduleRepository.findAllByGroupRoomIdAndDateRange(groupRoomId, startDate, endDate)
+        val allSchedules = scheduleRepository.findAllByGroupRoomIdAndDateRange(groupRoomId, startDate, endDate)
+
+        // 차단/신고 숨김 — 일정은 슬롯 제약이 없어 캘린더에서 아예 제외한다(작성자 차단 또는 개별 숨김).
+        val visibility = contentVisibilityService.forViewer(userId)
+        val schedules = allSchedules.filter {
+            visibility.scheduleHiddenReason(it.id, it.createdBy.id) == null
+        }
 
         val scheduleIds = schedules.map { it.id }
         val commentCountMap: Map<Long, Int> = if (scheduleIds.isNotEmpty()) {
@@ -79,9 +87,20 @@ class ScheduleServiceImpl(
         val commentCount = commentRepository.countByTargetTypeAndTargetId(CommentTargetType.SCHEDULE, scheduleId)
         val comments = commentRepository.findAllByTargetTypeAndTargetIdOrderByCreatedAtAsc(CommentTargetType.SCHEDULE, scheduleId)
 
+        // 차단/신고 숨김 — 일정 본문(직접 접근 방어)과 차단 사용자 댓글을 비워 내려보낸다.
+        val visibility = contentVisibilityService.forViewer(userId)
+        val scheduleResponse = ScheduleResponse.from(schedule, commentCount).let { resp ->
+            val reason = visibility.scheduleHiddenReason(schedule.id, schedule.createdBy.id)
+            if (reason != null) resp.asHidden(reason) else resp
+        }
+
         return ScheduleDetailResponse(
-            schedule = ScheduleResponse.from(schedule, commentCount),
-            comments = comments.map { CommentResponse.from(it) }
+            schedule = scheduleResponse,
+            comments = comments.map { comment ->
+                val resp = CommentResponse.from(comment)
+                val reason = visibility.commentHiddenReason(comment.id, comment.createdBy.id)
+                if (reason != null) resp.asHidden(reason) else resp
+            }
         )
     }
 

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/CommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/CommentResponse.kt
@@ -7,8 +7,17 @@ data class CommentResponse(
     val id: Long,
     val text: String,
     val createdBy: UserSummary,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    /** 차단/신고로 숨겨진 댓글인지. true 면 text 는 비워진 상태. */
+    val hidden: Boolean = false,
+    val hiddenReason: String? = null
 ) {
+    fun asHidden(reason: String): CommentResponse = copy(
+        text = "",
+        hidden = true,
+        hiddenReason = reason
+    )
+
     companion object {
         fun from(comment: Comment): CommentResponse = CommentResponse(
             id = comment.id,

--- a/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/presentation/dto/res/ScheduleResponse.kt
@@ -17,8 +17,17 @@ data class ScheduleResponse(
     val participants: List<UserSummary>,
     val createdBy: UserSummary,
     val commentCount: Int,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    /** 차단/신고로 숨겨진 일정인지. 목록에서는 보통 제외되며, 상세 직접 접근 방어용. */
+    val hidden: Boolean = false,
+    val hiddenReason: String? = null
 ) {
+    fun asHidden(reason: String): ScheduleResponse = copy(
+        title = "",
+        hidden = true,
+        hiddenReason = reason
+    )
+
     companion object {
         fun from(schedule: Schedule, commentCount: Int): ScheduleResponse = ScheduleResponse(
             id = schedule.id,

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -131,6 +131,11 @@ enum class ErrorCode(
     // ── Title (칭호) ──
     TITLE_NOT_OWNED("TITLE_NOT_OWNED", "획득하지 않은 칭호는 장착할 수 없습니다.", 400),
 
+    // ── Report / Block ──
+    REPORT_INVALID_TARGET("REPORT_INVALID_TARGET", "잘못된 신고 대상입니다.", 400),
+    CANNOT_REPORT_SELF("CANNOT_REPORT_SELF", "자기 자신은 신고할 수 없습니다.", 400),
+    CANNOT_BLOCK_SELF("CANNOT_BLOCK_SELF", "자기 자신은 차단할 수 없습니다.", 400),
+
     // ── Rate Limit ──
     RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),
 


### PR DESCRIPTION
## 개요
앱스토어 UGC 정책 대응 — 신고/차단 시스템. **숨김 ≠ 삭제** 원칙으로 하루 1편 슬롯·시그니처 지도 색칠 집계를 깨지 않음.

## 도메인
- **report**: 신고 접수(일기/댓글/일정/사용자). 콘텐츠 신고 시 신고자 본인에게 자동 숨김(REPORTED)
- **block**: `UserBlock`(사용자 전역·단방향 차단) + `ContentHide`(개별 숨김)
- **ContentVisibilityService**: 뷰어별 차단/숨김 해석 헬퍼

## 조회 숨김 (본문은 서버에서 비우고 hidden 플래그만 전송)
- 일기 목록/캘린더/상세: `hidden`+`hiddenReason`. 캘린더 슬롯·지도 집계 유지(빈 날로 안 보임)
- 일정: 목록 제외 + 상세 댓글 숨김
- 댓글: 텍스트 비움 + 플래그

## 어드민
- `/api/admin/reports` 목록(상태/타입 필터)·처리(RESOLVED/DISMISSED)

## 비고
- 마이그레이션 SQL 미포함 — 데이터 초기화 후 재적재 전제
- ktlintCheck / compileKotlin 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)