### PR TITLE
feat(report/block/restrict): 차단 알림 억제 · 그룹 6개 제한 · 신고 피신고자 · 서비스 이용 제한

### DIFF
--- a/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
@@ -3,21 +3,35 @@ package digdaserver.admin.report.application.service.impl
 import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.report.application.service.AdminReportService
 import digdaserver.admin.report.presentation.dto.res.AdminReportResponse
+import digdaserver.domain.comment.domain.repository.CommentRepository
+import digdaserver.domain.diary.domain.repository.DiaryRepository
+import digdaserver.domain.report.domain.entity.Report
 import digdaserver.domain.report.domain.entity.ReportStatus
 import digdaserver.domain.report.domain.entity.ReportTargetType
 import digdaserver.domain.report.domain.repository.ReportRepository
+import digdaserver.domain.schedule.domain.repository.ScheduleRepository
+import digdaserver.domain.user.domain.entity.User
+import digdaserver.domain.user.domain.repository.UserRepository
 import digdaserver.global.infra.exception.error.DigdaException
 import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 @Transactional(readOnly = true)
 class AdminReportServiceImpl(
-    private val reportRepository: ReportRepository
+    private val reportRepository: ReportRepository,
+    private val userRepository: UserRepository,
+    private val diaryRepository: DiaryRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val commentRepository: CommentRepository
 ) : AdminReportService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun search(
         status: ReportStatus?,
@@ -27,7 +41,10 @@ class AdminReportServiceImpl(
     ): AdminPageResponse<AdminReportResponse> {
         val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         val result = reportRepository.searchForAdmin(status, targetType, pageable)
-        return AdminPageResponse.of(result, AdminReportResponse::from)
+        return AdminPageResponse.of(result) { report ->
+            val reported = resolveReportedUser(report)
+            AdminReportResponse.from(report, reported?.id?.toString(), reported?.displayedName())
+        }
     }
 
     @Transactional
@@ -35,6 +52,40 @@ class AdminReportServiceImpl(
         val report = reportRepository.findById(reportId)
             .orElseThrow { DigdaException(ErrorCode.RESOURCE_NOT_FOUND) }
         report.markReviewed(status)
-        return AdminReportResponse.from(report)
+        val reported = resolveReportedUser(report)
+        return AdminReportResponse.from(report, reported?.id?.toString(), reported?.displayedName())
+    }
+
+    /**
+     * 신고 대상(targetId)에서 피신고자(작성자)를 해석한다.
+     * - USER: targetId 가 UUID → 그 사용자 본인
+     * - DIARY/SCHEDULE/COMMENT: targetId 가 콘텐츠 PK → 작성자(createdBy)
+     * 콘텐츠가 이미 삭제됐거나 id 파싱이 실패하면 null (어드민 화면에서 '-' 표기).
+     */
+    private fun resolveReportedUser(report: Report): User? {
+        return try {
+            when (report.targetType) {
+                ReportTargetType.USER ->
+                    userRepository.findById(UUID.fromString(report.targetId)).orElse(null)
+                ReportTargetType.DIARY ->
+                    report.targetId.toLongOrNull()
+                        ?.let { diaryRepository.findById(it).orElse(null)?.createdBy }
+                ReportTargetType.SCHEDULE ->
+                    report.targetId.toLongOrNull()
+                        ?.let { scheduleRepository.findById(it).orElse(null)?.createdBy }
+                ReportTargetType.COMMENT ->
+                    report.targetId.toLongOrNull()
+                        ?.let { commentRepository.findById(it).orElse(null)?.createdBy }
+            }
+        } catch (e: Exception) {
+            log.warn(
+                "action=피신고자 해석 실패, reportId={}, targetType={}, targetId={}, error={}",
+                report.id,
+                report.targetType,
+                report.targetId,
+                e.message
+            )
+            null
+        }
     }
 }

--- a/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
@@ -25,6 +25,12 @@ data class AdminReportResponse(
     @Schema(description = "대상 ID(콘텐츠는 PK, USER 는 UUID)")
     val targetId: String,
 
+    @Schema(description = "피신고자 ID(UUID). 대상 콘텐츠/사용자의 작성자. 해석 불가 시 null")
+    val reportedUserId: String?,
+
+    @Schema(description = "피신고자 이름. 해석 불가 시 null")
+    val reportedUserName: String?,
+
     @Schema(description = "대상이 속한 그룹방 ID")
     val groupRoomId: Long?,
 
@@ -44,12 +50,18 @@ data class AdminReportResponse(
     val reviewedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(report: Report): AdminReportResponse = AdminReportResponse(
+        fun from(
+            report: Report,
+            reportedUserId: String? = null,
+            reportedUserName: String? = null
+        ): AdminReportResponse = AdminReportResponse(
             reportId = report.id,
             reporterId = report.reporter.id.toString(),
             reporterName = report.reporter.displayedName(),
             targetType = report.targetType,
             targetId = report.targetId,
+            reportedUserId = reportedUserId,
+            reportedUserName = reportedUserName,
             groupRoomId = report.groupRoomId,
             reason = report.reason,
             detail = report.detail,

--- a/src/main/kotlin/digdaserver/admin/user/application/service/AdminUserService.kt
+++ b/src/main/kotlin/digdaserver/admin/user/application/service/AdminUserService.kt
@@ -12,4 +12,6 @@ interface AdminUserService {
     fun getDetail(userId: UUID): AdminUserResponse
 
     fun updateRole(userId: UUID, role: Role): AdminUserResponse
+
+    fun updateRestriction(userId: UUID, restricted: Boolean): AdminUserResponse
 }

--- a/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/user/application/service/impl/AdminUserServiceImpl.kt
@@ -20,6 +20,21 @@ class AdminUserServiceImpl(
 ) : AdminUserService {
 
     override fun search(keyword: String?, role: Role?, page: Int, size: Int): AdminPageResponse<AdminUserResponse> {
+        // 키워드가 UUID(user_id) 형태면 정확 매칭으로 단건 조회 — 신고된 사용자를 ID 로 바로 찾기 위함.
+        val asUuid = keyword?.trim()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        if (asUuid != null) {
+            val user = userRepository.findById(asUuid).orElse(null)
+                ?.takeIf { role == null || it.role == role }
+            val content = listOfNotNull(user?.let(AdminUserResponse::from))
+            return AdminPageResponse(
+                page = 0,
+                size = size,
+                totalElements = content.size.toLong(),
+                totalPages = if (content.isEmpty()) 0 else 1,
+                content = content
+            )
+        }
+
         val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         val result = userRepository.searchForAdmin(keyword, role, pageable)
         return AdminPageResponse.of(result, AdminUserResponse::from)
@@ -36,6 +51,14 @@ class AdminUserServiceImpl(
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
         user.role = role
+        return AdminUserResponse.from(user)
+    }
+
+    @Transactional
+    override fun updateRestriction(userId: UUID, restricted: Boolean): AdminUserResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+        user.updateRestricted(restricted)
         return AdminUserResponse.from(user)
     }
 }

--- a/src/main/kotlin/digdaserver/admin/user/presentation/controller/AdminUserController.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/controller/AdminUserController.kt
@@ -2,6 +2,7 @@ package digdaserver.admin.user.presentation.controller
 
 import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.user.application.service.AdminUserService
+import digdaserver.admin.user.presentation.dto.req.AdminUpdateUserRestrictionRequest
 import digdaserver.admin.user.presentation.dto.req.AdminUpdateUserRoleRequest
 import digdaserver.admin.user.presentation.dto.res.AdminUserResponse
 import digdaserver.domain.user.domain.entity.Role
@@ -51,5 +52,19 @@ class AdminUserController(
         request: AdminUpdateUserRoleRequest
     ): ResponseEntity<AdminUserResponse> {
         return ResponseEntity.ok(adminUserService.updateRole(userId, request.role))
+    }
+
+    @Operation(
+        summary = "사용자 서비스 이용 제한",
+        description = "제한된 사용자는 앱에서 마이페이지 외 기능을 사용할 수 없습니다."
+    )
+    @PatchMapping("/{userId}/restriction")
+    fun updateRestriction(
+        @PathVariable userId: UUID,
+        @Valid
+        @RequestBody
+        request: AdminUpdateUserRestrictionRequest
+    ): ResponseEntity<AdminUserResponse> {
+        return ResponseEntity.ok(adminUserService.updateRestriction(userId, request.restricted))
     }
 }

--- a/src/main/kotlin/digdaserver/admin/user/presentation/dto/req/AdminUpdateUserRestrictionRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/dto/req/AdminUpdateUserRestrictionRequest.kt
@@ -1,0 +1,12 @@
+package digdaserver.admin.user.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "사용자 서비스 이용 제한 설정 요청")
+data class AdminUpdateUserRestrictionRequest(
+
+    @field:NotNull
+    @Schema(description = "true=제한, false=해제", example = "true")
+    val restricted: Boolean
+)

--- a/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/user/presentation/dto/res/AdminUserResponse.kt
@@ -25,6 +25,9 @@ data class AdminUserResponse(
     @Schema(description = "권한(USER/ADMIN)")
     val role: String,
 
+    @Schema(description = "서비스 이용 제한 여부")
+    val restricted: Boolean,
+
     @Schema(description = "가입일시")
     val createdAt: LocalDateTime,
 
@@ -39,6 +42,7 @@ data class AdminUserResponse(
             profileImage = user.profileImage,
             socialProvider = user.socialProvider.name,
             role = user.role.name,
+            restricted = user.restricted,
             createdAt = user.createdAt,
             updatedAt = user.updatedAt
         )

--- a/src/main/kotlin/digdaserver/domain/block/domain/repository/UserBlockRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/block/domain/repository/UserBlockRepository.kt
@@ -23,4 +23,8 @@ interface UserBlockRepository : JpaRepository<UserBlock, Long> {
     /** 조회 필터용 — 내가 차단한 사용자 ID 집합. */
     @Query("SELECT b.blocked.id FROM UserBlock b WHERE b.blocker.id = :blockerId")
     fun findBlockedIdsByBlockerId(@Param("blockerId") blockerId: UUID): List<UUID>
+
+    /** 알림 억제용 — 이 사용자(blocked)를 차단한 사람들의 ID 집합. */
+    @Query("SELECT b.blocker.id FROM UserBlock b WHERE b.blocked.id = :blockedId")
+    fun findBlockerIdsByBlockedId(@Param("blockedId") blockedId: UUID): List<UUID>
 }

--- a/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
@@ -43,6 +43,8 @@ class CommentServiceImpl(
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
+
         val comment = commentRepository.save(
             Comment(
                 targetType = CommentTargetType.SCHEDULE,
@@ -80,6 +82,8 @@ class CommentServiceImpl(
 
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
 
         val comment = commentRepository.save(
             Comment(

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -353,6 +353,8 @@ class DiaryServiceImpl(
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
+
         val resolvedUrls = resolveImageUrls(request.imageIds)
 
         val diary = Diary(

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -82,6 +82,13 @@ class GroupRoomServiceImpl(
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
+
+        // 1인당 그룹방은 최대 MAX_GROUP_ROOMS_PER_USER 개 (생성+참여 합산).
+        if (membershipRepository.countActiveByUserId(userId) >= MAX_GROUP_ROOMS_PER_USER) {
+            throw DigdaException(ErrorCode.GROUP_ROOM_LIMIT_EXCEEDED)
+        }
+
         val thumbnailUrl = resolveImageUrl(request.thumbnailImageId)
 
         val groupRoom = groupRoomRepository.save(
@@ -360,5 +367,8 @@ class GroupRoomServiceImpl(
 
     companion object {
         private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+
+        /** 1인당 참여 가능한 그룹방 최대 개수(생성+참여 합산). */
+        const val MAX_GROUP_ROOMS_PER_USER = 6L
     }
 }

--- a/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/presentation/dto/res/MembershipSummary.kt
@@ -3,6 +3,7 @@ package digdaserver.domain.group_room.presentation.dto.res
 import digdaserver.domain.membership.domain.entity.Membership
 
 data class MembershipSummary(
+    val userId: String,
     val name: String,
     val profileImage: String?,
     val role: String,
@@ -10,6 +11,7 @@ data class MembershipSummary(
 ) {
     companion object {
         fun from(membership: Membership): MembershipSummary = MembershipSummary(
+            userId = membership.user.id.toString(),
             name = membership.user.displayedName(),
             profileImage = membership.user.profileImage,
             role = membership.role.name.lowercase(),

--- a/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/invite/application/service/impl/InviteServiceImpl.kt
@@ -1,5 +1,6 @@
 package digdaserver.domain.invite.application.service.impl
 
+import digdaserver.domain.group_room.application.service.impl.GroupRoomServiceImpl.Companion.MAX_GROUP_ROOMS_PER_USER
 import digdaserver.domain.group_room.domain.entity.GroupRoomRole
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.group_room.presentation.dto.res.GroupRoomResponse
@@ -81,6 +82,11 @@ class InviteServiceImpl(
             throw DigdaException(ErrorCode.ALREADY_JOINED)
         }
 
+        // 1인당 그룹방 개수 제한 — 가입 화면에서 미리 막아 안내한다.
+        if (membershipRepository.countActiveByUserId(userId) >= MAX_GROUP_ROOMS_PER_USER) {
+            throw DigdaException(ErrorCode.GROUP_ROOM_LIMIT_EXCEEDED)
+        }
+
         return InviteValidateResponse(
             groupRoomName = groupRoom.name,
             thumbnailImage = groupRoom.thumbnailImage,
@@ -109,8 +115,15 @@ class InviteServiceImpl(
             throw DigdaException(ErrorCode.ALREADY_JOINED)
         }
 
+        // 1인당 그룹방 개수 제한(생성+참여 합산). 실제 가입 시점에서도 재확인한다.
+        if (membershipRepository.countActiveByUserId(userId) >= MAX_GROUP_ROOMS_PER_USER) {
+            throw DigdaException(ErrorCode.GROUP_ROOM_LIMIT_EXCEEDED)
+        }
+
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
 
         membershipRepository.save(
             Membership(

--- a/src/main/kotlin/digdaserver/domain/membership/domain/repository/MembershipRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/domain/repository/MembershipRepository.kt
@@ -17,6 +17,10 @@ interface MembershipRepository : JpaRepository<Membership, Long> {
     @Query("SELECT m FROM Membership m JOIN FETCH m.groupRoom g WHERE m.user.id = :userId AND g.deletedAt IS NULL ORDER BY g.lastActivityAt DESC")
     fun findAllByUserIdWithGroupRoom(userId: UUID): List<Membership>
 
+    /** 1인당 그룹방 개수 제한 판정용 — 삭제되지 않은 그룹방의 참여 수. */
+    @Query("SELECT COUNT(m) FROM Membership m WHERE m.user.id = :userId AND m.groupRoom.deletedAt IS NULL")
+    fun countActiveByUserId(userId: UUID): Long
+
     fun existsByGroupRoomIdAndUserId(groupRoomId: Long, userId: UUID): Boolean
 
     fun countByGroupRoomId(groupRoomId: Long): Int

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -1,5 +1,6 @@
 package digdaserver.domain.notification.application.service.impl
 
+import digdaserver.domain.block.domain.repository.UserBlockRepository
 import digdaserver.domain.group_room.domain.entity.GroupRoom
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
@@ -30,6 +31,7 @@ class NotificationServiceImpl(
     private val membershipRepository: MembershipRepository,
     private val groupRoomRepository: GroupRoomRepository,
     private val userRepository: UserRepository,
+    private val userBlockRepository: UserBlockRepository,
     private val pushDispatcher: NotificationPushDispatcher
 ) : NotificationService {
 
@@ -136,7 +138,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = diaryId,
                 relatedType = "DIARY"
-            )
+            ),
+            actorUserId = authorUserId
         )
     }
 
@@ -165,7 +168,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
                 relatedType = "SCHEDULE"
-            )
+            ),
+            actorUserId = creatorUserId
         )
     }
 
@@ -232,7 +236,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
                 relatedType = "SCHEDULE"
-            )
+            ),
+            actorUserId = actorUserId
         )
     }
 
@@ -334,7 +339,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
                 relatedType = "SCHEDULE"
-            )
+            ),
+            actorUserId = commenterUserId
         )
     }
 
@@ -359,7 +365,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = diaryId,
                 relatedType = "DIARY"
-            )
+            ),
+            actorUserId = commenterUserId
         )
     }
 
@@ -423,7 +430,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = quizId,
                 relatedType = "QUIZ"
-            )
+            ),
+            actorUserId = authorUserId
         )
     }
 
@@ -447,7 +455,8 @@ class NotificationServiceImpl(
                 groupRoomName = groupRoom.name,
                 relatedId = quizId,
                 relatedType = "QUIZ"
-            )
+            ),
+            actorUserId = solverUserId
         )
     }
 
@@ -475,7 +484,8 @@ class NotificationServiceImpl(
                 message = message,
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name
-            )
+            ),
+            actorUserId = actorUserId
         )
     }
 
@@ -531,13 +541,30 @@ class NotificationServiceImpl(
         return notifiedCount
     }
 
-    private fun notify(recipients: List<User>, payload: NotificationPayload) {
+    /**
+     * [actorUserId] 를 넘기면, 그 사용자를 '차단한' 수신자에게는 알림을 보내지 않는다.
+     * (차단한 사람이 일기·일정·댓글 등을 작성해도 알림이 뜨지 않게 하기 위함)
+     * 작성 주체가 없는 운영성 알림(공지·리마인더·멤버 변동)은 actorUserId 없이 호출한다.
+     */
+    private fun notify(
+        recipients: List<User>,
+        payload: NotificationPayload,
+        actorUserId: UUID? = null
+    ) {
         if (recipients.isEmpty()) return
 
-        val notifications = recipients.map { user -> payload.toEntity(user) }
+        val targets = if (actorUserId != null) {
+            val blockers = userBlockRepository.findBlockerIdsByBlockedId(actorUserId).toHashSet()
+            recipients.filter { it.id !in blockers }
+        } else {
+            recipients
+        }
+        if (targets.isEmpty()) return
+
+        val notifications = targets.map { user -> payload.toEntity(user) }
         notificationRepository.saveAll(notifications)
 
-        pushDispatcher.dispatch(recipients, payload)
+        pushDispatcher.dispatch(targets, payload)
     }
 
     private fun NotificationPayload.toEntity(recipient: User): Notification =

--- a/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/schedule/application/service/impl/ScheduleServiceImpl.kt
@@ -119,6 +119,8 @@ class ScheduleServiceImpl(
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
 
+        if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
+
         val schedule = scheduleRepository.save(
             Schedule(
                 groupRoom = groupRoom,

--- a/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/digdaserver/domain/user/domain/entity/User.kt
@@ -51,7 +51,11 @@ class User(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var role: Role = Role.USER
+    var role: Role = Role.USER,
+
+    // 서비스 이용 제한 — true 면 앱에서 마이페이지 외 기능을 막는다(어드민이 설정).
+    @Column(name = "restricted", nullable = false)
+    var restricted: Boolean = false
 
 ) : BaseTimeEntity() {
 
@@ -110,5 +114,10 @@ class User(
     /** 자격증명 없는 유령 ADMIN 정리용 — 역할만 USER 로 강등(데이터 삭제 아님). */
     fun demoteToUser() {
         this.role = Role.USER
+    }
+
+    /** 서비스 이용 제한 설정/해제 (어드민 전용). */
+    fun updateRestricted(value: Boolean) {
+        this.restricted = value
     }
 }

--- a/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/user/presentation/dto/res/MyProfileResponse.kt
@@ -9,7 +9,9 @@ data class MyProfileResponse(
     val email: String?,
     val profileImage: String?,
     val provider: String,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    // 서비스 이용 제한 여부 — true 면 앱이 마이페이지 외 기능을 막는다.
+    val restricted: Boolean
 ) {
     companion object {
         fun from(user: User): MyProfileResponse = MyProfileResponse(
@@ -18,7 +20,8 @@ data class MyProfileResponse(
             email = user.email,
             profileImage = user.profileImage,
             provider = user.socialProvider.name.lowercase(),
-            createdAt = user.createdAt
+            createdAt = user.createdAt,
+            restricted = user.restricted
         )
     }
 }

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -39,6 +39,7 @@ enum class ErrorCode(
     NAME_TOO_SHORT("NAME_TOO_SHORT", "닉네임은 2자 이상이어야 합니다.", 400),
     NAME_TOO_LONG("NAME_TOO_LONG", "닉네임은 20자 이하여야 합니다.", 400),
     INVALID_ROLE("INVALID_ROLE", "유효하지 않은 역할입니다.", 400),
+    USER_RESTRICTED("USER_RESTRICTED", "서비스 이용이 제한된 계정입니다. 자세한 내용은 고객센터로 문의해주세요.", 403),
 
     // ── GroupRoom ──
     GROUP_ROOM_NOT_FOUND("GROUP_ROOM_NOT_FOUND", "존재하지 않는 그룹방입니다.", 404),
@@ -48,6 +49,7 @@ enum class ErrorCode(
     GROUP_ROOM_NOT_SCHEDULED_FOR_DELETION("GROUP_ROOM_NOT_SCHEDULED_FOR_DELETION", "삭제 예약되지 않은 그룹방입니다.", 400),
     GROUP_ROOM_ALREADY_DELETED("GROUP_ROOM_ALREADY_DELETED", "이미 삭제된 그룹방입니다.", 410),
     OWNS_ACTIVE_GROUP_ROOM("OWNS_ACTIVE_GROUP_ROOM", "소유 중인 그룹방이 있어 탈퇴할 수 없습니다. 방장을 양도해주세요.", 409),
+    GROUP_ROOM_LIMIT_EXCEEDED("GROUP_ROOM_LIMIT_EXCEEDED", "참여할 수 있는 그룹방은 최대 6개입니다.", 409),
 
     // ── Invite ──
     INVITE_CODE_INVALID("INVITE_CODE_INVALID", "존재하지 않는 초대 코드입니다.", 404),

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -111,6 +111,12 @@ class SchemaAutoMigration(
             postSql = listOf(
                 "UPDATE group_character SET master_unlocked = b'1' WHERE level >= 20"
             )
+        ),
+        // 서비스 이용 제한 플래그. user 는 MySQL 예약어라 백틱 필요. 기본 false.
+        MissingColumn(
+            table = "user",
+            column = "restricted",
+            addSql = "ALTER TABLE `user` ADD COLUMN restricted BIT(1) NOT NULL DEFAULT b'0'"
         )
     )
 


### PR DESCRIPTION
## 변경 요약
앱 요청사항(차단/신고/제한) 대응 서버 작업입니다.

### 1. 차단 사용자 알림 억제
- 차단한 사용자가 일기·일정·댓글·퀴즈·모찌 레벨업 등 행동을 해도, **차단한 사람에게는 알림이 가지 않음**
- `NotificationService.notify(..., actorUserId)` 에 차단 필터 추가 / `UserBlockRepository.findBlockerIdsByBlockedId`

### 2. 그룹방 1인당 6개 제한 (서버 강제)
- 기존엔 안내 팝업만 있고 실제로 막히지 않았음 → 서버에서 강제
- 생성/참여 시 `MembershipRepository.countActiveByUserId` 로 검사, `GROUP_ROOM_LIMIT_EXCEEDED`

### 3. 신고 어드민 — 피신고자 식별
- `AdminReportResponse` 에 `reportedUserId` / `reportedUserName` 추가
- 대상 콘텐츠(일기/댓글/일정) 작성자 또는 USER 대상에서 해석
- `MembershipSummary` 에 `userId` 노출(앱 차단 멤버 표시용)

### 4. 서비스 이용 제한
- `User.restricted` 컬럼 추가(+ `SchemaAutoMigration` ALTER, prod ddl-auto=none 대응)
- `MyProfileResponse` / `AdminUserResponse` 에 `restricted` 노출
- `PATCH /admin/users/{id}/restriction`
- 어드민 사용자 검색에서 `user_id`(UUID) 정확 매칭
- 제한 계정의 일기·일정·댓글·그룹 생성/참여를 `USER_RESTRICTED` 로 차단(서버 방어)

## 검증
- `./gradlew ktlintCheck` ✅
- `./gradlew compileKotlin` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)