### PR TITLE
chore(migration): restricted 컬럼 자동 마이그레이션 제거

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -111,12 +111,6 @@ class SchemaAutoMigration(
             postSql = listOf(
                 "UPDATE group_character SET master_unlocked = b'1' WHERE level >= 20"
             )
-        ),
-        // 서비스 이용 제한 플래그. user 는 MySQL 예약어라 백틱 필요. 기본 false.
-        MissingColumn(
-            table = "user",
-            column = "restricted",
-            addSql = "ALTER TABLE `user` ADD COLUMN restricted BIT(1) NOT NULL DEFAULT b'0'"
         )
     )
 


### PR DESCRIPTION
테이블 재생성 방침이라 `SchemaAutoMigration` 의 `user.restricted` ADD 엔트리 제거.
`User.restricted` 엔티티/`PATCH /admin/users/{id}/restriction`/`USER_RESTRICTED` 가드는 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)