### PR TITLE
feat(report/inquiry): 신고 원본 콘텐츠 + 고객센터 문의

### DIFF
--- a/src/main/kotlin/digdaserver/admin/inquiry/application/service/AdminInquiryService.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/application/service/AdminInquiryService.kt
@@ -1,0 +1,14 @@
+package digdaserver.admin.inquiry.application.service
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.inquiry.presentation.dto.res.AdminInquiryResponse
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+
+interface AdminInquiryService {
+
+    /** 문의 목록 — 상태 필터(없으면 전체), 최신순 페이징. */
+    fun search(status: InquiryStatus?, page: Int, size: Int): AdminPageResponse<AdminInquiryResponse>
+
+    /** 문의를 답변 완료(ANSWERED)로 전이. */
+    fun markAnswered(inquiryId: Long): AdminInquiryResponse
+}

--- a/src/main/kotlin/digdaserver/admin/inquiry/application/service/impl/AdminInquiryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/application/service/impl/AdminInquiryServiceImpl.kt
@@ -1,0 +1,41 @@
+package digdaserver.admin.inquiry.application.service.impl
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.inquiry.application.service.AdminInquiryService
+import digdaserver.admin.inquiry.presentation.dto.res.AdminInquiryResponse
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+import digdaserver.domain.inquiry.domain.repository.InquiryRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AdminInquiryServiceImpl(
+    private val inquiryRepository: InquiryRepository
+) : AdminInquiryService {
+
+    override fun search(
+        status: InquiryStatus?,
+        page: Int,
+        size: Int
+    ): AdminPageResponse<AdminInquiryResponse> {
+        val pageable = PageRequest.of(page, size)
+        val result = if (status != null) {
+            inquiryRepository.findAllByStatusOrderByCreatedAtDesc(status, pageable)
+        } else {
+            inquiryRepository.findAllByOrderByCreatedAtDesc(pageable)
+        }
+        return AdminPageResponse.of(result) { AdminInquiryResponse.from(it) }
+    }
+
+    @Transactional
+    override fun markAnswered(inquiryId: Long): AdminInquiryResponse {
+        val inquiry = inquiryRepository.findById(inquiryId)
+            .orElseThrow { DigdaException(ErrorCode.RESOURCE_NOT_FOUND) }
+        inquiry.markAnswered()
+        return AdminInquiryResponse.from(inquiry)
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/inquiry/presentation/controller/AdminInquiryController.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/presentation/controller/AdminInquiryController.kt
@@ -1,0 +1,41 @@
+package digdaserver.admin.inquiry.presentation.controller
+
+import digdaserver.admin.common.dto.res.AdminPageResponse
+import digdaserver.admin.inquiry.application.service.AdminInquiryService
+import digdaserver.admin.inquiry.presentation.dto.res.AdminInquiryResponse
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/inquiries")
+@Tag(name = "Admin - Inquiry", description = "관리자 고객센터 문의 관리 API")
+class AdminInquiryController(
+    private val adminInquiryService: AdminInquiryService
+) {
+
+    @Operation(summary = "문의 목록 조회", description = "상태 필터 + 페이징. 최신순.")
+    @GetMapping
+    fun search(
+        @RequestParam(required = false) status: InquiryStatus?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<AdminPageResponse<AdminInquiryResponse>> {
+        return ResponseEntity.ok(adminInquiryService.search(status, page, size))
+    }
+
+    @Operation(summary = "문의 답변 완료 처리", description = "문의를 ANSWERED(답변 완료)로 전이합니다.")
+    @PatchMapping("/{inquiryId}/answered")
+    fun markAnswered(
+        @PathVariable inquiryId: Long
+    ): ResponseEntity<AdminInquiryResponse> {
+        return ResponseEntity.ok(adminInquiryService.markAnswered(inquiryId))
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/res/AdminInquiryResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/res/AdminInquiryResponse.kt
@@ -1,0 +1,43 @@
+package digdaserver.admin.inquiry.presentation.dto.res
+
+import digdaserver.domain.inquiry.domain.entity.Inquiry
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민용 고객센터 문의")
+data class AdminInquiryResponse(
+
+    @Schema(description = "문의 ID")
+    val inquiryId: Long,
+
+    @Schema(description = "작성자 ID(UUID)")
+    val userId: String,
+
+    @Schema(description = "작성자 이름")
+    val userName: String,
+
+    @Schema(description = "문의 내용")
+    val content: String,
+
+    @Schema(description = "처리 상태")
+    val status: InquiryStatus,
+
+    @Schema(description = "접수 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "답변 시각")
+    val answeredAt: LocalDateTime?
+) {
+    companion object {
+        fun from(inquiry: Inquiry): AdminInquiryResponse = AdminInquiryResponse(
+            inquiryId = inquiry.id,
+            userId = inquiry.user.id.toString(),
+            userName = inquiry.user.displayedName(),
+            content = inquiry.content,
+            status = inquiry.status,
+            createdAt = inquiry.createdAt,
+            answeredAt = inquiry.answeredAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/report/application/service/impl/AdminReportServiceImpl.kt
@@ -3,6 +3,7 @@ package digdaserver.admin.report.application.service.impl
 import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.report.application.service.AdminReportService
 import digdaserver.admin.report.presentation.dto.res.AdminReportResponse
+import digdaserver.admin.report.presentation.dto.res.AdminReportTargetContentResponse
 import digdaserver.domain.comment.domain.repository.CommentRepository
 import digdaserver.domain.diary.domain.repository.DiaryRepository
 import digdaserver.domain.report.domain.entity.Report
@@ -43,7 +44,12 @@ class AdminReportServiceImpl(
         val result = reportRepository.searchForAdmin(status, targetType, pageable)
         return AdminPageResponse.of(result) { report ->
             val reported = resolveReportedUser(report)
-            AdminReportResponse.from(report, reported?.id?.toString(), reported?.displayedName())
+            AdminReportResponse.from(
+                report,
+                reported?.id?.toString(),
+                reported?.displayedName(),
+                resolveTargetContent(report)
+            )
         }
     }
 
@@ -53,7 +59,89 @@ class AdminReportServiceImpl(
             .orElseThrow { DigdaException(ErrorCode.RESOURCE_NOT_FOUND) }
         report.markReviewed(status)
         val reported = resolveReportedUser(report)
-        return AdminReportResponse.from(report, reported?.id?.toString(), reported?.displayedName())
+        return AdminReportResponse.from(
+            report,
+            reported?.id?.toString(),
+            reported?.displayedName(),
+            resolveTargetContent(report)
+        )
+    }
+
+    /**
+     * 신고 대상(targetId)의 원본 콘텐츠를 어드민 검토용 스냅샷으로 만든다.
+     * - DIARY:    제목 + 본문 + 사진 URL 들
+     * - SCHEDULE: 제목 + 기간/시간 요약
+     * - COMMENT:  댓글 내용
+     * - USER:     원본 콘텐츠 없음(available=false)
+     * 콘텐츠가 삭제됐거나 파싱 실패하면 available=false.
+     */
+    private fun resolveTargetContent(report: Report): AdminReportTargetContentResponse {
+        return try {
+            when (report.targetType) {
+                ReportTargetType.USER -> AdminReportTargetContentResponse.unavailable()
+
+                ReportTargetType.DIARY ->
+                    report.targetId.toLongOrNull()
+                        ?.let { diaryRepository.findById(it).orElse(null) }
+                        ?.let { diary ->
+                            AdminReportTargetContentResponse(
+                                available = true,
+                                title = diary.title,
+                                text = diary.content,
+                                images = diary.images.map { it.url },
+                                authorName = diary.createdBy.displayedName(),
+                                createdAt = diary.createdAt
+                            )
+                        } ?: AdminReportTargetContentResponse.unavailable()
+
+                ReportTargetType.SCHEDULE ->
+                    report.targetId.toLongOrNull()
+                        ?.let { scheduleRepository.findById(it).orElse(null) }
+                        ?.let { schedule ->
+                            val period = if (schedule.startDate == schedule.endDate) {
+                                schedule.startDate.toString()
+                            } else {
+                                "${schedule.startDate} ~ ${schedule.endDate}"
+                            }
+                            val time = when {
+                                schedule.allDay -> "종일"
+                                schedule.startTime != null ->
+                                    "${schedule.startTime}" +
+                                        (schedule.endTime?.let { " ~ $it" } ?: "")
+                                else -> ""
+                            }
+                            AdminReportTargetContentResponse(
+                                available = true,
+                                title = schedule.title,
+                                text = listOf(period, time).filter { it.isNotBlank() }
+                                    .joinToString(" · "),
+                                authorName = schedule.createdBy.displayedName(),
+                                createdAt = schedule.createdAt
+                            )
+                        } ?: AdminReportTargetContentResponse.unavailable()
+
+                ReportTargetType.COMMENT ->
+                    report.targetId.toLongOrNull()
+                        ?.let { commentRepository.findById(it).orElse(null) }
+                        ?.let { comment ->
+                            AdminReportTargetContentResponse(
+                                available = true,
+                                text = comment.text,
+                                authorName = comment.createdBy.displayedName(),
+                                createdAt = comment.createdAt
+                            )
+                        } ?: AdminReportTargetContentResponse.unavailable()
+            }
+        } catch (e: Exception) {
+            log.warn(
+                "action=신고 원본 콘텐츠 해석 실패, reportId={}, targetType={}, targetId={}, error={}",
+                report.id,
+                report.targetType,
+                report.targetId,
+                e.message
+            )
+            AdminReportTargetContentResponse.unavailable()
+        }
     }
 
     /**

--- a/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportResponse.kt
@@ -47,13 +47,18 @@ data class AdminReportResponse(
     val createdAt: LocalDateTime,
 
     @Schema(description = "검토 시각")
-    val reviewedAt: LocalDateTime?
+    val reviewedAt: LocalDateTime?,
+
+    @Schema(description = "신고된 콘텐츠 원본 스냅샷(검토용)")
+    val targetContent: AdminReportTargetContentResponse
 ) {
     companion object {
         fun from(
             report: Report,
             reportedUserId: String? = null,
-            reportedUserName: String? = null
+            reportedUserName: String? = null,
+            targetContent: AdminReportTargetContentResponse =
+                AdminReportTargetContentResponse.unavailable()
         ): AdminReportResponse = AdminReportResponse(
             reportId = report.id,
             reporterId = report.reporter.id.toString(),
@@ -67,7 +72,8 @@ data class AdminReportResponse(
             detail = report.detail,
             status = report.status,
             createdAt = report.createdAt,
-            reviewedAt = report.reviewedAt
+            reviewedAt = report.reviewedAt,
+            targetContent = targetContent
         )
     }
 }

--- a/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportTargetContentResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/report/presentation/dto/res/AdminReportTargetContentResponse.kt
@@ -1,0 +1,41 @@
+package digdaserver.admin.report.presentation.dto.res
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+/**
+ * 신고된 콘텐츠의 원본 스냅샷 — 어드민이 신고를 검토할 때 실제 내용을 함께 본다.
+ * 종류별로 채워지는 필드가 다르다.
+ * - DIARY:    title + text(본문) + images(사진들)
+ * - SCHEDULE: title + text(기간/시간 요약)
+ * - COMMENT:  text(댓글 내용)
+ * - USER:     content 없음(available=false)
+ * 콘텐츠가 이미 삭제됐으면 available=false 로 내려 어드민에서 '원본 없음' 표기.
+ */
+@Schema(description = "신고된 콘텐츠 원본 스냅샷")
+data class AdminReportTargetContentResponse(
+
+    @Schema(description = "원본이 남아 있는지(삭제·해석불가 시 false)")
+    val available: Boolean,
+
+    @Schema(description = "제목(일기/일정)")
+    val title: String? = null,
+
+    @Schema(description = "본문/내용(일기 본문·댓글 내용·일정 요약)")
+    val text: String? = null,
+
+    @Schema(description = "사진 URL 목록(일기)")
+    val images: List<String> = emptyList(),
+
+    @Schema(description = "작성자 이름")
+    val authorName: String? = null,
+
+    @Schema(description = "작성 시각")
+    val createdAt: LocalDateTime? = null
+) {
+    companion object {
+        /** 원본을 찾지 못했을 때(삭제됨/USER 대상 등). */
+        fun unavailable(): AdminReportTargetContentResponse =
+            AdminReportTargetContentResponse(available = false)
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/application/service/InquiryService.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/application/service/InquiryService.kt
@@ -1,0 +1,14 @@
+package digdaserver.domain.inquiry.application.service
+
+import digdaserver.domain.inquiry.presentation.dto.req.CreateInquiryRequest
+import digdaserver.domain.inquiry.presentation.dto.res.InquiryResponse
+import java.util.UUID
+
+interface InquiryService {
+
+    /** 고객센터 문의 작성. 하루 2건 초과 시 INQUIRY_DAILY_LIMIT. */
+    fun create(userId: UUID, request: CreateInquiryRequest): InquiryResponse
+
+    /** 내 문의 목록(최신순). */
+    fun myInquiries(userId: UUID): List<InquiryResponse>
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/application/service/impl/InquiryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/application/service/impl/InquiryServiceImpl.kt
@@ -1,0 +1,63 @@
+package digdaserver.domain.inquiry.application.service.impl
+
+import digdaserver.domain.inquiry.application.service.InquiryService
+import digdaserver.domain.inquiry.domain.entity.Inquiry
+import digdaserver.domain.inquiry.domain.repository.InquiryRepository
+import digdaserver.domain.inquiry.presentation.dto.req.CreateInquiryRequest
+import digdaserver.domain.inquiry.presentation.dto.res.InquiryResponse
+import digdaserver.domain.user.domain.repository.UserRepository
+import digdaserver.global.infra.exception.error.DigdaException
+import digdaserver.global.infra.exception.error.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class InquiryServiceImpl(
+    private val inquiryRepository: InquiryRepository,
+    private val userRepository: UserRepository
+) : InquiryService {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /** 하루 작성 한도. */
+    private val dailyLimit = 2L
+
+    @Transactional
+    override fun create(userId: UUID, request: CreateInquiryRequest): InquiryResponse {
+        val content = request.content.trim()
+        if (content.isBlank()) throw DigdaException(ErrorCode.INQUIRY_CONTENT_REQUIRED)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
+
+        // 오늘(00:00 이후) 작성 건수로 하루 2건 제한. 무분별한 도배 방지.
+        val startOfToday = LocalDate.now().atStartOfDay()
+        val todayCount = inquiryRepository.countByUserIdAndCreatedAtAfter(userId, startOfToday)
+        if (todayCount >= dailyLimit) {
+            log.info(
+                "action=고객센터 문의 한도 초과, userId={}, todayCount={}",
+                userId,
+                todayCount
+            )
+            throw DigdaException(ErrorCode.INQUIRY_DAILY_LIMIT)
+        }
+
+        val saved = inquiryRepository.save(Inquiry(user = user, content = content))
+        log.info(
+            "action=고객센터 문의 접수, userId={}, inquiryId={}, todayCount={}",
+            userId,
+            saved.id,
+            todayCount + 1
+        )
+        return InquiryResponse.from(saved)
+    }
+
+    override fun myInquiries(userId: UUID): List<InquiryResponse> {
+        return inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+            .map { InquiryResponse.from(it) }
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/Inquiry.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/Inquiry.kt
@@ -1,0 +1,58 @@
+package digdaserver.domain.inquiry.domain.entity
+
+import digdaserver.domain.user.domain.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * 고객센터 문의. 사용자가 마이페이지에서 작성하며 어드민이 검토한다.
+ * 무분별한 작성을 막기 위해 작성 API 에서 하루 2건으로 제한한다(서비스 레이어에서 검사).
+ */
+@Entity
+@Table(
+    name = "inquiry",
+    indexes = [
+        Index(name = "idx_inquiry_user_created", columnList = "user_id, created_at"),
+        Index(name = "idx_inquiry_status", columnList = "status")
+    ]
+)
+class Inquiry(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(name = "content", nullable = false, length = 1000)
+    val content: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    var status: InquiryStatus = InquiryStatus.PENDING,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "answered_at")
+    var answeredAt: LocalDateTime? = null
+) {
+    fun markAnswered() {
+        this.status = InquiryStatus.ANSWERED
+        this.answeredAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/InquiryStatus.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/InquiryStatus.kt
@@ -1,0 +1,10 @@
+package digdaserver.domain.inquiry.domain.entity
+
+/** 고객센터 문의 처리 상태. */
+enum class InquiryStatus {
+    /** 접수됨(미답변). */
+    PENDING,
+
+    /** 답변/처리 완료. */
+    ANSWERED
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/domain/repository/InquiryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/domain/repository/InquiryRepository.kt
@@ -1,0 +1,23 @@
+package digdaserver.domain.inquiry.domain.repository
+
+import digdaserver.domain.inquiry.domain.entity.Inquiry
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface InquiryRepository : JpaRepository<Inquiry, Long> {
+
+    /** 하루 작성 한도 검사용 — 특정 사용자가 [from] 이후 작성한 문의 수. */
+    fun countByUserIdAndCreatedAtAfter(userId: UUID, from: LocalDateTime): Long
+
+    /** 내 문의 목록(최신순). */
+    fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<Inquiry>
+
+    /** 어드민 목록 — 상태 필터(없으면 전체), 최신순 페이징. */
+    fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<Inquiry>
+
+    fun findAllByStatusOrderByCreatedAtDesc(status: InquiryStatus, pageable: Pageable): Page<Inquiry>
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/presentation/controller/InquiryController.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/presentation/controller/InquiryController.kt
@@ -1,0 +1,45 @@
+package digdaserver.domain.inquiry.presentation.controller
+
+import digdaserver.domain.inquiry.application.service.InquiryService
+import digdaserver.domain.inquiry.presentation.dto.req.CreateInquiryRequest
+import digdaserver.domain.inquiry.presentation.dto.res.InquiryResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@Tag(name = "Inquiry", description = "고객센터 문의 API")
+class InquiryController(
+    private val inquiryService: InquiryService
+) {
+
+    @Operation(
+        summary = "고객센터 문의 작성",
+        description = "마이페이지 고객센터에서 문의를 보냅니다. 하루 2건까지만 작성할 수 있습니다."
+    )
+    @PostMapping("/inquiries")
+    fun create(
+        @AuthenticationPrincipal userId: String,
+        @RequestBody @Valid
+        request: CreateInquiryRequest
+    ): ResponseEntity<InquiryResponse> {
+        val response = inquiryService.create(UUID.fromString(userId), request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @Operation(summary = "내 문의 목록", description = "내가 보낸 고객센터 문의를 최신순으로 조회합니다.")
+    @GetMapping("/inquiries")
+    fun myInquiries(
+        @AuthenticationPrincipal userId: String
+    ): ResponseEntity<List<InquiryResponse>> {
+        return ResponseEntity.ok(inquiryService.myInquiries(UUID.fromString(userId)))
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/req/CreateInquiryRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/req/CreateInquiryRequest.kt
@@ -1,0 +1,14 @@
+package digdaserver.domain.inquiry.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "고객센터 문의 작성 요청")
+data class CreateInquiryRequest(
+
+    @field:NotBlank
+    @field:Size(max = 1000)
+    @Schema(description = "문의 내용", example = "로그인이 안 돼요.")
+    val content: String
+)

--- a/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/res/InquiryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/res/InquiryResponse.kt
@@ -1,0 +1,35 @@
+package digdaserver.domain.inquiry.presentation.dto.res
+
+import digdaserver.domain.inquiry.domain.entity.Inquiry
+import digdaserver.domain.inquiry.domain.entity.InquiryStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "고객센터 문의")
+data class InquiryResponse(
+
+    @Schema(description = "문의 ID")
+    val id: Long,
+
+    @Schema(description = "문의 내용")
+    val content: String,
+
+    @Schema(description = "처리 상태")
+    val status: InquiryStatus,
+
+    @Schema(description = "접수 시각")
+    val createdAt: LocalDateTime,
+
+    @Schema(description = "답변 시각")
+    val answeredAt: LocalDateTime?
+) {
+    companion object {
+        fun from(inquiry: Inquiry): InquiryResponse = InquiryResponse(
+            id = inquiry.id,
+            content = inquiry.content,
+            status = inquiry.status,
+            createdAt = inquiry.createdAt,
+            answeredAt = inquiry.answeredAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -138,6 +138,10 @@ enum class ErrorCode(
     CANNOT_REPORT_SELF("CANNOT_REPORT_SELF", "자기 자신은 신고할 수 없습니다.", 400),
     CANNOT_BLOCK_SELF("CANNOT_BLOCK_SELF", "자기 자신은 차단할 수 없습니다.", 400),
 
+    // ── Inquiry (고객센터) ──
+    INQUIRY_CONTENT_REQUIRED("INQUIRY_CONTENT_REQUIRED", "문의 내용을 입력해주세요.", 400),
+    INQUIRY_DAILY_LIMIT("INQUIRY_DAILY_LIMIT", "고객센터 문의는 하루 2번까지만 보낼 수 있어요.", 429),
+
     // ── Rate Limit ──
     RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED", "요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.", 429),
 


### PR DESCRIPTION
## 변경
### 신고 검토 강화
- 어드민 신고 응답에 **신고된 콘텐츠 원본 스냅샷**(`targetContent`) 추가
  - DIARY: 제목 + 본문 + 사진 URL 들
  - SCHEDULE: 제목 + 기간/시간 요약
  - COMMENT: 내용
  - 삭제됐거나 USER 신고면 `available=false`
- 신고자 ID·이름은 기존 `AdminReportResponse`(reporterId/reporterName)에 **이미 포함** — 어드민 화면에서 표시만 하면 됨.

### 고객센터 문의(Inquiry) 신설
- 사용자: `POST /inquiries`(작성, **하루 2건 제한**), `GET /inquiries`(내 문의)
- 어드민: `GET /api/admin/inquiries`(상태필터·페이징), `PATCH /api/admin/inquiries/{id}/answered`
- 에러코드 `INQUIRY_DAILY_LIMIT`(429), `INQUIRY_CONTENT_REQUIRED`(400)

## 마이그레이션
- 신규 `inquiry` 테이블은 **JPA 엔티티로만 정의(마이그레이션 SQL 미작성)**. dev 는 ddl-auto 로 생성, prod 는 운영에서 테이블 생성.

## 검증
- `./gradlew ktlintFormat compileKotlin` ✅ 통과