### PR TITLE
feat(inquiry): 고객센터 문의 답변 기능

### DIFF
--- a/src/main/kotlin/digdaserver/admin/inquiry/application/service/AdminInquiryService.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/application/service/AdminInquiryService.kt
@@ -9,6 +9,6 @@ interface AdminInquiryService {
     /** 문의 목록 — 상태 필터(없으면 전체), 최신순 페이징. */
     fun search(status: InquiryStatus?, page: Int, size: Int): AdminPageResponse<AdminInquiryResponse>
 
-    /** 문의를 답변 완료(ANSWERED)로 전이. */
-    fun markAnswered(inquiryId: Long): AdminInquiryResponse
+    /** 문의에 답변 등록 — 답변 내용 저장 + ANSWERED 전이. */
+    fun answer(inquiryId: Long, answer: String): AdminInquiryResponse
 }

--- a/src/main/kotlin/digdaserver/admin/inquiry/application/service/impl/AdminInquiryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/application/service/impl/AdminInquiryServiceImpl.kt
@@ -32,10 +32,10 @@ class AdminInquiryServiceImpl(
     }
 
     @Transactional
-    override fun markAnswered(inquiryId: Long): AdminInquiryResponse {
+    override fun answer(inquiryId: Long, answer: String): AdminInquiryResponse {
         val inquiry = inquiryRepository.findById(inquiryId)
             .orElseThrow { DigdaException(ErrorCode.RESOURCE_NOT_FOUND) }
-        inquiry.markAnswered()
+        inquiry.answer(answer.trim())
         return AdminInquiryResponse.from(inquiry)
     }
 }

--- a/src/main/kotlin/digdaserver/admin/inquiry/presentation/controller/AdminInquiryController.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/presentation/controller/AdminInquiryController.kt
@@ -2,14 +2,17 @@ package digdaserver.admin.inquiry.presentation.controller
 
 import digdaserver.admin.common.dto.res.AdminPageResponse
 import digdaserver.admin.inquiry.application.service.AdminInquiryService
+import digdaserver.admin.inquiry.presentation.dto.req.AnswerInquiryRequest
 import digdaserver.admin.inquiry.presentation.dto.res.AdminInquiryResponse
 import digdaserver.domain.inquiry.domain.entity.InquiryStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -31,11 +34,13 @@ class AdminInquiryController(
         return ResponseEntity.ok(adminInquiryService.search(status, page, size))
     }
 
-    @Operation(summary = "문의 답변 완료 처리", description = "문의를 ANSWERED(답변 완료)로 전이합니다.")
-    @PatchMapping("/{inquiryId}/answered")
-    fun markAnswered(
-        @PathVariable inquiryId: Long
+    @Operation(summary = "문의 답변 등록", description = "답변 내용을 저장하고 ANSWERED(답변 완료)로 전이합니다.")
+    @PatchMapping("/{inquiryId}/answer")
+    fun answer(
+        @PathVariable inquiryId: Long,
+        @RequestBody @Valid
+        request: AnswerInquiryRequest
     ): ResponseEntity<AdminInquiryResponse> {
-        return ResponseEntity.ok(adminInquiryService.markAnswered(inquiryId))
+        return ResponseEntity.ok(adminInquiryService.answer(inquiryId, request.answer))
     }
 }

--- a/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/req/AnswerInquiryRequest.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/req/AnswerInquiryRequest.kt
@@ -1,0 +1,14 @@
+package digdaserver.admin.inquiry.presentation.dto.req
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "고객센터 문의 답변 등록 요청")
+data class AnswerInquiryRequest(
+
+    @field:NotBlank
+    @field:Size(max = 2000)
+    @Schema(description = "답변 내용", example = "안내드립니다. ...")
+    val answer: String
+)

--- a/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/res/AdminInquiryResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/inquiry/presentation/dto/res/AdminInquiryResponse.kt
@@ -23,6 +23,9 @@ data class AdminInquiryResponse(
     @Schema(description = "처리 상태")
     val status: InquiryStatus,
 
+    @Schema(description = "어드민 답변 내용(미답변이면 null)")
+    val answer: String?,
+
     @Schema(description = "접수 시각")
     val createdAt: LocalDateTime,
 
@@ -36,6 +39,7 @@ data class AdminInquiryResponse(
             userName = inquiry.user.displayedName(),
             content = inquiry.content,
             status = inquiry.status,
+            answer = inquiry.answer,
             createdAt = inquiry.createdAt,
             answeredAt = inquiry.answeredAt
         )

--- a/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/Inquiry.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/domain/entity/Inquiry.kt
@@ -45,13 +45,19 @@ class Inquiry(
     @Column(name = "status", nullable = false, length = 32)
     var status: InquiryStatus = InquiryStatus.PENDING,
 
+    /** 어드민 답변 내용. 미답변이면 null. */
+    @Column(name = "answer", length = 2000)
+    var answer: String? = null,
+
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "answered_at")
     var answeredAt: LocalDateTime? = null
 ) {
-    fun markAnswered() {
+    /** 어드민이 답변을 등록 — 답변 내용 저장 + 상태 ANSWERED 전이. */
+    fun answer(answer: String) {
+        this.answer = answer
         this.status = InquiryStatus.ANSWERED
         this.answeredAt = LocalDateTime.now()
     }

--- a/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/res/InquiryResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/inquiry/presentation/dto/res/InquiryResponse.kt
@@ -17,6 +17,9 @@ data class InquiryResponse(
     @Schema(description = "처리 상태")
     val status: InquiryStatus,
 
+    @Schema(description = "어드민 답변 내용(미답변이면 null)")
+    val answer: String?,
+
     @Schema(description = "접수 시각")
     val createdAt: LocalDateTime,
 
@@ -28,6 +31,7 @@ data class InquiryResponse(
             id = inquiry.id,
             content = inquiry.content,
             status = inquiry.status,
+            answer = inquiry.answer,
             createdAt = inquiry.createdAt,
             answeredAt = inquiry.answeredAt
         )


### PR DESCRIPTION
## 변경
- `Inquiry.answer`(varchar 2000) 컬럼 추가. `answer(text)` 로 내용 저장 + `ANSWERED` 전이.
- 어드민 `PATCH /api/admin/inquiries/{id}/answer`(AnswerInquiryRequest) — 답변 등록/수정.
- `InquiryResponse`·`AdminInquiryResponse` 에 `answer` 추가 → 앱 고객센터에서 답변 노출.

## 마이그레이션
- 신규 컬럼은 **엔티티로만 정의(마이그레이션 SQL 미작성)**. ddl-auto create 로 반영.

## 검증
- `./gradlew ktlintFormat compileKotlin` ✅