### PR TITLE
fix(fcm): iOS 푸시 미수신 — ApnsConfig 명시

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
@@ -2,6 +2,8 @@ package digdaserver.global.infra.fcm.presentation.application.impl
 
 import com.google.firebase.messaging.AndroidConfig
 import com.google.firebase.messaging.AndroidNotification
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingException
 import com.google.firebase.messaging.MessagingErrorCode
@@ -72,6 +74,20 @@ class FcmServiceImpl(
                     AndroidNotification.builder()
                         .setChannelId("digda_default")
                         .setPriority(AndroidNotification.Priority.HIGH)
+                        .build()
+                )
+                .build()
+        )
+        // iOS(APNs) 설정을 명시한다. 상위 Notification 만으론 사운드/우선순위가 빠져
+        // 백그라운드 배너가 누락되거나 무음 처리될 수 있다. apns-push-type=alert,
+        // apns-priority=10(즉시 전달) + 기본 사운드로 표시를 보장한다.
+        .setApnsConfig(
+            ApnsConfig.builder()
+                .putHeader("apns-push-type", "alert")
+                .putHeader("apns-priority", "10")
+                .setAps(
+                    Aps.builder()
+                        .setSound("default")
                         .build()
                 )
                 .build()


### PR DESCRIPTION
## 문제
공지/알림이 **안드로이드는 수신되는데 iOS 는 안 옴**. iOS 디바이스 토큰은 `devices` 테이블에 정상 등록됨(앱 측 firebase_options appId 정정으로 해결됨).

## 원인
`FcmServiceImpl.buildMulticast` 가 상위 `Notification`(title/body) + `AndroidConfig` 만 설정하고 **`ApnsConfig` 가 없었음**. 이 경우 APNs 페이로드에 사운드/우선순위 헤더가 빠져 iOS 백그라운드 배너가 누락되거나 무음 처리될 수 있음.

## 변경
`ApnsConfig` 명시 추가:
- 헤더 `apns-push-type=alert`, `apns-priority=10`(즉시 전달)
- `aps.sound=default`

안드로이드 동작에는 영향 없음(AndroidConfig 그대로).

## 검증
머지·배포 후 어드민에서 공지 발송 → iOS 수신 확인. 실패 시 서버 로그 `FcmServiceImpl: FCM send failed for token (...)` 의 에러코드로 APNs 인증 문제 여부 추가 판별.

🤖 Generated with [Claude Code](https://claude.com/claude-code)