### PR TITLE
chore(fcm): APNs 실제 거부 사유 로깅 강화

### DIFF
--- a/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/global/infra/fcm/presentation/application/impl/FcmServiceImpl.kt
@@ -103,11 +103,25 @@ class FcmServiceImpl(
         val invalid = mutableListOf<String>()
         responses.forEachIndexed { idx, resp ->
             if (resp.isSuccessful) return@forEachIndexed
-            val errorCode = resp.exception?.messagingErrorCode
+            val ex = resp.exception
+            val errorCode = ex?.messagingErrorCode
             if (errorCode in INVALID_TOKEN_ERRORS) {
                 invalid += chunk[idx]
             } else {
-                log.warn("FCM send failed for token ({}): {}", errorCode, resp.exception?.message)
+                // iOS 만 401 로 실패할 때 Apple 의 실제 거부 사유(InvalidProviderToken=키 문제,
+                // BadDeviceToken=환경 불일치, TopicDisallowed=번들 불일치 등)를 드러내기 위해
+                // FCM 응답 본문(httpResponse.content)과 전체 예외 스택을 함께 남긴다.
+                // 토큰 prefix 로 devices 테이블의 iOS/Android 행과 대조 가능.
+                val httpBody = ex?.httpResponse?.content
+                log.warn(
+                    "FCM send failed (token={}…, errorCode={}, messagingErrorCode={}): {} | apnsBody={}",
+                    chunk[idx].take(12),
+                    ex?.errorCode,
+                    errorCode,
+                    ex?.message,
+                    httpBody,
+                    ex
+                )
             }
         }
         return invalid


### PR DESCRIPTION
## 배경
iOS 푸시만 안 옴. 서버 로그엔 `FCM send failed for token (null): Unexpected HTTP response with status: 401` 만 떠서 Apple 의 실제 거부 사유를 알 수 없음. (안드로이드는 정상 → 서버/서비스계정/프로젝트(digda-792fa)는 정상, APNs 인증 단계 문제)

## 변경
발송 실패 로깅에 다음을 추가:
- 토큰 prefix (devices 테이블의 iOS/Android 행과 대조용)
- `errorCode`, `messagingErrorCode`
- **`httpResponse.content`** — FCM 응답 본문(여기에 APNs 실제 사유가 담김)
- 전체 예외 스택

## 기대
공지 재발송 시 로그에서 `InvalidProviderToken`(키 문제) / `BadDeviceToken`(APNs 환경 불일치) / `TopicDisallowed`(번들 불일치) 등 정확한 사유가 보여 콘솔에서 어디를 고칠지 확정 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)