### PR TITLE
방장 양도 동기화 + 퀴즈 정답·오답 알림/표시

### DIFF
--- a/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/res/AdminGroupRoomResponse.kt
+++ b/src/main/kotlin/digdaserver/admin/grouproom/presentation/dto/res/AdminGroupRoomResponse.kt
@@ -41,18 +41,24 @@ data class AdminGroupRoomResponse(
     val updatedAt: LocalDateTime
 ) {
     companion object {
-        fun from(room: GroupRoom): AdminGroupRoomResponse = AdminGroupRoomResponse(
-            groupRoomId = room.id,
-            name = room.name,
-            thumbnailImage = room.thumbnailImage,
-            maxMembers = room.maxMembers,
-            ownerId = room.owner.id.toString(),
-            ownerName = room.owner.name,
-            lastActivityAt = room.lastActivityAt,
-            deleteScheduledAt = room.deleteScheduledAt,
-            deletedAt = room.deletedAt,
-            createdAt = room.createdAt,
-            updatedAt = room.updatedAt
-        )
+        fun from(room: GroupRoom): AdminGroupRoomResponse {
+            // 실제 방장은 OWNER 역할 멤버십이 소스오브트루스다. 과거 방장 양도 시
+            // group_room.owner_id 를 갱신하지 않던 버그로 남은 stale 데이터까지
+            // 올바르게 보이도록, OWNER 멤버십 유저를 우선 사용하고 없으면 owner 로 폴백.
+            val ownerUser = room.memberships.firstOrNull { it.isOwner }?.user ?: room.owner
+            return AdminGroupRoomResponse(
+                groupRoomId = room.id,
+                name = room.name,
+                thumbnailImage = room.thumbnailImage,
+                maxMembers = room.maxMembers,
+                ownerId = ownerUser.id.toString(),
+                ownerName = ownerUser.name,
+                lastActivityAt = room.lastActivityAt,
+                deleteScheduledAt = room.deleteScheduledAt,
+                deletedAt = room.deletedAt,
+                createdAt = room.createdAt,
+                updatedAt = room.updatedAt
+            )
+        }
     }
 }

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -125,8 +125,26 @@ class CharacterQuizServiceImpl(
         val safeSize = size.coerceIn(1, 100)
         val result =
             quizRepository.findPageByGroupRoomId(groupRoomId, PageRequest.of(safePage, safeSize))
+
+        // 조회자의 응시 기록을 한 번에 가져와 정답/오답 배지를 채운다(퀴즈당 1회 응시라
+        // quizId 로 유일). 미응시 퀴즈는 attempted=false 로 남는다.
+        val quizIds = result.content.map { it.id }
+        val attemptByQuizId = if (quizIds.isEmpty()) {
+            emptyMap()
+        } else {
+            attemptRepository.findAllByUserIdAndQuizIdIn(userId, quizIds)
+                .associateBy({ it.quiz.id }, { it.correct })
+        }
+
         return CharacterQuizListResponse(
-            items = result.content.map(CharacterQuizResponse::from),
+            items = result.content.map { quiz ->
+                val attemptCorrect = attemptByQuizId[quiz.id]
+                CharacterQuizResponse.from(
+                    quiz,
+                    attempted = attemptCorrect != null,
+                    attemptCorrect = attemptCorrect
+                )
+            },
             page = result.number,
             totalPages = result.totalPages,
             totalElements = result.totalElements
@@ -239,13 +257,12 @@ class CharacterQuizServiceImpl(
         )
 
         try {
-            if (correct) {
-                notificationService.notifyQuizAnsweredCorrectly(
-                    groupRoomId = quiz.groupRoom.id,
-                    quizId = quizId,
-                    solverUserId = userId
-                )
-            }
+            notificationService.notifyQuizAnswered(
+                groupRoomId = quiz.groupRoom.id,
+                quizId = quizId,
+                solverUserId = userId,
+                correct = correct
+            )
             if (gain.levelGained > 0 || gain.stageChanged) {
                 notificationService.notifyMochiLevelUp(
                     groupRoomId = quiz.groupRoom.id,

--- a/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizAttemptRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizAttemptRepository.kt
@@ -8,4 +8,7 @@ import java.util.UUID
 @Repository
 interface CharacterQuizAttemptRepository : JpaRepository<CharacterQuizAttempt, Long> {
     fun existsByQuizIdAndUserId(quizId: Long, userId: UUID): Boolean
+
+    /** 특정 유저가 주어진 퀴즈들에 남긴 응시 기록(목록 화면의 정답/오답 표시용). */
+    fun findAllByUserIdAndQuizIdIn(userId: UUID, quizIds: List<Long>): List<CharacterQuizAttempt>
 }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -12,6 +12,10 @@ import java.time.LocalDateTime
  *
  * [remainingCount] 는 퀴즈 풀기 화면(pickRandom) 에서만 채워지는 "지금 풀 수 있는 남은
  * 퀴즈 수"(현재 문제 포함). 목록/생성 응답에서는 null.
+ *
+ * [attempted] 는 목록을 조회한 사용자가 이 퀴즈를 이미 응시했는지, [attemptCorrect] 는
+ * 응시했다면 정답이었는지(true)/오답이었는지(false)를 나타낸다. 미응시면 각각
+ * false/null 이라 목록에서 "정답/오답" 배지를 표시할 수 있다.
  */
 data class CharacterQuizResponse(
     val id: Long,
@@ -24,10 +28,17 @@ data class CharacterQuizResponse(
     val authorName: String,
     val imageUrl: String?,
     val createdAt: LocalDateTime,
-    val remainingCount: Int? = null
+    val remainingCount: Int? = null,
+    val attempted: Boolean = false,
+    val attemptCorrect: Boolean? = null
 ) {
     companion object {
-        fun from(quiz: CharacterQuiz, remainingCount: Int? = null): CharacterQuizResponse {
+        fun from(
+            quiz: CharacterQuiz,
+            remainingCount: Int? = null,
+            attempted: Boolean = false,
+            attemptCorrect: Boolean? = null
+        ): CharacterQuizResponse {
             return CharacterQuizResponse(
                 id = quiz.id,
                 groupRoomId = quiz.groupRoom.id,
@@ -39,7 +50,9 @@ data class CharacterQuizResponse(
                 authorName = quiz.author?.name ?: "탈퇴자",
                 imageUrl = quiz.imageUrl,
                 createdAt = quiz.createdAt,
-                remainingCount = remainingCount
+                remainingCount = remainingCount,
+                attempted = attempted,
+                attemptCorrect = attemptCorrect
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/application/service/impl/MembershipServiceImpl.kt
@@ -96,6 +96,11 @@ class MembershipServiceImpl(
         membership.changeRole(GroupRoomRole.MEMBER)
         targetMembership.changeRole(GroupRoomRole.OWNER)
 
+        // 멤버십 역할뿐 아니라 그룹방 소유자(owner_id)도 함께 옮겨야 한다.
+        // 이걸 빼먹으면 group_room.owner_id 가 이전 방장으로 남아 어드민 그룹목록에
+        // 이전 방장 이름이 계속 노출된다.
+        groupRoom.transferOwnership(targetMembership.user)
+
         notificationService.notifyOwnershipTransferred(groupRoomId, userId, targetUserId)
 
         userActionLogService.record(

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/NotificationService.kt
@@ -78,10 +78,11 @@ interface NotificationService {
         question: String
     )
 
-    fun notifyQuizAnsweredCorrectly(
+    fun notifyQuizAnswered(
         groupRoomId: Long,
         quizId: Long,
-        solverUserId: UUID
+        solverUserId: UUID,
+        correct: Boolean
     )
 
     fun notifyMochiLevelUp(

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -436,21 +436,30 @@ class NotificationServiceImpl(
     }
 
     @Transactional
-    override fun notifyQuizAnsweredCorrectly(
+    override fun notifyQuizAnswered(
         groupRoomId: Long,
         quizId: Long,
-        solverUserId: UUID
+        solverUserId: UUID,
+        correct: Boolean
     ) {
         val groupRoom = findGroupRoom(groupRoomId)
         val solver = findUser(solverUserId)
         val recipients = memberRecipientsExcept(groupRoomId, solverUserId)
 
+        // 정답/오답 모두 알림을 보낸다. 오답도 위로 경험치가 있어 모찌 성장에 반영되므로
+        // 그룹원이 응시 현황을 알 수 있게 한다.
+        val (title, message) = if (correct) {
+            "퀴즈 정답!" to "${solver.name}님이 퀴즈를 맞혔어요! 모찌가 경험치를 얻었어요. 🎉"
+        } else {
+            "퀴즈 응시" to "${solver.name}님이 퀴즈에 도전했지만 아쉽게 틀렸어요. 😅"
+        }
+
         notify(
             recipients,
             NotificationPayload(
                 type = NotificationType.QUIZ_ANSWERED,
-                title = "퀴즈 정답!",
-                message = "${solver.name}님이 퀴즈를 맞혔어요! 모찌가 경험치를 얻었어요. 🎉",
+                title = title,
+                message = message,
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = quizId,


### PR DESCRIPTION
## 변경
1. **방장 양도 동기화**: `changeRole` 이 멤버십 역할만 바꾸고 `group_room.owner_id` 를 안 옮겨, 어드민 그룹목록에 이전 방장이 노출되던 버그 수정(`transferOwnership` 호출 추가). 어드민 응답은 OWNER 멤버십 기준으로 방장을 뽑아 기존 stale 데이터까지 교정.
2. **퀴즈 정답/오답**: 목록 응답에 조회자의 `attempted`/`attemptCorrect` 추가. 정답에만 오던 알림을 오답에도 발송.

## 검증
- ktlintCheck + compileKotlin 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)