### PR TITLE
feat: 2.0.0 대형 패치 — 그림일기 개편·대댓글·퀴즈 응시자·닉네임·강제 업데이트

### DIFF
--- a/src/main/kotlin/digdaserver/domain/appconfig/application/service/impl/AppConfigServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/application/service/impl/AppConfigServiceImpl.kt
@@ -26,7 +26,10 @@ class AppConfigServiceImpl(
             noticeEnabled = request.noticeEnabled,
             noticeMessage = request.noticeMessage.trim(),
             feedbackEnabled = request.feedbackEnabled,
-            feedbackUrl = request.feedbackUrl.trim()
+            feedbackUrl = request.feedbackUrl.trim(),
+            minAppVersion = request.minAppVersion?.trim(),
+            storeUrlAndroid = request.storeUrlAndroid?.trim(),
+            storeUrlIos = request.storeUrlIos?.trim()
         )
         return AppConfigResponse.from(appConfigRepository.save(config))
     }

--- a/src/main/kotlin/digdaserver/domain/appconfig/domain/entity/AppConfig.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/domain/entity/AppConfig.kt
@@ -13,6 +13,8 @@ import jakarta.persistence.Table
  *
  * - 대공지(전광판): [noticeEnabled] && [noticeMessage] 가 있으면 그룹홈 상단에 흐른다.
  * - 피드백: [feedbackEnabled] 면 마이페이지에 "피드백 받기" 노출, [feedbackUrl] 로 이동.
+ * - 강제 업데이트: [minAppVersion] 보다 낮은 버전의 앱은 스토어 이동 다이얼로그로 막는다.
+ *   빈 문자열이면 게이트 비활성. 스토어 URL 이 비어 있으면 앱이 기본 URL 로 폴백.
  */
 @Entity
 @Table(name = "app_config")
@@ -33,19 +35,41 @@ class AppConfig(
     var feedbackEnabled: Boolean = false,
 
     @Column(name = "feedback_url", nullable = false, length = 500)
-    var feedbackUrl: String = ""
+    var feedbackUrl: String = "",
+
+    /** 강제 업데이트 최소 버전(semver "2.0.0"). 빈 값 = 게이트 끔. */
+    @Column(name = "min_app_version", nullable = false, length = 20)
+    var minAppVersion: String = "",
+
+    /** 안드로이드 스토어 URL. 빈 값이면 앱이 Play 기본 URL 로 폴백. */
+    @Column(name = "store_url_android", nullable = false, length = 500)
+    var storeUrlAndroid: String = "",
+
+    /** iOS App Store URL. 빈 값이면 앱이 안내 문구만 노출. */
+    @Column(name = "store_url_ios", nullable = false, length = 500)
+    var storeUrlIos: String = ""
 
 ) : BaseTimeEntity() {
 
+    /**
+     * 어드민 저장. 버전/스토어 필드는 구버전 어드민 UI 가 보내지 않을 수 있어
+     * null 이면 기존 값을 유지한다(의도치 않은 초기화 방지).
+     */
     fun update(
         noticeEnabled: Boolean,
         noticeMessage: String,
         feedbackEnabled: Boolean,
-        feedbackUrl: String
+        feedbackUrl: String,
+        minAppVersion: String? = null,
+        storeUrlAndroid: String? = null,
+        storeUrlIos: String? = null
     ) {
         this.noticeEnabled = noticeEnabled
         this.noticeMessage = noticeMessage
         this.feedbackEnabled = feedbackEnabled
         this.feedbackUrl = feedbackUrl
+        minAppVersion?.let { this.minAppVersion = it }
+        storeUrlAndroid?.let { this.storeUrlAndroid = it }
+        storeUrlIos?.let { this.storeUrlIos = it }
     }
 }

--- a/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/req/UpdateAppConfigRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/req/UpdateAppConfigRequest.kt
@@ -7,5 +7,9 @@ data class UpdateAppConfigRequest(
     val noticeEnabled: Boolean = false,
     val noticeMessage: String = "",
     val feedbackEnabled: Boolean = false,
-    val feedbackUrl: String = ""
+    val feedbackUrl: String = "",
+    // 강제 업데이트 게이트 — null 이면 기존 값 유지(구버전 어드민 호환).
+    val minAppVersion: String? = null,
+    val storeUrlAndroid: String? = null,
+    val storeUrlIos: String? = null
 )

--- a/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/res/AppConfigResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/appconfig/presentation/dto/res/AppConfigResponse.kt
@@ -15,7 +15,16 @@ data class AppConfigResponse(
     val feedbackEnabled: Boolean,
 
     @field:Schema(description = "피드백 폼 URL")
-    val feedbackUrl: String
+    val feedbackUrl: String,
+
+    @field:Schema(description = "강제 업데이트 최소 버전(semver). 빈 값 = 게이트 끔")
+    val minAppVersion: String = "",
+
+    @field:Schema(description = "안드로이드 스토어 URL(빈 값 = 앱 기본 폴백)")
+    val storeUrlAndroid: String = "",
+
+    @field:Schema(description = "iOS App Store URL(빈 값 = 앱 기본 폴백)")
+    val storeUrlIos: String = ""
 ) {
     companion object {
         val default = AppConfigResponse(
@@ -29,7 +38,10 @@ data class AppConfigResponse(
             noticeEnabled = c.noticeEnabled,
             noticeMessage = c.noticeMessage,
             feedbackEnabled = c.feedbackEnabled,
-            feedbackUrl = c.feedbackUrl
+            feedbackUrl = c.feedbackUrl,
+            minAppVersion = c.minAppVersion,
+            storeUrlAndroid = c.storeUrlAndroid,
+            storeUrlIos = c.storeUrlIos
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/character/application/service/impl/CharacterQuizServiceImpl.kt
@@ -13,6 +13,7 @@ import digdaserver.domain.character.presentation.dto.res.CharacterQuizListRespon
 import digdaserver.domain.character.presentation.dto.res.CharacterQuizResponse
 import digdaserver.domain.character.presentation.dto.res.CharacterStateResponse
 import digdaserver.domain.character.presentation.dto.res.QuizAttemptResultResponse
+import digdaserver.domain.character.presentation.dto.res.QuizAttemptSummary
 import digdaserver.domain.group_room.domain.repository.GroupRoomRepository
 import digdaserver.domain.membership.domain.repository.MembershipRepository
 import digdaserver.domain.notification.application.service.NotificationService
@@ -126,23 +127,25 @@ class CharacterQuizServiceImpl(
         val result =
             quizRepository.findPageByGroupRoomId(groupRoomId, PageRequest.of(safePage, safeSize))
 
-        // 조회자의 응시 기록을 한 번에 가져와 정답/오답 배지를 채운다(퀴즈당 1회 응시라
-        // quizId 로 유일). 미응시 퀴즈는 attempted=false 로 남는다.
+        // 모든 응시 기록을 한 번에 가져와 퀴즈별 "누가 풀었는지" 목록과 조회자 본인의
+        // 정답/오답 배지를 함께 채운다(퀴즈당 1회 응시라 (quiz, user) 유일).
         val quizIds = result.content.map { it.id }
-        val attemptByQuizId = if (quizIds.isEmpty()) {
+        val attemptsByQuizId: Map<Long, List<QuizAttemptSummary>> = if (quizIds.isEmpty()) {
             emptyMap()
         } else {
-            attemptRepository.findAllByUserIdAndQuizIdIn(userId, quizIds)
-                .associateBy({ it.quiz.id }, { it.correct })
+            attemptRepository.findAllWithUserByQuizIdIn(quizIds)
+                .groupBy({ it.quiz.id }, { QuizAttemptSummary.from(it) })
         }
 
         return CharacterQuizListResponse(
             items = result.content.map { quiz ->
-                val attemptCorrect = attemptByQuizId[quiz.id]
+                val attempts = attemptsByQuizId[quiz.id].orEmpty()
+                val mine = attempts.firstOrNull { it.userId == userId }
                 CharacterQuizResponse.from(
                     quiz,
-                    attempted = attemptCorrect != null,
-                    attemptCorrect = attemptCorrect
+                    attempted = mine != null,
+                    attemptCorrect = mine?.correct,
+                    attempts = attempts
                 )
             },
             page = result.number,

--- a/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizAttemptRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/character/domain/repository/CharacterQuizAttemptRepository.kt
@@ -2,6 +2,8 @@ package digdaserver.domain.character.domain.repository
 
 import digdaserver.domain.character.domain.entity.CharacterQuizAttempt
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -11,4 +13,14 @@ interface CharacterQuizAttemptRepository : JpaRepository<CharacterQuizAttempt, L
 
     /** 특정 유저가 주어진 퀴즈들에 남긴 응시 기록(목록 화면의 정답/오답 표시용). */
     fun findAllByUserIdAndQuizIdIn(userId: UUID, quizIds: List<Long>): List<CharacterQuizAttempt>
+
+    /**
+     * 주어진 퀴즈들의 모든 응시 기록 — 목록에서 "누가 풀었고 맞았는지" 표시용.
+     * user 를 fetch join 해 닉네임 접근 시 N+1 을 피한다. 응시순 정렬.
+     */
+    @Query(
+        "SELECT a FROM CharacterQuizAttempt a JOIN FETCH a.user " +
+            "WHERE a.quiz.id IN :quizIds ORDER BY a.attemptedAt ASC"
+    )
+    fun findAllWithUserByQuizIdIn(@Param("quizIds") quizIds: List<Long>): List<CharacterQuizAttempt>
 }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/CharacterQuizResponse.kt
@@ -16,6 +16,9 @@ import java.time.LocalDateTime
  * [attempted] 는 목록을 조회한 사용자가 이 퀴즈를 이미 응시했는지, [attemptCorrect] 는
  * 응시했다면 정답이었는지(true)/오답이었는지(false)를 나타낸다. 미응시면 각각
  * false/null 이라 목록에서 "정답/오답" 배지를 표시할 수 있다.
+ *
+ * [attempts] 는 이 퀴즈를 푼 모든 그룹원의 응시 요약(응시순) — 목록에서 "누가 풀었고
+ * 맞았는지"를 본인 여부와 무관하게 항상 보여주기 위한 필드. 목록 조회에서만 채워진다.
  */
 data class CharacterQuizResponse(
     val id: Long,
@@ -30,14 +33,16 @@ data class CharacterQuizResponse(
     val createdAt: LocalDateTime,
     val remainingCount: Int? = null,
     val attempted: Boolean = false,
-    val attemptCorrect: Boolean? = null
+    val attemptCorrect: Boolean? = null,
+    val attempts: List<QuizAttemptSummary> = emptyList()
 ) {
     companion object {
         fun from(
             quiz: CharacterQuiz,
             remainingCount: Int? = null,
             attempted: Boolean = false,
-            attemptCorrect: Boolean? = null
+            attemptCorrect: Boolean? = null,
+            attempts: List<QuizAttemptSummary> = emptyList()
         ): CharacterQuizResponse {
             return CharacterQuizResponse(
                 id = quiz.id,
@@ -47,12 +52,13 @@ data class CharacterQuizResponse(
                 question = quiz.question,
                 options = quiz.options(),
                 expMultiplier = quiz.expMultiplier,
-                authorName = quiz.author?.name ?: "탈퇴자",
+                authorName = quiz.author?.displayedName() ?: "탈퇴자",
                 imageUrl = quiz.imageUrl,
                 createdAt = quiz.createdAt,
                 remainingCount = remainingCount,
                 attempted = attempted,
-                attemptCorrect = attemptCorrect
+                attemptCorrect = attemptCorrect,
+                attempts = attempts
             )
         }
     }

--- a/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/QuizAttemptSummary.kt
+++ b/src/main/kotlin/digdaserver/domain/character/presentation/dto/res/QuizAttemptSummary.kt
@@ -1,0 +1,26 @@
+package digdaserver.domain.character.presentation.dto.res
+
+import digdaserver.domain.character.domain.entity.CharacterQuizAttempt
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 퀴즈 목록에서 "누가 풀었고 맞았는지"를 보여주기 위한 응시 요약 1건.
+ * [userName] 은 프로필에서 지정한 닉네임 우선([User.displayedName]) — 탈퇴자는 안 내려간다
+ * (attempt 는 user FK 필수라 탈퇴 시 함께 정리됨).
+ */
+data class QuizAttemptSummary(
+    val userId: UUID,
+    val userName: String,
+    val correct: Boolean,
+    val attemptedAt: LocalDateTime
+) {
+    companion object {
+        fun from(attempt: CharacterQuizAttempt): QuizAttemptSummary = QuizAttemptSummary(
+            userId = attempt.user.id,
+            userName = attempt.user.displayedName(),
+            correct = attempt.correct,
+            attemptedAt = attempt.attemptedAt
+        )
+    }
+}

--- a/src/main/kotlin/digdaserver/domain/comment/application/service/CommentService.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/CommentService.kt
@@ -7,7 +7,13 @@ interface CommentService {
 
     fun createScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, text: String): CreateCommentResponse
 
-    fun createDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, text: String): CreateCommentResponse
+    fun createDiaryComment(
+        userId: UUID,
+        groupRoomId: Long,
+        diaryId: Long,
+        text: String,
+        parentCommentId: Long? = null
+    ): CreateCommentResponse
 
     fun deleteScheduleComment(userId: UUID, groupRoomId: Long, scheduleId: Long, commentId: Long)
 

--- a/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/application/service/impl/CommentServiceImpl.kt
@@ -73,7 +73,13 @@ class CommentServiceImpl(
     }
 
     @Transactional
-    override fun createDiaryComment(userId: UUID, groupRoomId: Long, diaryId: Long, text: String): CreateCommentResponse {
+    override fun createDiaryComment(
+        userId: UUID,
+        groupRoomId: Long,
+        diaryId: Long,
+        text: String,
+        parentCommentId: Long?
+    ): CreateCommentResponse {
         validateGroupRoomMember(groupRoomId, userId)
         validateCommentText(text)
 
@@ -85,12 +91,25 @@ class CommentServiceImpl(
 
         if (user.restricted) throw DigdaException(ErrorCode.USER_RESTRICTED)
 
+        // 대댓글 검증 — 부모가 같은 일기의 최상위 댓글이어야 한다(댓글→대댓글 1단계만 허용).
+        if (parentCommentId != null) {
+            val parent = commentRepository.findById(parentCommentId)
+                .orElseThrow { DigdaException(ErrorCode.COMMENT_NOT_FOUND) }
+            if (parent.targetType != CommentTargetType.DIARY || parent.targetId != diaryId) {
+                throw DigdaException(ErrorCode.COMMENT_NOT_FOUND)
+            }
+            if (parent.parentId != null) {
+                throw DigdaException(ErrorCode.COMMENT_REPLY_DEPTH_EXCEEDED)
+            }
+        }
+
         val comment = commentRepository.save(
             Comment(
                 targetType = CommentTargetType.DIARY,
                 targetId = diaryId,
                 text = text,
-                createdBy = user
+                createdBy = user,
+                parentId = parentCommentId
             )
         )
 
@@ -139,6 +158,10 @@ class CommentServiceImpl(
             throw DigdaException(ErrorCode.FORBIDDEN)
         }
 
+        // 최상위 댓글을 지우면 매달린 대댓글도 함께 삭제(고아 방지 — FK 없이 parent_comment_id 로 매핑).
+        if (comment.parentId == null) {
+            commentRepository.deleteAllByParentId(comment.id)
+        }
         commentRepository.delete(comment)
     }
 

--- a/src/main/kotlin/digdaserver/domain/comment/domain/entity/Comment.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/domain/entity/Comment.kt
@@ -37,6 +37,14 @@ class Comment(
     @Column(nullable = false, length = 200)
     val text: String,
 
+    /**
+     * 대댓글의 부모 댓글 id. null 이면 최상위 댓글.
+     * 구조는 댓글 → 대댓글 1단계까지만 허용한다(대대댓글 금지 — 서비스에서 검증).
+     * prod 는 SchemaAutoMigration 에서 동일 컬럼을 멱등 ADD.
+     */
+    @Column(name = "parent_comment_id")
+    val parentId: Long? = null,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by", nullable = false)
     val createdBy: User,

--- a/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/domain/repository/CommentRepository.kt
@@ -36,6 +36,11 @@ interface CommentRepository : JpaRepository<Comment, Long> {
     @Query("DELETE FROM Comment c WHERE c.createdBy.id = :userId")
     fun deleteAllByCreatedById(@Param("userId") userId: UUID)
 
+    /** 최상위 댓글 삭제 시 매달린 대댓글 일괄 삭제. */
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.parentId = :parentId")
+    fun deleteAllByParentId(@Param("parentId") parentId: Long): Int
+
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.targetType = :targetType AND c.targetId = :targetId")
     fun deleteAllByTargetTypeAndTargetId(

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/controller/CommentController.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/controller/CommentController.kt
@@ -41,7 +41,13 @@ class CommentController(
         @PathVariable diaryId: Long,
         @RequestBody request: CreateCommentRequest
     ): ResponseEntity<CreateCommentResponse> {
-        val response = commentService.createDiaryComment(UUID.fromString(userId), groupRoomId, diaryId, request.text)
+        val response = commentService.createDiaryComment(
+            UUID.fromString(userId),
+            groupRoomId,
+            diaryId,
+            request.text,
+            request.parentCommentId
+        )
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/req/CreateCommentRequest.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/req/CreateCommentRequest.kt
@@ -1,5 +1,7 @@
 package digdaserver.domain.comment.presentation.dto.req
 
 data class CreateCommentRequest(
-    val text: String
+    val text: String,
+    /** 대댓글이면 부모 댓글 id. null 이면 최상위 댓글. 대댓글의 대댓글(2단계)은 거부된다. */
+    val parentCommentId: Long? = null
 )

--- a/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CreateCommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/comment/presentation/dto/res/CreateCommentResponse.kt
@@ -7,14 +7,17 @@ data class CreateCommentResponse(
     val id: Long,
     val text: String,
     val createdBy: CommentUserSummary,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    /** 대댓글이면 부모 댓글 id. 최상위 댓글은 null. */
+    val parentId: Long? = null
 ) {
     companion object {
         fun from(comment: Comment): CreateCommentResponse = CreateCommentResponse(
             id = comment.id,
             text = comment.text,
             createdBy = CommentUserSummary.from(comment.createdBy),
-            createdAt = comment.createdAt
+            createdAt = comment.createdAt,
+            parentId = comment.parentId
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/DiaryService.kt
@@ -4,12 +4,14 @@ import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDayResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryReactionToggleResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryRegionMapResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryResponse
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -34,6 +36,12 @@ interface DiaryService {
     ): DiaryListResponse
 
     fun getDiaryCalendar(userId: UUID, groupRoomId: Long, month: YearMonth): DiaryCalendarResponse
+
+    /** 특정 날짜의 그룹 일기 전부 — 캘린더 날짜 탭 → 일기 목록 화면용. */
+    fun getDiariesByDate(userId: UUID, groupRoomId: Long, date: LocalDate): DiaryDayResponse
+
+    /** 대표 썸네일 지정 — 그룹원 누구나 가능. 같은 날의 기존 대표는 해제된다. */
+    fun setRepresentative(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDayResponse
 
     fun getDiaryDetail(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDetailResponse
 

--- a/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -21,6 +21,7 @@ import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarEntry
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarStats
 import digdaserver.domain.diary.presentation.dto.res.DiaryCommentResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDayResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
@@ -232,35 +233,24 @@ class DiaryServiceImpl(
         // 사진 그리드용: 해당 월의 모든 일기를 이미지까지 한 번에 로드.
         val monthDiaries = diaryRepository.findAllWithImagesByGroupRoomIdAndDateBetween(groupRoomId, startDate, endDate)
 
-        // 차단/신고 숨김 — 일기를 지우지 않고 대표 칸만 숨김 표시. "하루 1편" 슬롯이 빈 날로 보이지 않게.
+        // 차단/신고 숨김 — 일기를 지우지 않고 대표 칸만 숨김 표시. 슬롯이 빈 날로 보이지 않게.
         val visibility = contentVisibilityService.forViewer(userId)
 
-        // 날짜별 그룹핑. 같은 날 여러 편이면 최신(createdAt DESC, 쿼리에서 이미 정렬)을 대표로 사용.
+        // 날짜별 그룹핑(쿼리에서 createdAt ASC 정렬). 대표 = 지정 대표 → 없으면 가장 먼저 작성된 일기.
         val byDate = monthDiaries.groupBy { it.date }
         val entries = byDate.entries
             .sortedBy { it.key }
             .map { (date, diaries) ->
-                // 대표는 보이는 일기 우선. 전부 숨김이면 첫 일기를 대표로 두되 숨김 표시(슬롯·count 유지).
-                val visible = diaries.firstOrNull {
-                    visibility.diaryHiddenReason(it.id, it.createdBy.id) == null
-                }
-                val representative = visible ?: diaries.first()
-                val entry = DiaryCalendarEntry(
-                    date = date,
-                    diaryId = representative.id,
-                    thumbnailUrl = representative.images.minByOrNull { it.sortOrder }?.url,
-                    mood = representative.mood,
-                    count = diaries.size
-                )
-                if (visible != null) {
-                    entry
-                } else {
-                    val reason = visibility.diaryHiddenReason(representative.id, representative.createdBy.id)
-                        ?: VisibilityReason.HIDDEN
-                    entry.asHidden(reason)
-                }
+                val entry = buildCalendarEntry(date, diaries, visibility)
+                entry
             }
         val dates = entries.map { it.date }
+
+        // "인당 하루 1편" — 조회자 본인이 쓴 날짜(앱이 작성 가능 여부를 즉시 판정).
+        val myDates = monthDiaries
+            .filter { it.createdBy.id == userId }
+            .map { it.date }
+            .distinct()
 
         // 통계: 편수 / 최다 기분 / 연속 기록.
         val count = monthDiaries.size
@@ -274,7 +264,119 @@ class DiaryServiceImpl(
         return DiaryCalendarResponse(
             dates = dates,
             entries = entries,
-            stats = DiaryCalendarStats(count = count, streak = streak, topMood = topMood)
+            stats = DiaryCalendarStats(count = count, streak = streak, topMood = topMood),
+            myDates = myDates
+        )
+    }
+
+    /**
+     * 한 날짜의 캘린더 칸(대표 일기) 계산.
+     * 우선순위: 지정 대표(representative=true, 보임) → 가장 먼저 작성된 보이는 일기 →
+     * 전부 숨김이면 첫 일기를 대표로 두되 숨김 표시(슬롯·count 유지).
+     * [diaries] 는 createdAt ASC 로 정렬돼 들어온다.
+     */
+    private fun buildCalendarEntry(
+        date: LocalDate,
+        diaries: List<Diary>,
+        visibility: digdaserver.domain.block.application.service.ViewerVisibility
+    ): DiaryCalendarEntry {
+        fun visible(d: Diary) = visibility.diaryHiddenReason(d.id, d.createdBy.id) == null
+        val representative = diaries.firstOrNull { it.representative && visible(it) }
+            ?: diaries.firstOrNull { visible(it) }
+        val chosen = representative ?: diaries.first()
+        val entry = DiaryCalendarEntry(
+            date = date,
+            diaryId = chosen.id,
+            thumbnailUrl = chosen.images.minByOrNull { it.sortOrder }?.url,
+            mood = chosen.mood,
+            count = diaries.size
+        )
+        if (representative != null) return entry
+        val reason = visibility.diaryHiddenReason(chosen.id, chosen.createdBy.id)
+            ?: VisibilityReason.HIDDEN
+        return entry.asHidden(reason)
+    }
+
+    override fun getDiariesByDate(userId: UUID, groupRoomId: Long, date: LocalDate): DiaryDayResponse {
+        ensureMember(userId, groupRoomId)
+        val diaries = diaryRepository.findAllWithImagesByGroupRoomIdAndDate(groupRoomId, date)
+        val visibility = contentVisibilityService.forViewer(userId)
+        return buildDayResponse(date, diaries, userId, visibility)
+    }
+
+    @Transactional
+    override fun setRepresentative(userId: UUID, groupRoomId: Long, diaryId: Long): DiaryDayResponse {
+        ensureMember(userId, groupRoomId)
+        val diary = diaryRepository.findById(diaryId)
+            .orElseThrow { DigdaException(ErrorCode.DIARY_NOT_FOUND) }
+        if (diary.groupRoom.id != groupRoomId) throw DigdaException(ErrorCode.DIARY_NOT_FOUND)
+
+        // 그룹원 누구나 지정 가능 — 같은 날 기존 대표를 내리고 이 일기만 올린다.
+        diaryRepository.clearRepresentativeForDate(groupRoomId, diary.date)
+        diary.representative = true
+        log.info(
+            "action=일기 대표 썸네일 지정, userId={}, groupRoomId={}, diaryId={}, date={}",
+            userId,
+            groupRoomId,
+            diaryId,
+            diary.date
+        )
+
+        val diaries = diaryRepository.findAllWithImagesByGroupRoomIdAndDate(groupRoomId, diary.date)
+        val visibility = contentVisibilityService.forViewer(userId)
+        return buildDayResponse(diary.date, diaries, userId, visibility)
+    }
+
+    /** 날짜별 일기 목록 응답 조립 — 댓글/좋아요 수·숨김 처리·대표/내 일기 id 포함. */
+    private fun buildDayResponse(
+        date: LocalDate,
+        diaries: List<Diary>,
+        userId: UUID,
+        visibility: digdaserver.domain.block.application.service.ViewerVisibility
+    ): DiaryDayResponse {
+        val diaryIds = diaries.map { it.id }
+
+        val commentCountMap: Map<Long, Int> = if (diaryIds.isNotEmpty()) {
+            commentRepository.countByTargetTypeAndTargetIdIn(CommentTargetType.DIARY, diaryIds)
+                .associate { row -> (row[0] as Long) to (row[1] as Long).toInt() }
+        } else {
+            emptyMap()
+        }
+        val likeCountMap: Map<Long, Long> = if (diaryIds.isNotEmpty()) {
+            diaryLikeRepository.countByDiaryIdIn(diaryIds)
+                .associate { row -> (row[0] as Long) to (row[1] as Long) }
+        } else {
+            emptyMap()
+        }
+        val likedByMeSet: Set<Long> = if (diaryIds.isNotEmpty()) {
+            diaryLikeRepository.findLikedDiaryIds(diaryIds, userId).toSet()
+        } else {
+            emptySet()
+        }
+
+        fun visible(d: Diary) = visibility.diaryHiddenReason(d.id, d.createdBy.id) == null
+        // 대표 = 지정 대표 → 가장 먼저 작성된 일기(리스트는 createdAt ASC).
+        val representativeId = (
+            diaries.firstOrNull { it.representative && visible(it) }
+                ?: diaries.firstOrNull { visible(it) }
+                ?: diaries.firstOrNull()
+            )?.id
+        val myDiaryId = diaries.firstOrNull { it.createdBy.id == userId }?.id
+
+        return DiaryDayResponse(
+            date = date,
+            diaries = diaries.map { diary ->
+                val summary = DiarySummaryResponse.from(
+                    diary = diary,
+                    commentCount = commentCountMap[diary.id] ?: 0,
+                    likeCount = likeCountMap[diary.id] ?: 0L,
+                    likedByMe = diary.id in likedByMeSet
+                )
+                val reason = visibility.diaryHiddenReason(diary.id, diary.createdBy.id)
+                if (reason != null) summary.asHidden(reason) else summary
+            },
+            representativeDiaryId = representativeId,
+            myDiaryId = myDiaryId
         )
     }
 
@@ -349,6 +451,13 @@ class DiaryServiceImpl(
         validateWeather(request.weather)
         validateMood(request.mood)
         validateImageCount(request.imageIds.size)
+
+        // 인당 하루 1편 — 같은 그룹·같은 날짜에 '본인' 일기가 이미 있으면 거부.
+        // (2.0.0: 그룹당 1편 → 인당 1편으로 완화. 다른 그룹원이 쓴 날에도 내 일기는 쓸 수 있다.)
+        if (diaryRepository.existsByGroupRoomIdAndCreatedByIdAndDate(groupRoomId, userId, request.date)) {
+            log.info("action=일기 작성 거부(인당 하루 1편), userId={}, groupRoomId={}, date={}", userId, groupRoomId, request.date)
+            throw DigdaException(ErrorCode.DIARY_ALREADY_WRITTEN)
+        }
 
         val user = userRepository.findById(userId)
             .orElseThrow { DigdaException(ErrorCode.USER_NOT_FOUND) }
@@ -430,10 +539,21 @@ class DiaryServiceImpl(
         request.date?.let {
             if (it.isAfter(todayKst())) throw DigdaException(ErrorCode.FUTURE_DATE_NOT_ALLOWED)
             if (it.isBefore(editableFrom())) throw DigdaException(ErrorCode.DIARY_DATE_TOO_OLD)
+            // 날짜를 옮길 때도 인당 하루 1편 유지 — 옮겨갈 날짜에 내 다른 일기가 있으면 거부.
+            if (it != diary.date &&
+                diaryRepository.existsByGroupRoomIdAndCreatedByIdAndDateAndIdNot(groupRoomId, userId, it, diaryId)
+            ) {
+                throw DigdaException(ErrorCode.DIARY_ALREADY_WRITTEN)
+            }
         }
         request.weather?.let { validateWeather(it) }
         request.mood?.let { validateMood(it) }
         request.imageIds?.let { validateImageCount(it.size) }
+
+        // 날짜를 옮기면 대표 지위는 유지하지 않는다 — 옮겨간 날짜의 기존 대표와 충돌 방지.
+        if (request.date != null && request.date != diary.date) {
+            diary.representative = false
+        }
 
         diary.updateBasics(
             title = request.title,

--- a/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/entity/Diary.kt
@@ -75,6 +75,14 @@ class Diary(
     @JoinColumn(name = "created_by", nullable = false)
     val createdBy: User,
 
+    /**
+     * 그날(그룹+날짜)의 대표 썸네일 여부. 하루에 최대 1건만 true.
+     * 아무도 지정하지 않은 날은 전부 false 이며, 이때 대표는 "가장 먼저 작성된 일기"로 폴백한다.
+     * prod 는 SchemaAutoMigration 에서 동일 컬럼을 멱등 ADD.
+     */
+    @Column(name = "representative", nullable = false)
+    var representative: Boolean = false,
+
     @OneToMany(mappedBy = "diary", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     @OrderBy("sortOrder ASC")
     val images: MutableList<DiaryImage> = mutableListOf()

--- a/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/domain/repository/DiaryRepository.kt
@@ -25,18 +25,46 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
 
     /**
      * 기간 내 모든 일기를 이미지까지 fetch join 으로 한 번에 로드한다.
-     * 캘린더 그리드(날짜별 썸네일/기분)와 통계 계산용. 날짜 오름차순, 같은 날은 최신 작성 우선.
+     * 캘린더 그리드(날짜별 썸네일/기분)와 통계 계산용. 날짜 오름차순, 같은 날은 먼저 쓴 순
+     * (대표 미지정 시 "가장 먼저 작성된 일기"가 기본 대표라 ASC 로 맞춘다).
      */
     @Query(
         "SELECT DISTINCT d FROM Diary d LEFT JOIN FETCH d.images " +
             "WHERE d.groupRoom.id = :groupRoomId AND d.date BETWEEN :startDate AND :endDate " +
-            "ORDER BY d.date ASC, d.createdAt DESC"
+            "ORDER BY d.date ASC, d.createdAt ASC"
     )
     fun findAllWithImagesByGroupRoomIdAndDateBetween(
         groupRoomId: Long,
         startDate: LocalDate,
         endDate: LocalDate
     ): List<Diary>
+
+    /** 인당 하루 1편 검증 — 사용자가 그 그룹·그 날짜에 이미 일기를 썼는지. */
+    fun existsByGroupRoomIdAndCreatedByIdAndDate(groupRoomId: Long, createdById: UUID, date: LocalDate): Boolean
+
+    /** 인당 하루 1편 검증(수정용) — 본인 일기 자신은 제외하고 판정. */
+    fun existsByGroupRoomIdAndCreatedByIdAndDateAndIdNot(
+        groupRoomId: Long,
+        createdById: UUID,
+        date: LocalDate,
+        id: Long
+    ): Boolean
+
+    /** 특정 날짜의 그룹 일기 전부(이미지 포함) — 날짜별 일기 목록 화면용. 먼저 쓴 순. */
+    @Query(
+        "SELECT DISTINCT d FROM Diary d LEFT JOIN FETCH d.images " +
+            "WHERE d.groupRoom.id = :groupRoomId AND d.date = :date " +
+            "ORDER BY d.createdAt ASC"
+    )
+    fun findAllWithImagesByGroupRoomIdAndDate(
+        @Param("groupRoomId") groupRoomId: Long,
+        @Param("date") date: LocalDate
+    ): List<Diary>
+
+    /** 대표 썸네일 재지정 — 같은 날의 기존 대표 플래그를 전부 내린다. */
+    @Modifying
+    @Query("UPDATE Diary d SET d.representative = false WHERE d.groupRoom.id = :groupRoomId AND d.date = :date AND d.representative = true")
+    fun clearRepresentativeForDate(@Param("groupRoomId") groupRoomId: Long, @Param("date") date: LocalDate): Int
 
     @Query(
         """

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/controller/DiaryController.kt
@@ -5,6 +5,7 @@ import digdaserver.domain.diary.presentation.dto.req.CreateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.req.ToggleDiaryReactionRequest
 import digdaserver.domain.diary.presentation.dto.req.UpdateDiaryRequest
 import digdaserver.domain.diary.presentation.dto.res.DiaryCalendarResponse
+import digdaserver.domain.diary.presentation.dto.res.DiaryDayResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryDetailResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryLikeResponse
 import digdaserver.domain.diary.presentation.dto.res.DiaryListResponse
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -81,6 +83,28 @@ class DiaryController(
         @RequestParam(defaultValue = "0") offset: Int
     ): ResponseEntity<DiaryListResponse> {
         val response = diaryService.getDiariesByRegion(UUID.fromString(userId), groupRoomId, regionKey, limit, offset)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "날짜별 일기 목록", description = "특정 날짜의 그룹 일기 전부(먼저 쓴 순)와 대표 썸네일/내 일기 id 를 반환합니다.")
+    @GetMapping("/group-rooms/{groupRoomId}/diaries/by-date")
+    fun getDiariesByDate(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @RequestParam date: LocalDate
+    ): ResponseEntity<DiaryDayResponse> {
+        val response = diaryService.getDiariesByDate(UUID.fromString(userId), groupRoomId, date)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "대표 썸네일 지정", description = "해당 일기를 그날의 대표 썸네일로 지정합니다. 그룹원 누구나 가능하며 기존 대표는 해제됩니다.")
+    @PutMapping("/group-rooms/{groupRoomId}/diaries/{diaryId}/representative")
+    fun setRepresentative(
+        @AuthenticationPrincipal userId: String,
+        @PathVariable groupRoomId: Long,
+        @PathVariable diaryId: Long
+    ): ResponseEntity<DiaryDayResponse> {
+        val response = diaryService.setRepresentative(UUID.fromString(userId), groupRoomId, diaryId)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCalendarResponse.kt
@@ -8,11 +8,13 @@ import java.time.LocalDate
  * - [dates] : 일기가 존재하는 날짜 목록(하위호환 — 기존 dot marker 용).
  * - [entries] : 날짜별 대표 일기 요약(사진 그리드용 썸네일/기분/편수).
  * - [stats] : 이번 달 통계 스트립(편수·연속 기록·최다 기분).
+ * - [myDates] : 조회자 본인이 일기를 쓴 날짜 목록 — "인당 하루 1편" 규칙의 작성 가능 여부 판정용.
  */
 data class DiaryCalendarResponse(
     val dates: List<LocalDate>,
     val entries: List<DiaryCalendarEntry> = emptyList(),
-    val stats: DiaryCalendarStats = DiaryCalendarStats()
+    val stats: DiaryCalendarStats = DiaryCalendarStats(),
+    val myDates: List<LocalDate> = emptyList()
 )
 
 /**

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryCommentResponse.kt
@@ -8,6 +8,8 @@ data class DiaryCommentResponse(
     val text: String,
     val createdBy: DiaryUserSummary,
     val createdAt: LocalDateTime,
+    /** 대댓글이면 부모 댓글 id. 최상위 댓글은 null. */
+    val parentId: Long? = null,
     /** 차단/신고로 숨겨진 댓글인지. true 면 text 는 비워진 상태. */
     val hidden: Boolean = false,
     val hiddenReason: String? = null
@@ -24,7 +26,8 @@ data class DiaryCommentResponse(
             id = comment.id,
             text = comment.text,
             createdBy = DiaryUserSummary.from(comment.createdBy),
-            createdAt = comment.createdAt
+            createdAt = comment.createdAt,
+            parentId = comment.parentId
         )
     }
 }

--- a/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryDayResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/diary/presentation/dto/res/DiaryDayResponse.kt
@@ -1,0 +1,18 @@
+package digdaserver.domain.diary.presentation.dto.res
+
+import java.time.LocalDate
+
+/**
+ * 특정 날짜의 그림일기 목록 응답 — 캘린더에서 날짜를 탭했을 때의 목록 화면용.
+ *
+ * - [diaries] : 그날 작성된 모든 일기(먼저 쓴 순). 차단/신고 숨김은 본문만 비워 자리 유지.
+ * - [representativeDiaryId] : 그날의 대표 썸네일 일기 id. 지정된 대표가 없으면
+ *   "가장 먼저 작성된 일기"로 폴백해 항상 하나를 가리킨다(일기가 없으면 null).
+ * - [myDiaryId] : 조회자 본인이 그날 쓴 일기 id(없으면 null) — 작성 버튼 노출 판정용.
+ */
+data class DiaryDayResponse(
+    val date: LocalDate,
+    val diaries: List<DiarySummaryResponse>,
+    val representativeDiaryId: Long?,
+    val myDiaryId: Long?
+)

--- a/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/group_room/application/service/impl/GroupRoomServiceImpl.kt
@@ -212,7 +212,7 @@ class GroupRoomServiceImpl(
             .firstOrNull()
 
         return GroupHomeResponse(
-            userName = user.name,
+            userName = user.displayedName(),
             today = TodaySummaryResponse(
                 scheduleCount = scheduleCount,
                 newDiaryCount = newDiaryCount,

--- a/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipResponse.kt
+++ b/src/main/kotlin/digdaserver/domain/membership/presentation/dto/res/MembershipResponse.kt
@@ -15,7 +15,7 @@ data class MembershipResponse(
     companion object {
         fun from(membership: Membership): MembershipResponse = MembershipResponse(
             userId = membership.user.id,
-            name = membership.user.name,
+            name = membership.user.displayedName(),
             profileImage = membership.user.profileImage,
             color = membership.color,
             role = membership.role.name.lowercase(),

--- a/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/digdaserver/domain/notification/application/service/impl/NotificationServiceImpl.kt
@@ -115,7 +115,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.MEMBER_JOINED,
                 title = "새 구성원 참여",
-                message = "${joinedUser.name}님이 '${groupRoom.name}' 그룹방에 참여했습니다.",
+                message = "${joinedUser.displayedName()}님이 '${groupRoom.name}' 그룹방에 참여했습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name
             )
@@ -133,7 +133,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.DIARY_WRITTEN,
                 title = "새 일기",
-                message = "${author.name}님이 '$diaryTitle' 일기를 작성했습니다.",
+                message = "${author.displayedName()}님이 '$diaryTitle' 일기를 작성했습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = diaryId,
@@ -163,7 +163,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.SCHEDULE_CREATED,
                 title = "새 일정",
-                message = "${creator.name}님이 '$scheduleTitle' 일정에 회원님을 참가자로 추가했습니다.",
+                message = "${creator.displayedName()}님이 '$scheduleTitle' 일정에 회원님을 참가자로 추가했습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
@@ -184,7 +184,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.MEMBER_LEFT,
                 title = "구성원 탈퇴",
-                message = "${leaver.name}님이 '${groupRoom.name}' 그룹방에서 나갔습니다.",
+                message = "${leaver.displayedName()}님이 '${groupRoom.name}' 그룹방에서 나갔습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name
             )
@@ -202,7 +202,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.OWNERSHIP_TRANSFERRED,
                 title = "방장 권한 이양",
-                message = "'${groupRoom.name}' 그룹방의 방장이 ${newOwner.name}님으로 변경되었습니다.",
+                message = "'${groupRoom.name}' 그룹방의 방장이 ${newOwner.displayedName()}님으로 변경되었습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = groupRoomId,
@@ -231,7 +231,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.SCHEDULE_UPDATED,
                 title = "일정 참가자 추가",
-                message = "${actor.name}님이 '$scheduleTitle' 일정에 회원님을 참가자로 추가했습니다.",
+                message = "${actor.displayedName()}님이 '$scheduleTitle' 일정에 회원님을 참가자로 추가했습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
@@ -334,7 +334,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.COMMENT_ON_SCHEDULE,
                 title = "새 댓글",
-                message = "${commenter.name}님이 '$scheduleTitle' 일정에 댓글을 남겼습니다.",
+                message = "${commenter.displayedName()}님이 '$scheduleTitle' 일정에 댓글을 남겼습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = scheduleId,
@@ -360,7 +360,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.COMMENT_ON_DIARY,
                 title = "새 댓글",
-                message = "${commenter.name}님이 '$diaryTitle' 일기에 댓글을 남겼습니다.",
+                message = "${commenter.displayedName()}님이 '$diaryTitle' 일기에 댓글을 남겼습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = diaryId,
@@ -401,7 +401,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.MEMBER_REMOVED,
                 title = "구성원 내보냄",
-                message = "${removedUser.name}님이 '${groupRoom.name}' 그룹방에서 내보내졌습니다.",
+                message = "${removedUser.displayedName()}님이 '${groupRoom.name}' 그룹방에서 내보내졌습니다.",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name
             )
@@ -425,7 +425,7 @@ class NotificationServiceImpl(
             NotificationPayload(
                 type = NotificationType.QUIZ_CREATED,
                 title = "새 퀴즈 등록",
-                message = "${author.name}님이 퀴즈를 등록했어요. \"$shortQuestion\"",
+                message = "${author.displayedName()}님이 퀴즈를 등록했어요. \"$shortQuestion\"",
                 groupRoomId = groupRoomId,
                 groupRoomName = groupRoom.name,
                 relatedId = quizId,
@@ -449,9 +449,9 @@ class NotificationServiceImpl(
         // 정답/오답 모두 알림을 보낸다. 오답도 위로 경험치가 있어 모찌 성장에 반영되므로
         // 그룹원이 응시 현황을 알 수 있게 한다.
         val (title, message) = if (correct) {
-            "퀴즈 정답!" to "${solver.name}님이 퀴즈를 맞혔어요! 모찌가 경험치를 얻었어요. 🎉"
+            "퀴즈 정답!" to "${solver.displayedName()}님이 퀴즈를 맞혔어요! 모찌가 경험치를 얻었어요. 🎉"
         } else {
-            "퀴즈 응시" to "${solver.name}님이 퀴즈에 도전했지만 아쉽게 틀렸어요. 😅"
+            "퀴즈 응시" to "${solver.displayedName()}님이 퀴즈에 도전했지만 아쉽게 틀렸어요. 😅"
         }
 
         notify(

--- a/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/digdaserver/global/infra/exception/error/ErrorCode.kt
@@ -75,12 +75,14 @@ enum class ErrorCode(
     FUTURE_DATE_NOT_ALLOWED("FUTURE_DATE_NOT_ALLOWED", "미래 날짜에는 일기를 작성할 수 없습니다.", 400),
     DIARY_DATE_TOO_OLD("DIARY_DATE_TOO_OLD", "3개월 이전 날짜에는 일기를 작성할 수 없습니다.", 400),
     DIARY_EDIT_WINDOW_EXPIRED("DIARY_EDIT_WINDOW_EXPIRED", "작성한 지 3개월이 지난 일기는 수정하거나 삭제할 수 없습니다.", 400),
+    DIARY_ALREADY_WRITTEN("DIARY_ALREADY_WRITTEN", "이 날짜에는 이미 내가 쓴 일기가 있어요. 하루에 한 편만 쓸 수 있어요.", 409),
     INVALID_WEATHER_VALUE("INVALID_WEATHER_VALUE", "날씨 값은 0~3 범위여야 합니다.", 400),
     INVALID_MOOD_VALUE("INVALID_MOOD_VALUE", "기분 값은 0~3 범위여야 합니다.", 400),
 
     // ── Comment ──
     COMMENT_NOT_FOUND("COMMENT_NOT_FOUND", "존재하지 않는 댓글입니다.", 404),
     COMMENT_TOO_LONG("COMMENT_TOO_LONG", "댓글은 200자 이하여야 합니다.", 400),
+    COMMENT_REPLY_DEPTH_EXCEEDED("COMMENT_REPLY_DEPTH_EXCEEDED", "대댓글에는 답글을 달 수 없어요.", 400),
 
     // ── Todo ──
     TODO_NOT_FOUND("TODO_NOT_FOUND", "존재하지 않는 할 일입니다.", 404),

--- a/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
+++ b/src/main/kotlin/digdaserver/global/infra/migration/SchemaAutoMigration.kt
@@ -124,6 +124,35 @@ class SchemaAutoMigration(
             postSql = listOf(
                 "UPDATE group_character SET master_unlocked = b'1' WHERE level >= 20"
             )
+        ),
+        // 2.0.0 그림일기 대댓글 — 부모 댓글 id. NULL 허용이라 추가만으로 충분(기존 댓글=최상위).
+        MissingColumn(
+            table = "comment",
+            column = "parent_comment_id",
+            addSql = "ALTER TABLE comment ADD COLUMN parent_comment_id BIGINT NULL"
+        ),
+        // 2.0.0 그림일기 대표 썸네일 — 하루(그룹+날짜)에 최대 1건 true. 기본 false 면
+        // "가장 먼저 작성된 일기" 폴백이 동작하므로 backfill 불필요.
+        MissingColumn(
+            table = "diary",
+            column = "representative",
+            addSql = "ALTER TABLE diary ADD COLUMN representative BIT(1) NOT NULL DEFAULT b'0'"
+        ),
+        // 2.0.0 강제 업데이트 게이트 — 최소 버전/스토어 URL. 빈 값 기본이라 backfill 불필요.
+        MissingColumn(
+            table = "app_config",
+            column = "min_app_version",
+            addSql = "ALTER TABLE app_config ADD COLUMN min_app_version VARCHAR(20) NOT NULL DEFAULT ''"
+        ),
+        MissingColumn(
+            table = "app_config",
+            column = "store_url_android",
+            addSql = "ALTER TABLE app_config ADD COLUMN store_url_android VARCHAR(500) NOT NULL DEFAULT ''"
+        ),
+        MissingColumn(
+            table = "app_config",
+            column = "store_url_ios",
+            addSql = "ALTER TABLE app_config ADD COLUMN store_url_ios VARCHAR(500) NOT NULL DEFAULT ''"
         )
     )
 


### PR DESCRIPTION
## 2.0.0 서버 변경 사항

### 1. 그림일기 대형 개편
- **그룹당 하루 1편 → 인당 하루 1편** (작성/수정 시 검증, `DIARY_ALREADY_WRITTEN` 409)
- **대표 썸네일**: `diary.representative` 컬럼. 지정 대표 없으면 최초 작성 일기로 폴백
- 신규 API: `GET /diaries/by-date?date=` (날짜별 목록 + 대표/내 일기 id), `PUT /diaries/{id}/representative` (그룹원 누구나)
- 캘린더 응답에 `myDates`(조회자가 쓴 날짜) 추가 — 앱의 작성 가능 판정용

### 2. 그림일기 대댓글 (1단계)
- `comment.parent_comment_id` — 댓글→대댓글만 허용, 2단계는 `COMMENT_REPLY_DEPTH_EXCEEDED` 400
- 부모 댓글 삭제 시 대댓글 동반 삭제

### 3. 퀴즈 목록 개선
- 각 퀴즈에 `attempts`(모든 응시자 닉네임+정답여부, 응시순) 추가 — 목록에서 누가 풀었는지 항상 표시

### 4. 닉네임 통일
- 그룹원 목록(MembershipResponse), 그룹홈 userName, 알림 메시지 11곳, 퀴즈 작성자 → `displayedName()`

### 5. 강제 업데이트 게이트
- `app_config.min_app_version / store_url_android / store_url_ios` — null 이면 기존 값 유지(구버전 어드민 저장 호환)

### 마이그레이션 (SchemaAutoMigration, 멱등 ADD)
- `comment.parent_comment_id`, `diary.representative`, `app_config.min_app_version/store_url_android/store_url_ios`

✅ ktlintFormat + compileKotlin 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)